### PR TITLE
Migrate .model.disutility

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -98,6 +98,14 @@ jobs:
       run: ixmp/ci/install-gams.sh
       shell: bash
 
+    - name: Install GAMS license
+      env:
+        GAMS_LICENSE: ${ secrets.GAMS_LICENSE }
+      run: |
+        echo "$GAMS_LICENSE" > $(dirname $(which gams))/gamslice.txt
+        gams
+      shell: bash
+
     - name: Upgrade pip, wheel, setuptools-scm
       run: python -m pip install --upgrade pip wheel setuptools-scm
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,7 +7,6 @@ on:
     branches: [ main ]
 
 env:
-  GAMS_VERSION: 25.1.1
   # For setuptools-scm. With fetch --tags below, this ensures that enough
   # history is fetched to contain the latest tag, so that setuptools-scm can
   # generate the version number. Update:
@@ -91,20 +90,10 @@ jobs:
           ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-
           ${{ matrix.os }}-
 
-    - name: Install GAMS
-      # Use the scripts from the checked-out ixmp repo
-      env:
-        CI_OS: ${{ matrix.os }}
-      run: ixmp/ci/install-gams.sh
-      shell: bash
-
-    - name: Install GAMS license
-      env:
-        GAMS_LICENSE: ${ secrets.GAMS_LICENSE }
-      run: |
-        echo "$GAMS_LICENSE" > $(dirname $(which gams))/gamslice.txt
-        gams
-      shell: bash
+    - uses: iiasa/actions/setup-gams@main
+      with:
+        version: 25.1.1
+        license: ${{ secrets.GAMS_LICENSE }}
 
     - name: Upgrade pip, wheel, setuptools-scm
       run: python -m pip install --upgrade pip wheel setuptools-scm

--- a/doc/api/disutility.rst
+++ b/doc/api/disutility.rst
@@ -1,0 +1,123 @@
+.. currentmodule:: message_data.model.disutility
+
+Consumer disutility
+*******************
+
+This module provides a generalized consumer disutility formulation, currently used by :mod:`message_data.model.transport`.
+
+The formulation rests on the concept of “consumer groups.”
+Each consumer group may have a distinct disutility for using the outputs of each technology.
+
+
+Method & usage
+==============
+
+Use this code by calling :func:`add`, which takes arguments that describe the concrete usage:
+
+Consumer groups
+   This is a list of :class:`.Code` objects describing the consumer groups.
+   The list must be 1-dimensional, but can be composed (as in :mod:`message_data.model.transport`) from multiple dimensions.
+
+Technologies
+   This is a list of :class:`.Code` objects describing the technologies for which the consumers in the different groups experience disutility.
+   Each object must be have 'input' and 'output' annotations (:attr:`.Code.anno`); each of these is a :class:`dict` with the keys 'commodity', 'input', and 'unit', describing the source or sink for the technology.
+
+Template
+   This is also a :class:`.Code` object, similar to those in ``technologies``; see below.
+
+
+The code does *not* do the following steps needed to completely parametrize the formulation:
+
+- Set consumer group-specific 'demand' parameter values for new commodities.
+- Create a source technology for the “disutility” commodity.
+
+
+Detailed example
+================
+
+From :func:`.transport.build.main`:
+
+.. code-block:: python
+
+    # Add generalized disutility formulation to LDV technologies
+    disutility.add(
+        scenario,
+
+        # Generate a list of consumer groups
+        consumer_groups=consumer_groups(),
+
+        # Generate a list of technologies
+        technologies=generate_set_elements("technology", "LDV"),
+
+        template=Code(
+            # Template for IDs of conversion technologies
+            id="transport {technology} usage",
+
+            # Templates for inputs of conversion technologies
+            input=dict(
+                # Technology-specific output commodity
+                commodity="transport vehicle {technology}",
+                level="useful",
+                unit="km",
+            ),
+
+            # Templates for outputs of conversion technologies
+            output=dict(
+                # Consumer-group–specific demand commodity
+                commodity="transport pax {mode}",
+                level="useful",
+                unit="km",
+            ),
+        ),
+        **options,
+    )
+
+
+:func:`add` uses :func:`get_spec` to generate a specification that adds the following:
+
+- A single 'commodity' set element, “disutility”.
+
+- 1 'mode' set element per element in ``consumer_groups``.
+
+  **Example:** the function :func:`.consumer_groups` returns codes like “RUEAA”, “URLMF”, etc.; one 'mode' is created for each such group.
+
+- 1 'commodity' set element per technology in ``technologies``.
+  ``template.anno["input"]["commodity"]`` is used to generate the IDs of these commodities.
+
+  **Example:** “transport vehicle {technology}” is used to generate a commodity “transport vehicles ELC_100” associated with the technology with the ID “ELC_100”.
+
+- 1 'commodity' set element per consumer group.
+  ``template.anno["output"]["commodity"]`` is used to generate the IDs of these commodities.
+
+  **Example:** “transport pax {mode}” is used with to generate a commodity “transport pax RUEAA” is associated with the consumer group with ID “RUEAA”.
+
+- 1 additional 'technology' set element per disutility-affected technology.
+  ``template.id`` is used to generate the IDs of these technologies.
+
+  **Example:** “transport {technology} usage}” is used to generate “transport ELC_100 usage” associated with the existing technology “ELC_100”.
+
+
+The spec is applied to the target scenario using :func:`.model.build.apply_spec`.
+If the arguments produce a spec that is inconsistent with the target scenario, an exception will by raised at this point.
+
+
+Next, :func:`add` uses :func:`disutility_conversion` to generate data for the 'input' and 'output' parameters, as follows:
+
+- Existing, disutility-affected technologies (those listed in the ``technologies`` argument) 'output' to technology-specific commodities.
+
+  **Example:** the technology “ELC_100” outputs to the commodity “transport vehicle ELC_100”, instead of to a common/pooled commodity such as “transport vehicle”.
+
+- New, conversion technologies have one 'mode' per consumer group.
+
+  **Example:** the new technology “transport ELC_100 usage”
+
+  - …in “all” modes—takes the *same* quantity of input from the *technology-specific* commodity “transport ELC_100 vehicle”.
+  - …in each consumer-group specific mode e.g. “RUEAA”—takes a *group-specific* quantity of input from the common commodity “disutility”.
+  - …in each consumer-group specific mode e.g. “RUEAA”—outputs to a *group-specific* commodity, e.g. “transport pax RUEAA”.
+
+
+Code reference
+==============
+
+.. automodule:: message_ix_models.model.disutility
+   :members:

