### PR TITLE
Add mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ addopts = "--cov=message_ix_models --cov-report="
 [tool.setuptools_scm]
 
 # ToDo: Remove the following as the code style is applied in ixmp, message_ix_models.
-[tool.mypy.overrides]
+[tool.mypy]
+
+[[tool.mypy.overrides]]
 module = [
   "ixmp.model.dantzig",
   "message_ix.models",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,12 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 addopts = "--cov=message_ix_models --cov-report="
 
 [tool.setuptools_scm]
+
+# ToDo: Remove the following as the code style is applied in ixmp, message_ix_models.
+[tool.mypy.overrides]
+module = [
+  "ixmp.model.dantzig",
+  "message_ix.models",
+  "message_ix_models.util.node",
+]
+ignore_errors = true


### PR DESCRIPTION
This PR aims to address the type hint errors shown in the [lint workflow](https://github.com/iiasa/message-ix-models/runs/4691891651?check_suite_focus=true) of PR https://github.com/iiasa/message-ix-models/pull/41. Once https://github.com/iiasa/message-ix-models/issues/38 is addressed, https://github.com/iiasa/ixmp/pull/430 is merged and ixmp is released these changes can possibly be reversed.

## How to review
- Read the diff and note that the CI checks all pass.

## PR checklist

- [ ] Continuous integration checks all ✅