### PR TITLE
Add --years, --nodes CLI parameters

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2
+      # Uncomment and set equal to the "latest version testable on GitHub
+      # Actions" per pytest.yaml, if different from the default version used by
+      # setup-python.
+      with:
+        python-version: "3.9"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/doc/api/model.rst
+++ b/doc/api/model.rst
@@ -12,6 +12,7 @@ Models and variants (:mod:`~message_ix_models.model`)
 .. currentmodule:: message_ix_models.model.structure
 
 .. automodule:: message_ix_models.model.structure
+   :members: codelists
 
 .. autofunction:: get_codes
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add :command:`--years` and :command:`--nodes` to :func:`.common_params` (:pull:`35`).
+- New utility function :func:`.structure.codelists` (:pull:`35`).
 
 2021.7.27
 =========

--- a/message_ix_models/model/bare.py
+++ b/message_ix_models/model/bare.py
@@ -11,10 +11,14 @@ import message_ix_models
 from message_ix_models import ScenarioInfo
 from message_ix_models.model.build import apply_spec
 from message_ix_models.model.data import get_data
-from message_ix_models.model.structure import get_codes
+from message_ix_models.model.structure import codelists, get_codes
 from message_ix_models.util import eval_anno
 
 log = logging.getLogger(__name__)
+
+
+def _default_first(kind, default):
+    return [default] + list(filter(lambda id: id != default, codelists(kind)))
 
 
 #: Settings and valid values; the default is listed first.
@@ -24,8 +28,9 @@ log = logging.getLogger(__name__)
 #: - ``years``: recognized lists of time periods ("years"); these match the files
 #:   :file:`data/year/*.yaml`
 SETTINGS = dict(
-    regions=["R14", "R11", "R12", "RCP", "ISR"],
-    years=["B", "A"],
+    # Place the default value first
+    regions=_default_first("node", "R14"),
+    years=_default_first("year", "B"),
     res_with_dummies=[False, True],
 )
 

--- a/message_ix_models/model/cli.py
+++ b/message_ix_models/model/cli.py
@@ -1,5 +1,7 @@
 import click
 
+from message_ix_models.util.click import common_params
+
 
 @click.group("res")
 @click.pass_obj
@@ -8,13 +10,13 @@ def cli(context):
 
 
 @cli.command("create-bare")
-@click.option("--regions", type=click.Choice(["R11", "R14"]))
+@common_params("nodes")
 @click.pass_obj
-def create_bare(context, regions):
+def create_bare(context, nodes):
     """Create the RES from scratch."""
     from .bare import create_res
 
-    if regions:
-        context.regions = regions
+    if nodes:
+        context.regions = nodes
 
     create_res(context)

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -8,9 +8,24 @@ import pycountry
 from iam_units import registry
 from sdmx.model import Annotation, Code
 
-from message_ix_models.util import as_codes, eval_anno, load_package_data
+from message_ix_models.util import (
+    as_codes,
+    eval_anno,
+    load_package_data,
+    package_data_path,
+)
 
 log = logging.getLogger(__name__)
+
+
+def codelists(kind: str) -> List[str]:
+    """Return a valid IDs for code lists of `kind`.
+
+    Parameters
+    ----------
+    kind : str, "node" or "year"
+    """
+    return sorted(path.stem for path in package_data_path(kind).glob("*.yaml"))
 
 
 @lru_cache()

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -23,7 +23,8 @@ def codelists(kind: str) -> List[str]:
 
     Parameters
     ----------
