### PR TITLE
Add “message local data” config key

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,11 +20,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2
-      # Uncomment and set equal to the "latest version testable on GitHub
-      # Actions" per pytest.yaml, if different from the default version used by
-      # setup-python.
-      with:
-        python-version: "3.9"
+      # This should match the "Latest version testable on GitHub Actions"
+      # in pytest.yaml
+      # with:
+      #   python-version: "3.10"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
         twine check dist/*
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: __token__
@@ -40,7 +40,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       if: github.event_name == 'release'
       with:
         user: __token__

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,14 +23,16 @@ jobs:
   pytest:
     strategy:
       matrix:
-        os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
-        python-version:
-        # Latest version testable on GitHub Actions. This should match the
-        # version used in the 'pytest' workflows of both ixmp and message_ix.
-        - "3.9"
+        include:
+        # One job per OS; latest python version testable on GitHub actions.
+        # These should match the versions used in the "pytest" workflows of both
+        # ixmp and message_ix.
+        - os: macos-latest
+          python-version: "3.10"
+        - os: ubuntu-latest
+          python-version: "3.10"
+        - os: windows-latest
+          python-version: "3.9"
 
       fail-fast: false
 
@@ -72,14 +74,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Use OpenJDK 14 (macOS only)
-      # Using the default OpenJDK 1.8 on the macos-latest runner produces
-      # "Abort trap: 6" when JPype1 starts the JVM
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: '14'
-
     - name: Cache Python packages and GAMS installer
       uses: actions/cache@v2
       with:
@@ -116,6 +110,6 @@ jobs:
       run: make --directory=message-ix-models/doc html
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2
       with:
-        root_dir: message-ix-models
+        directory: message-ix-models

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -71,13 +71,15 @@ These are listed in order of preference.
   In order of ascending precedence:
 
   1. The default location is the *current working directory*, i.e. whichever directory the :doc:`cli` is invoked in, or in which Python code is run that imports and uses :mod:`message_ix_models`.
-  2. The :mod:`ixmp` configuration setting ``message local data``.
+  2. The :mod:`ixmp` configuration file setting ``message local data``.
   3. The ``MESSAGE_LOCAL_DATA`` environment variable.
   4. The ``--local-data`` CLI option and related options such as ``--cache-path`` or the ``--output`` option to the ``report`` command.
   5. Code that directly modifies the ``local_data`` setting on :class:`.Context`.
 
   - This location **should** be outside the Git-controlled directories for :mod:`message_ix_models` or :mod:`message_data`.
     If not, use :file:`.gitignore` files to hide these from Git.
+
+- Use :meth:`.Context.get_local_path` and :func:`.local_data_path` to construct paths under this directory.
 
 
 General guidelines

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Register “message local data” ixmp configuration file setting and use to set the :attr:`.Context.local_path` when provided.
+  See :ref:`local-data` (:pull:`47`)
 
 2022.1.26
 =========

--- a/message_ix_models/tests/util/test_scenarioinfo.py
+++ b/message_ix_models/tests/util/test_scenarioinfo.py
@@ -160,8 +160,13 @@ class TestSpec:
 
     def test_setitem(self):
         s = Spec()
-        s.add = ScenarioInfo()
 
+        # Setting a valid key via attribute access syntax works
+        s.add = ScenarioInfo()
+        # Setting a valid key via item access syntax works
+        s["add"] = ScenarioInfo()
+
+        # Setting an invalid key raises KeyError
         with pytest.raises(KeyError):
             s["foo"] = ScenarioInfo()
 

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -448,7 +448,7 @@ def merge_data(base, *others):
     """Merge dictionaries of DataFrames together into `base`."""
     for other in others:
         for par, df in other.items():
-            base[par] = base[par].append(df) if par in base else df
+            base[par] = pd.concat([base.get(par, None), df])
 
 
 def same_node(df):

--- a/message_ix_models/util/common.py
+++ b/message_ix_models/util/common.py
@@ -133,11 +133,8 @@ def local_data_path(*parts) -> Path:
     """
     import ixmp
 
-    try:
-        base = Path(ixmp.config.get("message local data"))
-    except KeyError:
-        base = Path.cwd()
-    return _make_path(base, *parts)
+    # The default value, Path.cwd(), is set in context.py
+    return _make_path(Path(ixmp.config.get("message local data")), *parts)
 
 
 def package_data_path(*parts) -> Path:

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -15,6 +15,9 @@ log = logging.getLogger(__name__)
 _CONTEXTS: List["Context"] = []
 
 
+ixmp.config.register("message local data", Path, Path.cwd())
+
+
 class Context(dict):
     """Context and settings for :mod:`message_ix_models` code."""
 
@@ -55,8 +58,7 @@ class Context(dict):
         # Default paths for local data
         default_local_data = Path(
             os.environ.get("MESSAGE_LOCAL_DATA", None)
-            or ixmp.config.values.get("message local data", None)
-            or Path.cwd()
+            or ixmp.config.get("message local data")
         ).resolve()
 
         for key, value in (


### PR DESCRIPTION
Adds support for a setting “message local data” in the ixmp configuration file. This location can be used to read/write data (e.g. reporting output) in a system-local location by message-ix-models or downstream code.

This also addresses CI failures like [this one](https://github.com/iiasa/message-ix-models/runs/5314379290) caused by dependence on unadvertised ixmp behaviour that was cleaned-up in iiasa/ixmp#435.

Also:
- Squash a warning with pandas ≥1.4 in `merge_data()`.
- Update CI workflows.
- Close #45.

## How to review

- Look at the changes to doc/data and doc/whatsnew.
- Note that the CI checks all pass.

Estimated time: < 5 minutes

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.