### PR TITLE
Create config.yaml for PtX module

### DIFF
--- a/message_ix_models/data/PtX/config.yaml
+++ b/message_ix_models/data/PtX/config.yaml
@@ -1,0 +1,8 @@
+# Configuration for the Power-to-X and Direct Air Capture technologies module
+
+# Emission coefficients associated to PtX technologies in MtC/(GWa fuel)
+# Values coincide with the emission factors for imports in MESSAGEix
+emission coefficients:
+  meth_h2: 0.549
+  gas_h2: 0.482
+  liq_h2: 0.623

--- a/message_ix_models/data/technology.yaml
+++ b/message_ix_models/data/technology.yaml
@@ -1630,6 +1630,75 @@ lh2_t/d:
   input: [liquid hydrogen, secondary]
   output: [liquid hydrogen, final]
 
+dac_1_exports:
+  name: dac_1_exports
+  description: Direct air capture technology
+  type: secondary
+  vintaged: TRUE
+  sector: direct_air_capture
+  input: [electr, secondary]
+
+dac_2_exports:
+  name: dac_2_exports
+  description: Direct air capture technology
+  type: secondary
+  vintaged: TRUE
+  sector: direct_air_capture
+  input: [electr, secondary]
+
+dac_3_exports:
+  name: dac_3_exports
+  description: Direct air capture technology
+  type: secondary
+  vintaged: TRUE
+  sector: direct_air_capture
+  input: [gas, secondary]
+
+dac_4_exports:
+  name: dac_4_exports
+  description: Direct air capture technology
+  type: secondary
+  vintaged: TRUE
+  sector: direct_air_capture
+  input: [electr, secondary]
+
+liq_h2:
+  name: liq_h2
+  description: Hydrogen-to-liquids technology, representing Fischer-Tropsh synthesis.
+  type: secondary
+  vintaged: TRUE
+  sector: power-to-x
+  input:
+    - [hydrogen, secondary]
+    - [electr, secondary]
+  output:
+    - [lightoil, secondary]
+    - [ht_heat, secondary]
+
+gas_h2:
+  name: gas_h2
+  description: Hydrogen-to-methane technology, representing methanation (Sabatier reaction) synthesis.
+  type: secondary
+  vintaged: TRUE
+  sector: power-to-x
+  input: [hydrogen, secondary]
+  output:
+    - [gas, secondary]
+    - [ht_heat, secondary]
+
+meth_h2:
+  name: meth_h2
+  description: Hydrogen-to-methanol technology, representing direct methanol synthesis.
+  type: secondary
+  vintaged: TRUE
+  sector: power-to-x
+  input:
+    - [hydrogen, secondary]
+    - [electr, secondary]
+  output:
+    - [methanol, secondary]
+    - [ht_heat, secondary]
+
 back_bio_ind:
   name: back_bio_ind
   description: Backstop for diagnosing model infeasibility


### PR DESCRIPTION
So far, this PR adds a draft of configuration file for the PtX module in iiasa/message_data#169.

This is done for using `Context` methods and other _utils_ such as `load_package_data()` from `message_ix_models`.

Depending on time availability:
- [x] ~~Migrate full code (excl. data sources) from `message_data`.~~ Postponed for after publication.
- [x] Documentation (migrate draft from iiasa/message_data#169)