--- a/doc/api/model-build.rst
+++ b/doc/api/model-build.rst
@@ -37,7 +37,7 @@ The following modules use this workflow and can be examples for developing simil
 Code reference
 ==============
 
-.. currentmodule:: message_data.model.build
+.. currentmodule:: message_ix_models.model.build
 
-.. automodule:: message_data.model.build
+.. automodule:: message_ix_models.model.build
    :members:

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -19,10 +19,18 @@ Commonly used:
 .. autosummary::
 
    as_codes
+   broadcast
+   copy_column
+   ffill
    load_package_data
    load_private_data
+   make_io
+   make_matched_dfs
+   make_source_tech
+   merge_data
    package_data_path
    private_data_path
+   same_node
    ~context.Context
    ~scenarioinfo.ScenarioInfo
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ These models are built in the `MESSAGEix framework <https://docs.messageix.org>`
    api/model
    api/model-bare
    api/model-build
+   api/disutility
    api/project
    api/tools
    api/util

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add :mod:`.model.disutility`, code for setting up structure and data for generalized consumer disutility (:pull:`13`)
 
 2021.3.24
 =========

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -66,6 +66,9 @@ def get_spec(
     add.set["commodity"] = [Code(id="disutility")]
     add.set["technology"] = [Code(id="disutility source")]
 
+    # Disutility is unitless
+    add.set["unit"].append("")
+
     # Add conversion technologies
     for t, g in product(technologies, groups):
         # String formatting arguments
@@ -187,7 +190,7 @@ def data_conversion(info, spec) -> Mapping[str, pd.DataFrame]:
             if par == "input":
                 # Add input of disutility
                 df = pd.concat(
-                    [df, df.assign(commodity="disutility")], ignore_index=True
+                    [df, df.assign(commodity="disutility", unit="")], ignore_index=True
                 )
 
             data0[par].append(df)

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -1,0 +1,229 @@
+from collections import defaultdict
+from functools import lru_cache, partial
+from typing import Mapping
+import logging
+
+import pandas as pd
+from sdmx.model import Annotation, Code
+from message_ix_models import ScenarioInfo
+from message_ix_models.model.build import apply_spec
+from message_ix_models.util import (
+    broadcast,
+    eval_anno,
+    make_io,
+    make_matched_dfs,
+    make_source_tech,
+    merge_data,
+    same_node,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+def add(scenario, consumer_groups, technologies, template, **options):
+    """Add disutility formulation to `scenario`."""
+    # Generate the spec given the configuration options
+    spec = get_spec(scenario, consumer_groups, technologies, template)
+
+    # Apply spec and add data
+    apply_spec(scenario, spec, partial(get_data, spec=spec), **options)
+
+
+def get_spec(scenario, consumer_groups, technologies, template):
+    """Get a spec for a disutility formulation."""
+    require = ScenarioInfo()
+    remove = ScenarioInfo()
+    add = ScenarioInfo()
+
+    require.set["technology"] = technologies
+
+    # Disutility commodity and source
+    add.set["commodity"] = [Code(id="disutility")]
+    add.set["technology"] = [Code(id="disutility source")]
+
+    # Add consumer groups
+    for cg in consumer_groups:
+        add.set["mode"].append(Code(id=cg.id, name=f"Production for {cg.id}"))
+
+    # Add conversion technologies
+    for t in technologies:
+        # String formatting arguments
+        fmt = dict(technology=t)
+
+        # - Format the ID string from the template
+        # - Copy the "output" annotation without modification
+        t_code = Code(
+            id=template.id.format(**fmt),
+            annotations=[template.get_annotation(id="output")],
+        )
+
+        # Format each field in the "input" annotation
+        input = eval(str(template.get_annotation(id="input").text))
+        t_code.annotations.append(
+            Annotation(
+                id="input", text=repr({k: v.format(**fmt) for k, v in input.items()})
+            )
+        )
+
+        add.set["technology"].append(t_code)
+
+    return dict(require=require, remove=remove, add=add)
+
+
+def get_data(scenario, spec, **kwargs) -> Mapping[str, pd.DataFrame]:
+    """Get data for disutility formulation.
+
+    Calls :meth:`data_conversion` and :meth:`data_source`.
+
+    Parameters
+    ----------
+    spec : dict
+        The output of :meth:`get_spec`.
+    """
+    if len(kwargs):
+        log.warning(f"Ignore {repr(kwargs)}")
+
+    info = ScenarioInfo(scenario)
+
+    # Get conversion technology data
+    data = data_conversion(info, spec)
+
+    # Get and append source data
+    merge_data(data, data_source(info, spec))
+
+    return data
+
+
+def data_conversion(info, spec) -> Mapping[str, pd.DataFrame]:
+    """Input and output data for disutility conversion technologies."""
+    common = dict(
+        year_vtg=info.Y,
+        year_act=info.Y,
+        # No subannual detail
+        time="year",
+        time_origin="year",
+        time_dest="year",
+    )
+
+    # Use the spec to retrieve information
+    technology = spec["add"].set["technology"]
+    mode = list(map(str, spec["add"].set["mode"]))
+
+    # Data to return
+    data = defaultdict(list)
+
+    # Loop over technologies
+    for t in technology:
+        # Use the annotations on the technology Code to get information about the
+        # commodity, level, and unit
+        input = eval_anno(t, "input")
+        output = eval_anno(t, "output")
+        if input is output is None:
+            if t.id == "disutility source":
+                continue  # Data for this tech is from disutility_source()
+            else:
+                raise ValueError(t)  # Error in user input
+
+        # Helper functions for output
+        @lru_cache()
+        def oc_for_mode(mode):
+            # Format the output commodity id given the mode id
+            return output["commodity"].format(mode=mode)
+
+        def output_commodity(df):
+            # Return a series with output commodity based on mode
+            return df["mode"].apply(oc_for_mode)
+
+        # Make input and output data frames
+        i_o = make_io(
+            (input["commodity"], input["level"], input["unit"]),
+            (None, output["level"], output["unit"]),
+            1.0,
+            on="output",
+            technology=t.id,
+            **common,
+        )
+        for par, df in i_o.items():
+            # Broadcast across nodes
+            df = df.pipe(broadcast, node_loc=info.N[1:]).pipe(same_node)
+            if par == "input":
+                # Common across modes
+                data[par].append(df.assign(mode="all"))
+
+                # Disutility inputs differ by mode
+                data[par].append(
+                    df.assign(commodity="disutility").pipe(broadcast, mode=mode)
+                )
+            elif par == "output":
+                # - Broadcast across modes
+                # - Use a function to set the output commodity based on the
+                #   mode
+                data[par].append(
+                    df.pipe(broadcast, mode=mode).assign(commodity=output_commodity)
+                )
+
+    # Concatenate to a single data frame per parameter
+    data = {par: pd.concat(dfs) for par, dfs in data.items()}
+
+    # Create data for capacity_factor and technical_lifetime
+    data.update(
+        make_matched_dfs(
+            base=data["input"],
+            capacity_factor=1,
+            # TODO get this from ScenarioInfo
+            technical_lifetime=10,
+            # commented: activity constraints for the technologies
+            # TODO get these values from an argument
+            growth_activity_lo=-0.5,
+            # growth_activity_up=0.5,
+            # initial_activity_up=1.,
+            # soft_activity_lo=-0.5,
+            # soft_activity_up=0.5,
+        )
+    )
+    # Remove growth_activity_lo for first year
+    data["growth_activity_lo"] = data["growth_activity_lo"].query(
+        f"year_act > {spec['add'].y0}"
+    )
+
+    # commented: initial activity constraints for the technologies
+    # data.update(
+    #    make_matched_dfs(base=data["output"], initial_activity_up=2.)
+    # )
+
+    return data
+
+
+def data_source(info, spec) -> Mapping[str, pd.DataFrame]:
+    """Generate data for a technology that emits the disutility commodity."""
+    # List of input levels where disutility commodity must exist
+    levels = set()
+    for t in spec["add"].set["technology"]:
+        input = eval_anno(t, "input")
+        if input:
+            levels.add(input["level"])
+        else:
+            # "disutility source" technology has no annotations
+            continue
+
+    log.info(f"Generate disutility on level(s): {repr(levels)}")
+
+    result = make_source_tech(
+        info,
+        common=dict(
+            commodity="disutility",
+            mode="all",
+            technology="disutility source",
+            time="year",
+            time_dest="year",
+            unit="-",
+        ),
+        output=1.0,
+        var_cost=1.0,
+        # TODO get this from ScenarioInfo
+        technical_lifetime=10,
+    )
+    result["output"] = result["output"].pipe(broadcast, level=sorted(levels))
+
+    return result

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -195,20 +195,8 @@ def data_conversion(info, spec) -> Mapping[str, pd.DataFrame]:
     # Concatenate to a single data frame per parameter
     data = {par: pd.concat(dfs, ignore_index=True) for par, dfs in data0.items()}
 
-    # Create data for capacity_factor and technical_lifetime
-    data.update(
-        make_matched_dfs(
-            base=data["input"],
-            capacity_factor=1,
-            technical_lifetime=None,
-        )
-    )
-
-    # Update technical_lifetime with values from duration_period for the corresponding
-    # period
-    data["technical_lifetime"] = data["technical_lifetime"].assign(
-        value=dp_for("year_vtg", info), unit="y"
-    )
+    # Create data for capacity_factor
+    data.update(make_matched_dfs(base=data["input"], capacity_factor=1.0))
 
     return data
 
@@ -227,6 +215,7 @@ def data_source(info, spec) -> Mapping[str, pd.DataFrame]:
 
     log.info(f"Generate disutility on level(s): {repr(levels)}")
 
+    # Use default capacity_factor = 1.0
     result = make_source_tech(
         info,
         common=dict(
@@ -239,13 +228,7 @@ def data_source(info, spec) -> Mapping[str, pd.DataFrame]:
         ),
         output=1.0,
         var_cost=1.0,
-        technical_lifetime=None,
     )
     result["output"] = result["output"].pipe(broadcast, level=sorted(levels))
-    # Update technical_lifetime with values from duration_period for the corresponding
-    # period
-    result["technical_lifetime"] = result["technical_lifetime"].assign(
-        value=dp_for("year_vtg", info), unit="y"
-    )
 
     return result

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -145,7 +145,7 @@ def dp_for(col_name: str, info: ScenarioInfo) -> pd.Series:
 
 
 def data_conversion(info, spec) -> Mapping[str, pd.DataFrame]:
-    """Input and output data for disutility conversion technologies."""
+    """Generate input and output data for disutility conversion technologies."""
     common = dict(
         mode="all",
         year_vtg=info.Y,
@@ -205,7 +205,7 @@ def data_conversion(info, spec) -> Mapping[str, pd.DataFrame]:
 
 
 def data_source(info, spec) -> Mapping[str, pd.DataFrame]:
-    """Generate data for a technology that emits the disutility commodity."""
+    """Generate data for a technology that emits the “disutility” commodity."""
     # List of input levels where disutility commodity must exist
     levels = set()
     for t in spec["add"].set["technology"]:

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -127,13 +127,15 @@ def get_data(scenario, spec, **kwargs) -> Mapping[str, pd.DataFrame]:
     return data
 
 
-def dp_for(col_name: str, info: ScenarioInfo) -> pd.Series:
+def dp_for(col_name: str, info: ScenarioInfo) -> pd.Series:  # pragma: no cover
     """:meth:`pandas.DataFrame.assign` helper for ``duration_period``.
 
     Returns a callable to be passed to :meth:`pandas.DataFrame.assign`. The callable
     takes a data frame as the first argument, and returns a :class:`pandas.Series`
     based on the ``duration_period`` parameter in `info`, aligned to `col_name` in the
     data frame.
+
+    Currently (2021-04-07) unused.
     """
 
     def func(df):
@@ -171,7 +173,7 @@ def data_conversion(info, spec) -> Mapping[str, pd.DataFrame]:
         if None in (input, output):
             if t.id == "disutility source":
                 continue  # Data for this tech is from data_source()
-            else:
+            else:  # pragma: no cover
                 raise ValueError(t)  # Error in user input
 
         # Make input and output data frames
@@ -212,9 +214,6 @@ def data_source(info, spec) -> Mapping[str, pd.DataFrame]:
         input = eval_anno(t, "input")
         if input:
             levels.add(input["level"])
-        else:
-            # "disutility source" technology has no annotations
-            continue
 
     log.info(f"Generate disutility on level(s): {repr(levels)}")
 

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from functools import lru_cache, partial
+from functools import partial
 from itertools import product
 from typing import Dict, List, Mapping, Sequence, Union
 

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -100,7 +100,7 @@ def get_spec(
         add.set["technology"].append(t_code)
 
     # Deduplicate "commodity" set elements
-    add.set["commodity"] = sorted(set(add.set["commodity"]))
+    add.set["commodity"] = sorted(map(str, set(add.set["commodity"])))
 
     return dict(require=require, remove=remove, add=add)
 

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
 from functools import lru_cache, partial
-from typing import Mapping
+from typing import Dict, Mapping, Sequence, Union
 import logging
 
+import message_ix
 import pandas as pd
 from sdmx.model import Annotation, Code
+
 from message_ix_models import ScenarioInfo
 from message_ix_models.model.build import apply_spec
 from message_ix_models.util import (
@@ -20,18 +22,40 @@ from message_ix_models.util import (
 
 log = logging.getLogger(__name__)
 
+CodeLike = Union[str, Code]
 
-def add(scenario, consumer_groups, technologies, template, **options):
+
+def add(
+    scenario: message_ix.Scenario,
+    groups: Sequence[CodeLike],
+    technologies: Sequence[CodeLike],
+    template: Code,
+    **options,
+) -> None:
     """Add disutility formulation to `scenario`."""
     # Generate the spec given the configuration options
-    spec = get_spec(scenario, consumer_groups, technologies, template)
+    spec = get_spec(groups, technologies, template)
 
     # Apply spec and add data
     apply_spec(scenario, spec, partial(get_data, spec=spec), **options)
 
 
-def get_spec(scenario, consumer_groups, technologies, template):
-    """Get a spec for a disutility formulation."""
+def get_spec(
+    groups: Sequence[CodeLike],
+    technologies: Sequence[CodeLike],
+    template: Code,
+) -> Dict[str, ScenarioInfo]:
+    """Get a spec for a disutility formulation.
+
+    Parameters
+    ----------
+    groups : list of Code
+        Identities of the consumer groups with distinct disutilities.
+    technologies : list of Code
+        The technologies to which the disutilities are applied.
+    template : .Code
+
+    """
     require = ScenarioInfo()
     remove = ScenarioInfo()
     add = ScenarioInfo()

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -127,7 +127,8 @@ class CliRunner(click.testing.CliRunner):
             self.invoke(*args, **kwargs)
 
         if self.last_result.exit_code != 0:
-            raise self.last_result.exc_info[1]
+            # Re-raise the exception triggered within the CLI invocation
+            raise self.last_result.exc_info[1].__context__
 
         return self.last_result
 

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -157,8 +157,9 @@ def bare_res(request, context: Context, solved: bool = False) -> message_ix.Scen
 
     Parameters
     ----------
-    request : .Request
-        The pytest :fixture:`pytest:request` fixture.
+    request : .Request or None
+        The pytest :fixture:`pytest:request` fixture. If provided the pytest test node
+        name is used for the scenario name of the returned Scenario.
     context : .Context
         Passed to :func:`.testing.bare_res`.
     solved : bool, optional
@@ -188,5 +189,10 @@ def bare_res(request, context: Context, solved: bool = False) -> message_ix.Scen
         log.info("Solve")
         base.solve(solve_options=dict(lpmethod=4), quiet=True)
 
-    log.info(f"Clone to '{name}/{request.node.name}'")
-    return base.clone(scenario=request.node.name, keep_solution=solved)
+    try:
+        new_name = request.node.name
+    except AttributeError:
+        new_name = "baseline"
+
+    log.info(f"Clone to '{name}/{new_name}'")
+    return base.clone(scenario=new_name, keep_solution=solved)

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -1,3 +1,4 @@
+"""Tests of :mod:`.model.disutility`."""
 from itertools import product
 
 import pandas as pd
@@ -34,19 +35,19 @@ COMMON = dict(
 
 @pytest.fixture
 def groups():
-    """List of two consumer groups."""
+    """Fixture: list of 2 consumer groups."""
     yield [Code(id="g0"), Code(id="g1")]
 
 
 @pytest.fixture
 def techs():
-    """List of two technologies, for which groups may have different disutilities."""
+    """Fixture: list of 2 technologies for which groups can have disutility."""
     yield [Code(id="t0"), Code(id="t1")]
 
 
 @pytest.fixture
 def template():
-    """:class:.`Code` object with annotations, for :func:`.disutility.get_spec`."""
+    """Fixture: :class:.`Code` with annotations, for :func:`.disutility.get_spec`."""
     # Template for inputs of conversion technologies, from a technology-specific
     # commodity
     input = dict(commodity="output of {technology}", level="useful", unit="kg")
@@ -67,13 +68,13 @@ def template():
 
 @pytest.fixture
 def spec(groups, techs, template):
-    """A prepared spec for the minimal test case."""
+    """Fixture: a prepared spec for the minimal test case."""
     yield disutility.get_spec(groups, techs, template)
 
 
 @pytest.fixture
 def scenario(request, test_context, techs):
-    """A :class:`.Scenario` with technologies given by :func:`techs`."""
+    """Fixture: a :class:`.Scenario` with technologies given by :func:`techs`."""
     s = testing.bare_res(request, test_context, solved=False)
     s.check_out()
 
@@ -93,7 +94,7 @@ def test_add(scenario, groups, techs, template):
 
 
 def minimal_test_data(scenario):
-    # Fill in the data for the test case
+    """Generate data for :func:`test_minimal`."""
     common = COMMON.copy()
     common.pop("node_loc")
     common.update(dict(mode="all"))
@@ -149,7 +150,7 @@ def minimal_test_data(scenario):
 
 
 def test_minimal(scenario, groups, techs, template):
-    """Minimal test case for :mod:`.disutility`."""
+    """Expected results are generated from a minimal test case."""
     # Set up structure
     disutility.add(scenario, groups, techs, template)
 

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -1,7 +1,8 @@
 from itertools import product
 
 import pandas as pd
-import pandas.testing as pdt
+
+# import pandas.testing as pdt
 import pytest
 from message_ix import make_df
 from sdmx.model import Annotation, Code

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -184,8 +184,15 @@ def test_get_spec(groups, techs, template):
     # Spec removes nothing
     assert set() == set(spec["remove"].set.keys())
 
-    # Spec adds the "disutility" commodity
-    assert {"disutility"} == set(map(str, spec["add"].set["commodity"]))
+    # Spec adds the "disutility" commodity; and adds (if not existing) the output
+    # commodities for t[01] and demand commodities for g[01]
+    assert {
+        "disutility",
+        "output of t0",
+        "output of t1",
+        "demand of group g0",
+        "demand of group g1",
+    } == set(map(str, spec["add"].set["commodity"]))
 
     # Spec adds the "distuility source" technology, and "{tech} usage" for each tech,
     # per the template

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -2,7 +2,6 @@
 from itertools import product
 
 import pandas as pd
-
 import pandas.testing as pdt
 import pytest
 from message_ix import make_df

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -1,0 +1,196 @@
+import pandas as pd
+import pytest
+from message_ix import make_df
+from sdmx.model import Annotation, Code
+
+from message_ix_models import ScenarioInfo, testing
+from message_ix_models.model import disutility
+from message_ix_models.util import (
+    add_par_data,
+    copy_column,
+    make_source_tech,
+    merge_data,
+)
+
+# Common data and fixtures for test_minimal() and other tests
+
+COMMON = dict(
+    level="useful",
+    node_dest="R14_AFR",
+    node_loc="R14_AFR",
+    node_origin="R14_AFR",
+    node="R14_AFR",
+    time_dest="year",
+    time_origin="year",
+    time="year",
+    unit="kg",
+)
+
+
+@pytest.fixture
+def groups():
+    """List of two consumer groups."""
+    yield [Code(id="g0"), Code(id="g1")]
+
+
+@pytest.fixture
+def techs():
+    """List of two technologies, for which groups may have different disutilities."""
+    yield [Code(id="t0"), Code(id="t1")]
+
+
+@pytest.fixture
+def template():
+    """:class:.`Code` object with annotations, for :func:`.disutility.get_spec`."""
+    # Template for inputs of conversion technologies, from a technology-specific
+    # commodity
+    input = dict(commodity="output of {technology}", level="useful", unit="kg")
+
+    # Template for outputs of conversion technologies, to a group–specific demand
+    # commodity
+    output = dict(commodity="demand of group {mode}", level="useful", unit="kg")
+
+    # Code's ID is itself a template for IDs of conversion technologies
+    yield Code(
+        id="{technology} usage",
+        annotations=[
+            Annotation(id="input", text=repr(input)),
+            Annotation(id="output", text=repr(output)),
+        ],
+    )
+
+
+@pytest.fixture
+def spec(groups, techs, template):
+    """A prepared spec for the minimal test case."""
+    yield disutility.get_spec(groups, techs, template)
+
+
+@pytest.fixture
+def scenario(request, test_context, techs):
+    """A :class:`.Scenario` with technologies given by :func:`techs`."""
+    s = testing.bare_res(request, test_context, solved=False)
+    s.check_out()
+
+    s.add_set("technology", ["t0", "t1"])
+
+    s.commit("Test fixture for .model.disutility")
+    yield s
+
+
+def test_add(scenario, groups, techs, template):
+    """:func:`.disutility.add` runs on the bare RES; the result solves."""
+    disutility.add(scenario, groups, techs, template)
+
+    # Scenario solves (no demand)
+    scenario.solve(quiet=True)
+    assert (scenario.var("ACT")["lvl"] == 0).all()
+
+
+def test_minimal(scenario, groups, techs, template):
+    """Minimal test case for disutility formulation."""
+    disutility.add(scenario, groups, techs, template)
+
+    # Fill in the data for the test case
+
+    common = COMMON.copy()
+    common.pop("node_loc")
+    common.update(dict(mode="all"))
+
+    data = dict()
+
+    for t in ("t0", "t1"):
+        common.update(dict(technology=t, commodity=f"output of {t}"))
+        merge_data(
+            data,
+            make_source_tech(
+                ScenarioInfo(scenario),
+                common,
+                output=1.0,
+                technical_lifetime=5.0,
+                var_cost=0.0,
+            ),
+        )
+
+    # For each combination of (tech) × (group) × (2 years)
+    df = pd.DataFrame(
+        [
+            ["g0", "output of t0", "t0 usage", 2020, 1.0],
+            ["g0", "output of t0", "t0 usage", 2025, 1.0],
+            ["g0", "output of t1", "t1 usage", 2020, 1.0],
+            ["g0", "output of t1", "t1 usage", 2025, 1.0],
+            ["g1", "output of t0", "t0 usage", 2020, 1.0],
+            ["g1", "output of t0", "t0 usage", 2025, 1.0],
+            ["g1", "output of t1", "t1 usage", 2020, 1.0],
+            ["g1", "output of t1", "t1 usage", 2025, 1.0],
+        ],
+        columns=["mode", "commodity", "technology", "year_vtg", "value"],
+    )
+    data["input"] = make_df("input", **df, **COMMON).assign(
+        node_origin=copy_column("node_loc"), year_act=copy_column("year_vtg")
+    )
+
+    data["demand"] = make_df(
+        "demand",
+        **pd.DataFrame(
+            [
+                ["demand of group g0", 2020, 1.0],
+                ["demand of group g0", 2025, 1.0],
+                ["demand of group g1", 2020, 1.0],
+                ["demand of group g1", 2025, 1.0],
+            ],
+            columns=["commodity", "year", "value"],
+        ),
+        **COMMON,
+    )
+
+    scenario.check_out()
+    add_par_data(scenario, data)
+    scenario.commit("Disutility test 1")
+
+    scenario.solve(quiet=True)
+
+    ACT = scenario.var("ACT").query("lvl > 0").drop(columns=["node_loc", "time", "mrg"])
+
+    # For debugging TODO comment before merging
+    print(ACT)
+
+
+def test_data_conversion(scenario, spec):
+    """:func:`~.disutility.data_conversion` runs."""
+    info = ScenarioInfo(scenario)
+    disutility.data_conversion(info, spec)
+
+
+def test_data_source(scenario, spec):
+    """:func:`~.disutility.data_source` runs."""
+    info = ScenarioInfo(scenario)
+    disutility.data_source(info, spec)
+
+
+def test_get_data(scenario, spec):
+    """:func:`~.disutility.get_data` runs."""
+    disutility.get_data(scenario, spec)
+
+
+def test_get_spec(groups, techs, template):
+    """:func:`~.disutility.get_spec` runs and produces expected output."""
+    spec = disutility.get_spec(groups, techs, template)
+
+    # Spec requires the existence of the base technologies
+    assert {"technology"} == set(spec["require"].set.keys())
+    assert techs == spec["require"].set["technology"]
+
+    # Spec removes nothing
+    assert set() == set(spec["remove"].set.keys())
+
+    # Spec adds the "disutility" commodity
+    assert {"disutility"} == set(map(str, spec["add"].set["commodity"]))
+
+    # Spec adds the "distuility source" technology, and "{tech} usage" for each tech,
+    # per the template
+    assert {"disutility source", "t0 usage", "t1 usage"} == set(
+        map(str, spec["add"].set["technology"])
+    )
+    # Spec adds two modes
+    assert {"g0", "g1"} == set(map(str, spec["add"].set["mode"]))

--- a/message_ix_models/tests/test_testing.py
+++ b/message_ix_models/tests/test_testing.py
@@ -1,4 +1,12 @@
+import click
+import pytest
+
 from message_ix_models.testing import bare_res
+
+
+def test_bare_res_no_request(test_context):
+    """:func:`bare_res` works with `request` = :obj:`None`."""
+    bare_res(None, test_context, solved=False)
 
 
 def test_bare_res_solved(request, test_context):
@@ -8,3 +16,8 @@ def test_bare_res_solved(request, test_context):
     test.
     """
     bare_res(request, test_context, solved=True)
+
+
+def test_cli_runner(mix_models_cli):
+    with pytest.raises(click.exceptions.UsageError, match="No such command 'foo'"):
+        mix_models_cli.assert_exit_0(["foo", "bar"])

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -2,15 +2,22 @@
 import logging
 from pathlib import Path
 
+import pandas as pd
 import pytest
+from message_ix import make_df
 
+from message_ix_models import ScenarioInfo
 from message_ix_models.util import (
     MESSAGE_DATA_PATH,
     MESSAGE_MODELS_PATH,
     as_codes,
+    broadcast,
+    copy_column,
+    ffill,
     iter_parameters,
     load_package_data,
     load_private_data,
+    make_source_tech,
     package_data_path,
     private_data_path,
 )
@@ -40,6 +47,37 @@ def test_as_codes_invalid(data):
     """as_codes() rejects invalid data."""
     with pytest.raises(TypeError):
         as_codes(data)
+
+
+def test_copy_column():
+    df = pd.DataFrame([[0, 1], [2, 3]], columns=["a", "b"])
+    df = df.assign(c=copy_column("a"), d=4)
+    assert all(df["c"] == [0, 2])
+    assert all(df["d"] == 4)
+
+
+def test_ffill():
+    years = list(range(6))
+
+    df = (
+        make_df(
+            "fix_cost",
+            year_act=[0, 2, 4],
+            year_vtg=[0, 2, 4],
+            technology=["foo", "bar", "baz"],
+            unit="USD",
+        )
+        .pipe(broadcast, node_loc=["A", "B", "C"])
+        .assign(value=list(map(float, range(9))))
+    )
+
+    # Function completes
+    result = ffill(df, "year_vtg", years, "year_act = year_vtg")
+
+    assert 2 * len(df) == len(result)
+    assert years == sorted(result["year_vtg"].unique())
+
+    # TODO test some specific values
 
 
 def test_iter_parameters(test_context):
@@ -77,6 +115,44 @@ def test_load_package_data_invalid():
 )
 def test_load_private_data(*parts, suffix=None):
     load_private_data("sources.yaml")
+
+
+def test_make_source_tech():
+    info = ScenarioInfo()
+    info.set["node"] = ["World", "node0", "node1"]
+    info.set["year"] = [1, 2, 3]
+
+    values = dict(
+        capacity_factor=1.0,
+        output=2.0,
+        var_cost=3.0,
+        technical_lifetime=4.0,
+    )
+    result = make_source_tech(
+        info,
+        common=dict(
+            commodity="commodity",
+            level="level",
+            mode="mode",
+            technology="technology",
+            time="time",
+            time_dest="time",
+            unit="unit",
+        ),
+        **values,
+    )
+    # Result is dictionary with the expected keys
+    assert isinstance(result, dict)
+    assert set(result.keys()) == set(values.keys())
+
+    # "World" node does not appear in results
+    assert set(result["output"]["node_loc"].unique()) == set(info.N[1:])
+
+    for df in result.values():
+        # Results have 2 nodes × 3 years
+        assert len(df) == 2 * 3
+        # No empty values
+        assert not df.isna().any(None)
 
 
 def test_package_data_path(*parts, suffix=None):

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -155,7 +155,7 @@ def broadcast(df, **kwargs):
             pd.concat([df] * len(levels), keys=levels, names=[dim])
             .drop(dim, axis=1)
             .reset_index(dim)
-            .reset_index()
+            .reset_index(drop=True)
         )
     return df
 
@@ -412,7 +412,7 @@ def make_matched_dfs(base, **par_value):
     return {
         par: message_ix.make_df(par, **data, value=value)
         .drop_duplicates()
-        .reset_index()
+        .reset_index(drop=True)
         for par, value in par_value.items()
     }
 

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -411,7 +411,7 @@ def make_matched_dfs(base, **par_value):
     }
 
 
-def make_source_tech(info, common, **values) -> Mapping[str, pd.DataFrame]:
+def make_source_tech(info, common, **values) -> Dict[str, pd.DataFrame]:
     """Return parameter data for a ‘source’ technology.
 
     The technology has no inputs; its output commodity and/or level are determined by

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -160,8 +160,8 @@ def copy_column(column_name):
 
     Examples
     --------
-    Modify `df` by filling the column 'baz' with the value ``3``, and copying
-    the column 'bar' into column 'foo'.
+    Modify `df` by filling the column 'baz' with the value ``3``, and copying the column
+    'bar' into column 'foo'.
 
     >>> df.assign(foo=copy_column('bar'), baz=3)
     """
@@ -354,9 +354,8 @@ def make_io(src, dest, efficiency, on="input", **kwargs):
     efficiency : float
         Conversion efficiency.
     on : 'input' or 'output'
-        If 'input', `efficiency` applies to the input, and the output, thus the
-        activity level of the technology, is in dest[2] units. If 'output',
-        the opposite.
+        If 'input', `efficiency` applies to the input, and the output, thus the activity
+        level of the technology, is in dest[2] units. If 'output', the opposite.
     kwargs
         Passed to :func:`make_df`.
 
@@ -389,11 +388,11 @@ def make_matched_dfs(base, **par_value):
     """Return data frames derived from *base* for multiple parameters.
 
     *par_values* maps from parameter names (e.g. 'fix_cost') to values.
-    make_matched_dfs returns a :class:`dict` of :class:`pandas.DataFrame`, one
-    for each parameter in *par_value*. The contents of *base* are used to
-    populate the columns of each data frame, and the values of *par_value*
-    overwrite the 'value' column. Duplicates—which occur when the target
-    parameter has fewer dimensions than *base*—are dropped.
+    make_matched_dfs returns a :class:`dict` of :class:`pandas.DataFrame`, one for each
+    parameter in *par_value*. The contents of *base* are used to populate the columns
+    of each data frame, and the values of *par_value* overwrite the 'value' column.
+    Duplicates—which occur when the target parameter has fewer dimensions than
+    *base*—are dropped.
 
     Examples
     --------

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -495,10 +495,11 @@ def strip_par_data(
     # Iterate over parameters with ≥1 dimensions indexed by `set_name`
     for par_name in iter_parameters(set_name):
         if par_name not in par_list:
-            raise RuntimeError(  # pragma: no cover
+            log.warning(  # pragma: no cover
                 f"MESSAGEix parameter {repr(par_name)} missing in Scenario "
                 f"{scenario.model}/{scenario.scenario}"
             )
+            continue
 
         # Iterate over dimensions indexed by `set_name`
         for dim, _ in filter(

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -205,7 +205,7 @@ def ffill(
         Data to fill forwards.
     dim : str
         Dimension to fill along. Must be a column in `df`.
-    labels : list of str
+    values : list of str
         Labels along `dim` that must be present in the returned data frame.
     expr : str, optional
         If provided, :meth:`.DataFrame.eval` is called. This can be used to assign one
@@ -507,8 +507,8 @@ def strip_par_data(
 
     # Iterate over parameters with ≥1 dimensions indexed by `set_name`
     for par_name in iter_parameters(set_name):
-        if par_name not in par_list:
-            log.warning(  # pragma: no cover
+        if par_name not in par_list:  # pragma: no cover
+            log.warning(
                 f"MESSAGEix parameter {repr(par_name)} missing in Scenario "
                 f"{scenario.model}/{scenario.scenario}"
             )

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -139,7 +139,13 @@ def broadcast(df, **kwargs):
         Keys are dimensions. Values are labels along that dimension to fill.
     """
     for dim, levels in kwargs.items():
-        assert df[dim].isna().all(), ("Dimension {dim} was not empty", df.head())
+        # Checks
+        assert df[dim].isna().all(), f"Dimension {dim} was not empty\n\n{df.head()}"
+        if len(levels) == 0:
+            log.debug(
+                f"Don't broadcast over {repr(dim)}; labels {levels} have length 0"
+            )
+            continue
 
         df = (
             pd.concat({level: df for level in levels}, names=[dim])
@@ -408,9 +414,9 @@ def make_matched_dfs(base, **par_value):
 def make_source_tech(info, common, **values) -> Mapping[str, pd.DataFrame]:
     """Return parameter data for a ‘source’ technology.
 
-    The technology has no inputs; its output commodity and/or level are
-    determined by `common`; either single values, or :obj:`None` if the
-    result will be :meth:`~DataFrame.pipe`'d through :func:`broadcast`.
+    The technology has no inputs; its output commodity and/or level are determined by
+    `common`; either single values, or :obj:`None` if the result will be
+    :meth:`~DataFrame.pipe`'d through :func:`broadcast`.
 
     Parameters
     ----------

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -430,8 +430,8 @@ def make_source_tech(info, common, **values) -> Dict[str, pd.DataFrame]:
     common : dict
         Passed to :func:`make_df`.
     **values
-        Values for 'capacity_factor' (optional; default 1.0), 'output',
-        'technical_lifetime', and 'var_cost'.
+        Values for 'capacity_factor' (optional; default 1.0), 'output', 'var_cost', and
+        optionally 'technical_lifetime'.
 
     Returns
     -------
@@ -440,15 +440,15 @@ def make_source_tech(info, common, **values) -> Dict[str, pd.DataFrame]:
     """
     # Check arguments
     values.setdefault("capacity_factor", 1.0)
-    missing = {"capacity_factor", "output", "technical_lifetime", "var_cost"} - set(
-        values.keys()
-    )
+    missing = {"capacity_factor", "output", "var_cost"} - set(values.keys())
     if len(missing):
-        raise ValueError(f"make_dummy_source() needs values for {repr(missing)}")
+        raise ValueError(f"make_source_tech() needs values for {repr(missing)}")
+    elif "technical_lifetime" not in values:
+        log.debug("No technical_lifetime for source technology")
 
     # Create data for "output"
-    output = (
-        message_ix.make_df(
+    result = dict(
+        output=message_ix.make_df(
             "output",
             value=values.pop("output"),
             year_act=info.Y,
@@ -458,8 +458,9 @@ def make_source_tech(info, common, **values) -> Dict[str, pd.DataFrame]:
         .pipe(broadcast, node_loc=info.N[1:])
         .pipe(same_node)
     )
-    result = make_matched_dfs(base=output, **values)
-    result["output"] = output
+
+    # Add data for other parameters
+    result.update(make_matched_dfs(base=result["output"], **values))
 
     return result
 

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -147,10 +147,15 @@ def broadcast(df, **kwargs):
             )
             continue
 
+        # - Duplicate the data
+        # - Drop the existing column named 'dim'
+        # - Re-add the column from the constructed MultiIndex
+        # - Reindex for sequential row numbers
         df = (
-            pd.concat({level: df for level in levels}, names=[dim])
+            pd.concat([df] * len(levels), keys=levels, names=[dim])
             .drop(dim, axis=1)
             .reset_index(dim)
+            .reset_index()
         )
     return df
 
@@ -405,7 +410,9 @@ def make_matched_dfs(base, **par_value):
     """
     data = {col: v for col, v in base.iteritems() if col != "value"}
     return {
-        par: message_ix.make_df(par, **data, value=value).drop_duplicates()
+        par: message_ix.make_df(par, **data, value=value)
+        .drop_duplicates()
+        .reset_index()
         for par, value in par_value.items()
     }
 

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -64,6 +64,9 @@ class ScenarioInfo:
             except AttributeError:
                 continue  # pd.DataFrame for ≥2-D set; don't convert
 
+        for name in ("duration_period",):
+            self.par[name] = scenario.par(name)
+
         self.is_message_macro = "PRICE_COMMODITY" in scenario.par_list()
 
         # Computed once


### PR DESCRIPTION
As well:
- 8 methods in `.util` used by `.model.disutility`.
- Install GAMS using iiasa/actions workflows, parallel to iiasa/ixmp#410 and iiasa/message_ix#452.
- Small tweaks and improvements to utilities, e.g. ScenarioInfo also stores `duration_period` when constructed off an existing scenario.

Partially addresses #4.