### PR TITLE
get_codes() fails to process child JPN of R32JPN

### DIFF
--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -71,6 +71,7 @@ class TestGetCodes:
             ("R11", "R11_AFR", 50, "CIV"),
             ("R14", "R14_AFR", 51, "CIV"),
             ("R32", "R32SSA-L", 41, "CIV"),
+            ("R32", "R32JPN", 1, "JPN"),
         ],
     )
     def test_nodes(self, codelist, to_check, length, member):


### PR DESCRIPTION
When calling `get_codes("node/R32")`, the region `R32JPN` has no child (`JPN`).

I've extended `test_nodes()` to check that, but it passes. So, it seems the problem is a bit more downstream. 

Will further investigate.

PS: I can't debug `get_codes()` since there is no module `sdmx`, but I think I've successfully pip install it (`sdmx-0.2.10`), so I'm not sure why it is still failing. Any suggestions @khaeru ?