### PR TITLE
adding R12 node yaml file

### DIFF
--- a/message_ix_models/data/node/R12.yaml
+++ b/message_ix_models/data/node/R12.yaml
@@ -1,0 +1,82 @@
+# Region code list
+#
+# - See message_data.tools.regions.
+# - The ISO 3166-1 alpha-3 codes are not defined in this file, but loaded from
+#   a copy of the ISO database, e.g. in pycountry.
+# - Among others, there are no assignments for:
+#   - ATA Antarctica
+#   - IOT British Indian Ocean Territory
+#   - SGS South Georgia
+
+World:
+  name: World
+  description: R12 regions
+
+R12_AFR:
+  parent: World
+  name: Sub-Saharan Africa
+  child: [AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI, ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT, MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, STP, SWZ, SYC, TCD, TGO, TZA, UGA, ZAF, ZMB, ZWE]
+
+R12_CPA:
+  parent: World
+  name: Rest Centrally Planned Asia
+  child: [KHM, LAO, MNG, PRK, VNM]
+  
+R12_CHN:
+  parent: World
+  name: China
+  child: [CHN, HKG]  
+  
+R12_EEU:
+  parent: World
+  name: Central and Eastern Europe
+  description: >-
+    Serbia and Montenegro (SCG) and Yugoslavia (YUG) still included in this list,
+    even though their ISO 3166-1 codes were deleted in 2006 and 2003, respectively.
+  child: [ALB, BGR, BIH, CZE, EST, HRV, HUN, LTU, LVA, MKD, MNE, POL, ROU, SCG, SRB, SVK, SVN, YUG]
+
+R12_FSU:
+  parent: World
+  name: Former Soviet Union
+  child: [ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TJK, TKM, UKR, UZB]
+
+R12_LAM:
+  parent: World
+  name: Latin America and The Caribbean
+  description: >-
+    The source includes “Netherlands Antilles” which has a provisional ISO 3166-2 alpha-3 code (ANT),
+    but is not a country. It was dissolved in 2010 into BES, CUW and SXM, also included.
+  child: [ABW, AIA, ANT, ARG, ATG, BES, BHS, BLZ, BMU, BOL, BRA, BRB, CHL, COL, CRI, CUB, CUW, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY, HND, HTI, JAM, KNA, LCA, MEX, MSR, MTQ, NIC, PAN, PER, PRY, SLV, SUR, SXM, TCA, TTO, URY, VCT, VEN, VGB]
+
+R12_MEA:
+  parent: World
+  name: Middle East and North Africa
+  child: [ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR, OMN, PSE, QAT, SAU, SDN, SSD, SYR, TUN, YEM]
+
+R12_NAM:
+  parent: World
+  name: North America
+  child: [CAN, GUM, PRI, SPM, USA, VIR]
+
+R12_PAO:
+  parent: World
+  name: Pacific OECD
+  child: [AUS, JPN, NZL]
+
+R12_PAS:
+  parent: World
+  name: Other Pacific Asia
+  description: >-
+    Trust Territory of the Pacific Islands (PCI) still included in this list,
+    but it was dissolved into MHL, FSM, MNP and PLW in 1986.
+  child: [ASM, BRN, CCK, COK, CXR, FJI, FSM, IDN, KIR, KOR, MAC, MHL, MMR, MNP, MYS, NCL, NFK, NIU, NRU, PCI, PCN, PHL, PLW, PNG, PYF, SGP, SLB, THA, TKL, TLS, TON, TUV, TWN, VUT, WLF, WSM]
+
+R12_SAS:
+  parent: World
+  name: South Asia
+  child: [AFG, BGD, BTN, IND, LKA, MDV, NPL, PAK]
+
+R12_WEU:
+  parent: World
+  name: Western Europe
+  child: [AND, AUT, BEL, CHE, CYP, DEU, DNK, ESP, FIN, FRA, FRO, GBR, GIB, GRC, GRL, IMN, IRL, ISL, ITA, LIE, LUX, MCO, MLT, NLD, NOR, PRT, SJM, SMR, SWE, TUR, VAT]


### PR DESCRIPTION
The difference between the standard R11 and this new R12 is about separating the CPA region in the R11 model into two new regions for the R12 model, namely CHN (China) and CPA (the rest CPA).