-    kind : str, "node" or "year"
+    kind : str
+        "node" or "year".
     """
     return sorted(path.stem for path in package_data_path(kind).glob("*.yaml"))
 

--- a/message_ix_models/tests/model/test_cli.py
+++ b/message_ix_models/tests/model/test_cli.py
@@ -2,4 +2,4 @@ def test_create_bare(mix_models_cli):
     """The ``res create-bare`` CLI command can be invoked."""
     # --regions is not a required option, but we give it anyway to test the CLI code
     # that handles it
-    mix_models_cli.assert_exit_0(["res", "create-bare", "--regions=R11"])
+    mix_models_cli.assert_exit_0(["res", "create-bare", "--nodes=R11"])

--- a/message_ix_models/tests/model/test_cli.py
+++ b/message_ix_models/tests/model/test_cli.py
@@ -1,5 +1,5 @@
 def test_create_bare(mix_models_cli):
     """The ``res create-bare`` CLI command can be invoked."""
-    # --regions is not a required option, but we give it anyway to test the CLI code
+    # "--nodes" is not a required option, but we give it anyway to test the CLI code
     # that handles it
     mix_models_cli.assert_exit_0(["res", "create-bare", "--nodes=R11"])

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -4,7 +4,19 @@ from pathlib import Path
 import pytest
 from iam_units import registry
 
-from message_ix_models.model.structure import get_codes
+from message_ix_models.model.structure import codelists, get_codes
+
+
+@pytest.mark.parametrize(
+    "kind, exp",
+    [
+        ("node", ["ISR", "R11", "R12", "R14", "R32", "RCP"]),
+        ("year", ["A", "B"]),
+    ],
+)
+def test_codelists(kind, exp):
+    """:func:`codelists` returns the expected IDs."""
+    assert exp == codelists(kind)
 
 
 class TestGetCodes:

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -75,6 +75,12 @@ PARAMS = {
         callback=store_context,
         help="Overwrite or modify existing model/scenario.",
     ),
+    "nodes": Option(
+        ["--nodes"],
+        help="Code list to use for 'node' dimension.",
+        # TODO make this list dynamic, e.g. using a callback to check against data/node/
+        type=Choice(["ISR", "R11", "R14", "R32", "RCP"]),
+    ),
     "output_model": Option(
         ["--output-model"], help="Model name under which scenarios should be generated."
     ),
@@ -118,5 +124,11 @@ PARAMS = {
     ),
     "verbose": Option(
         ["--verbose", "-v"], is_flag=True, help="Print DEBUG-level log messages."
+    ),
+    "years": Option(
+        ["--years"],
+        help="Code list to use for the 'year' dimension.",
+        # TODO make this list dynamic, e.g. using a callback to check against data/year/
+        type=Choice(["A", "B"]),
     ),
 }

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -6,6 +6,8 @@ import logging
 
 from click import Argument, Choice, Option
 
+from message_ix_models.model.structure import codelists
+
 log = logging.getLogger(__name__)
 
 
@@ -78,8 +80,7 @@ PARAMS = {
     "nodes": Option(
         ["--nodes"],
         help="Code list to use for 'node' dimension.",
-        # TODO make this list dynamic, e.g. using a callback to check against data/node/
-        type=Choice(["ISR", "R11", "R14", "R32", "RCP"]),
+        type=Choice(codelists("node")),
     ),
     "output_model": Option(
         ["--output-model"], help="Model name under which scenarios should be generated."
@@ -98,8 +99,7 @@ PARAMS = {
     "regions": Option(
         ["--regions"],
         help="Code list to use for 'node' dimension.",
-        # TODO make this list dynamic, e.g. using a callback to check against data/node/
-        type=Choice(["ISR", "R11", "R14", "R32", "RCP"]),
+        type=Choice(codelists("node")),
     ),
     "rep_out_path": Option(
         ["--rep-out-path"],
@@ -128,7 +128,6 @@ PARAMS = {
     "years": Option(
         ["--years"],
         help="Code list to use for the 'year' dimension.",
-        # TODO make this list dynamic, e.g. using a callback to check against data/year/
-        type=Choice(["A", "B"]),
+        type=Choice(codelists("year")),
     ),
 }


### PR DESCRIPTION
- Extend the set of options that can be added to click CLI commands via `@common_params()`.
- New utility function `message_ix_models.model.structure.codelists()` to return a list of all valid IDs for node/year codelists.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.