### PR TITLE
Update documentation URLs

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -110,6 +110,8 @@ jobs:
 
     - name: Test documentation build using Sphinx
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      env:
+        RTD_TOKEN_MESSAGE_DATA: ${{ secrets.RTD_TOKEN_MESSAGE_DATA }}
       run: make --directory=message-ix-models/doc html
 
     - name: Upload test coverage to Codecov.io

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Tools for MESSAGEix-GLOBIOM models
 
 .. image:: https://readthedocs.com/projects/iiasa-energy-program-message-ix-models/badge/?version=latest&token=e26aafa64d5e0792f1198aa1cc328a453f7bc63360efbe1031a13f13c7ba286f
    :alt: Documentation Status
-   :target: https://docs.messageix.org/projects/models2/en/latest/?badge=latest
+   :target: https://docs.messageix.org/projects/models/en/latest/?badge=latest
 
 .. image:: https://github.com/iiasa/message-ix-models/workflows/pytest/badge.svg
    :alt: Build status
@@ -20,7 +20,7 @@ Tools for MESSAGEix-GLOBIOM models
 ``message_ix_models`` provides tools for research using the MESSAGEix-GLOBIOM family of models.
 These models are built in the `MESSAGEix framework <https://docs.messageix.org>`_ and on the `ix modeling platform (ixmp) <https://docs.messageix.org/ixmp/>`_.
 
-See the `online documentation <https://docs.messageix.org/projects/models2/>`_ for further information.
+See the `online documentation <https://docs.messageix.org/projects/models/>`_ for further information.
 
 License
 =======

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -83,13 +83,10 @@ Commonly used:
       only
       use_defaults
 
-   The following Context methods and attribute are **deprecated**:
+   .. The following Context methods and attribute are **deprecated**:
 
-   .. autosummary::
-      get_config_file
-      get_path
-      load_config
-      units
+      .. autosummary::
+         (currently none)
 
    .. automethod:: clone_to_dest
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,6 +3,7 @@
 # This file only contains a selection of the most common options. For a full list see
 # the documentation: https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -81,11 +82,18 @@ extlinks = {
 
 # -- Options for sphinx.ext.intersphinx ------------------------------------------------
 
+# For message-data, see: https://docs.readthedocs.io/en/stable/guides
+# /intersphinx.html#intersphinx-with-private-projects
+_token = os.environ.get("RTD_TOKEN_MESSAGE_DATA", "")
+
 intersphinx_mapping = {
     "genno": ("https://genno.readthedocs.io/en/stable", None),
     "ixmp": ("https://docs.messageix.org/projects/ixmp/en/latest/", None),
     "message-ix": ("https://docs.messageix.org/en/latest/", None),
-    "m-data": ("https://docs.messageix.org/projects/models-internal/en/latest/", None),
+    "m-data": (
+        f"https://{_token}:@docs.messageix.org/projects/models-internal/en/latest/",
+        None,
+    ),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 # -- Project information ---------------------------------------------------------------
 
-project = '"MESSAGEix models"'
+project = "MESSAGEix-GLOBIOM tools"
 copyright = "2020–2021, IIASA Energy, Climate, and Environment (ECE) Program"
 author = "IIASA Energy, Climate, and Environment (ECE) Program"
 

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -5,6 +5,14 @@ This page describes development practices for :mod:`message_ix_models` and :mod:
 
 In the following, the bold-face words **required**, **optional**, etc. have specific meanings as described in `IETF RFC 2119 <https://tools.ietf.org/html/rfc2119>`_.
 
+On other pages:
+
+- :doc:`message-ix:contributing` in the MESSAGEix docs.
+  *All* of these apply to contributions to :mod:`message_ix_models` and :mod:`message_data`, including the :ref:`message-ix:code-style`.
+- :doc:`data`, for how to add and handle these.
+
+On this page:
+
 .. contents::
    :local:
    :backlinks: none

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,11 +1,17 @@
-.. "MESSAGEix models" documentation master file, created by
-   sphinx-quickstart on Tue Feb 23 14:52:14 2021.
+Tools for MESSAGEix-GLOBIOM models
+**********************************
 
-MESSAGEix models
-****************
+:mod:`message_ix_models` provides tools for research using the **MESSAGEix-GLOBIOM family of models** developed by the IIASA Energy, Climate, and Environment (ECE) Program and its collaborators.
+This ‘family’ includes single-country and other models derived from the main, global model; all built in the `MESSAGEix framework <https://docs.messageix.org>`_ and on the `ix modeling platform (ixmp) <https://docs.messageix.org/ixmp/>`_.
 
-:mod:`message_ix_models` provides tools for research using the MESSAGEix-GLOBIOM family of models.
-These models are built in the `MESSAGEix framework <https://docs.messageix.org>`_ and on the `ix modeling platform (ixmp) <https://docs.messageix.org/ixmp/>`_.
+Among other tasks, the tools allow modelers to:
+
+- retrieve input data from various upstream sources,
+- process/transform upstream data into model input parameters,
+- create, populate, modify, and parametrize scenarios,
+- conduct model runs,
+- set up model *variants* with additional details or features, and
+- report quantities computed from model outputs.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
- The docs for this repository are now at **https://docs.messageix.org/models**, not /models2
- Use a token on RTD/GitHub Actions to retrieve the Intersphinx inventory for the (private) message_data docs.

## How to review

- Note that GitHub Actions (in the “Test documentation build using Spinx” step) can retrieve the Intersphinx inventory for message_data.
- Note that RTD can retrieve the Intersphinx inventory for message_data.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update doc/whatsnew.~ N/A, no functional changes