### PR TITLE
Add requirement pyam-iamc

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     genno >= 1.8.0
     iam_units
     message_ix >= 3.2.0
+    pyam-iamc >= 0.6
     pycountry
     PyYAML
     sdmx1 >= 2.2.0


### PR DESCRIPTION
This PR adds `pyam-iamc >= 0.6` to the requirements. The aim to install minimum this version, is to possible remove the same requirement in _message_data_, which will then be implied by the requirement _message-ix-models_. 
Closes #36. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
<!--
