### PR TITLE
Add utility to adapt data from R11 to R12

### DIFF
--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -18,6 +18,7 @@ Commonly used:
 
 .. autosummary::
 
+   adapt_R11_R12
    adapt_R11_R14
    as_codes
    broadcast

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -138,6 +138,14 @@ Commonly used:
 .. automodule:: message_ix_models.util._logging
    :members:
 
+:mod:`.util.node`
+==================
+
+.. currentmodule:: message_ix_models.util.node
+
+.. automodule:: message_ix_models.util.node
+   :members:
+
 :mod:`.util.scenarioinfo`
 =========================
 

--- a/doc/pkg-data/node.rst
+++ b/doc/pkg-data/node.rst
@@ -8,7 +8,7 @@ The codes in these lists denote **regions** and **countries**.
 When loaded using :func:`.get_codes`, the :attr:`.Code.child` attribute is a list of child codes.
 See the function documentation for how to retrieve these.
 
-.. seealso:: :func:`.adapt_R11_R14`, :func:`.identify_nodes`.
+.. seealso:: :func:`.adapt_R11_R12`, :func:`.adapt_R11_R14`, :func:`.identify_nodes`.
 
 .. contents::
    :local:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Add :func:`adapt_R11_R12`, a function for adapting data from the :ref:`R11` to the :ref:`R12` node lists (:pull:`56`).
 - Work around `iiasa/ixmp#425 <https://github.com/iiasa/ixmp/issues/425>`__ in :func:`.disutility.data_conversion` (:ref:`docs <disutility-units>`, :pull:`55`).
 
 2022.3.3
@@ -47,7 +48,7 @@ Earlier releases
 --------
 
 - Add :func:`identify_nodes`, a function for identifying a :doc:`pkg-data/node` based on a :class:`.Scenario` (:pull:`24`).
-- Add :func:`adapt_R11_R14`, a function for adapting data from the :ref:`R11` to the :ref:`R14` (:pull:`24`).
+- Add :func:`adapt_R11_R14`, a function for adapting data from the :ref:`R11` to the :ref:`R14` node lists (:pull:`24`).
 - Add :func:`.export_test_data` and :command:`mix-models export-test-data` command (:pull:`16`).
   See :ref:`export-test-data`.
 - Allow use of pytest's persistent cache across test sessions (:pull:`23`).

--- a/message_ix_models/tests/util/test_node.py
+++ b/message_ix_models/tests/util/test_node.py
@@ -29,6 +29,9 @@ def test_mapping_adapter():
 
     assert all(columns + ["unit"] == result.columns)
 
+    with pytest.raises(TypeError):
+        a(1.2)
+
 
 PAR = "technical_lifetime"
 VALUE = [0.1, 0.2]

--- a/message_ix_models/tests/util/test_node.py
+++ b/message_ix_models/tests/util/test_node.py
@@ -7,13 +7,18 @@ from message_ix import Scenario, make_df
 
 from message_ix_models.model.bare import create_res
 from message_ix_models.model.structure import get_codes
-from message_ix_models.util import adapt_R11_R14, broadcast, identify_nodes
+from message_ix_models.util import (
+    adapt_R11_R12,
+    adapt_R11_R14,
+    broadcast,
+    identify_nodes,
+)
 
 PAR = "technical_lifetime"
-VALUE = 0.1
+VALUE = [0.1, 0.2]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def input():
     """Fixture: test data for :func:`.adapt_R11_R14`."""
     R11_all = get_codes("node/R11")
@@ -23,34 +28,45 @@ def input():
     ).pipe(broadcast, node_loc=R11_reg)
 
     # Set a specific value for the regions to be broadcast
-    df["value"] = df["value"].where(df["node_loc"] != "R11_FSU", VALUE)
+    df["value"] = df["value"].where(df["node_loc"] != "R11_CPA", VALUE[0])
+    df["value"] = df["value"].where(df["node_loc"] != "R11_FSU", VALUE[1])
 
     return {PAR: df}
 
 
-def test_adapt_R11_R14_0(input):
+@pytest.mark.parametrize(
+    "func,N,expected,target_nodes",
+    [
+        (adapt_R11_R12, 12, VALUE[0], ("R12_CHN", "R12_RCPA")),
+        (adapt_R11_R14, 14, VALUE[1], ("R14_CAS", "R14_RUS", "R14_SCS", "R14_UBM")),
+    ],
+)
+def test_adapt_df(input, func, N, expected, target_nodes):
     """:func:`.adapt_R11_R14` handles :class:`pandas.DataFrame`."""
     # Function runs
-    output = adapt_R11_R14(input)
+    output = func(input)
 
     # Output is a dict containing 1 entry
     df_out = output.pop(PAR)
     assert 0 == len(output)
 
     # Output covers all R14 regions
-    R14_all = get_codes("node/R14")
-    R14_reg = R14_all[R14_all.index("World")].child
-    assert set(R14_reg) == set(df_out["node_loc"])
+    all_nodes = get_codes(f"node/R{N}")
+    regions = all_nodes[all_nodes.index("World")].child
+    assert set(regions) == set(df_out["node_loc"])
 
     # Output has expected length
-    assert 14 * 2 == len(df_out)
+    assert N * 2 == len(df_out)
 
-    # Output values for new regions match input value for R11_FSU
-    target_nodes = ("R14_CAS", "R14_RUS", "R14_SCS", "R14_UBM")
-    assert (VALUE == df_out[df_out["node_loc"].isin(target_nodes)]["value"]).all()
+    # Output values for new regions match input value for the base region
+    assert (expected == df_out[df_out["node_loc"].isin(target_nodes)]["value"]).all()
 
 
-def test_adapt_R11_R14_1(input):
+@pytest.mark.parametrize(
+    "func,expected,node_loc",
+    [(adapt_R11_R12, VALUE[0], "R12_CHN"), (adapt_R11_R14, VALUE[1], "R14_CAS")],
+)
+def test_adapt_qty(input, func, expected, node_loc):
     """:func:`.adapt_R11_R14` handles :class:`genno.Quantity`."""
     # Convert to genno.Quantity
     df = input[PAR]
@@ -58,7 +74,7 @@ def test_adapt_R11_R14_1(input):
     input[PAR].attrs["_unit"] = df["unit"].unique()[0]
 
     # Function runs
-    output = adapt_R11_R14(input)
+    output = func(input)
 
     # Output is a dict containing 1 entry
     qty_out = output.pop(PAR)
@@ -67,9 +83,9 @@ def test_adapt_R11_R14_1(input):
     assert isinstance(qty_out, Quantity)
     assert "year" == qty_out.attrs["_unit"]
 
-    # Output values for new regions match input value for R11_FSU
+    # Output values for new regions match input value for the base region
     assert (
-        VALUE == qty_out.sel(node_loc="R14_CAS", technology="coal_ppl", year=2022)
+        expected == qty_out.sel(node_loc=node_loc, technology="coal_ppl", year=2022)
     ).all()
 
 

--- a/message_ix_models/tests/util/test_node.py
+++ b/message_ix_models/tests/util/test_node.py
@@ -1,6 +1,7 @@
 """Tests of :mod:`message_ix_models.util.node`."""
 import re
 
+import pandas as pd
 import pytest
 from genno import Quantity
 from message_ix import Scenario, make_df
@@ -13,6 +14,21 @@ from message_ix_models.util import (
     broadcast,
     identify_nodes,
 )
+from message_ix_models.util.node import MappingAdapter
+
+
+def test_mapping_adapter():
+    """Generic test of MappingAdapter."""
+    a = MappingAdapter({"foo": [("a", "x"), ("a", "y"), ("b", "z")]})
+
+    columns = ["foo", "bar", "value"]
+
+    df = pd.DataFrame([["a", "m", 1], ["b", "n", 2]], columns=columns)
+
+    result = a(df)
+
+    assert all(columns + ["unit"] == result.columns)
+
 
 PAR = "technical_lifetime"
 VALUE = [0.1, 0.2]

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -68,7 +68,7 @@ def add_par_data(
     for par_name, values in data.items():
         N = values.shape[0]
         log.info(f"{N} rows in {repr(par_name)}")
-        log.debug(values.to_string(max_rows=5))
+        log.debug("\n" + values.to_string(max_rows=5))
 
         total += N
 

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -19,12 +19,13 @@ from .common import (
     package_data_path,
     private_data_path,
 )
-from .node import adapt_R11_R14, identify_nodes
+from .node import adapt_R11_R12, adapt_R11_R14, identify_nodes
 from .scenarioinfo import ScenarioInfo
 
 __all__ = [
     "MESSAGE_DATA_PATH",
     "MESSAGE_MODELS_PATH",
+    "adapt_R11_R12",
     "adapt_R11_R14",
     "as_codes",
     "cached",

--- a/message_ix_models/util/common.py
+++ b/message_ix_models/util/common.py
@@ -1,6 +1,12 @@
 import logging
+from abc import abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, cast
+from typing import Any, Dict, Optional, Sequence, Tuple, cast
+
+import pandas as pd
+from genno.computations import concat
+from message_ix.reporting import Quantity
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +27,100 @@ PACKAGE_DATA: Dict[str, Any] = dict()
 
 #: Data already loaded with :func:`load_private_data`.
 PRIVATE_DATA: Dict[str, Any] = dict()
+
+
+class Adapter:
+    """Adapt `data`.
+
+    Adapter is an abstract base class for tools that adapt data in any way, e.g.
+    between different code lists for certain dimensions. An instance of an Adapter can
+    be called with any of the following as `data`:
+
+    - :class:`genno.Quantity`,
+    - :class:`pandas.DataFrame`, or
+    - :class:`dict` mapping :class:`str` parameter names to values (either of the above
+      types).
+
+    …and will return data of the same type.
+    """
+
+    def __call__(self, data):
+        if isinstance(data, Quantity):
+            return self._adapt(data)
+        elif isinstance(data, pd.DataFrame):
+            # Convert to Quantity
+            qty = Quantity.from_series(
+                data.set_index(
+                    list(filter(lambda c: c not in ("value", "unit"), data.columns))
+                )["value"],
+            )
+
+            # Store units
+            if "unit" in data.columns:
+                units = data["unit"].unique()
+                assert 1 == len(units), f"Non-unique units {units}"
+                unit = units[0]
+            else:
+                unit = ""  # dimensionless
+
+            # Adapt, convert back to pd.DataFrame, return
+            return self._adapt(qty).to_dataframe().assign(unit=unit).reset_index()
+        elif isinstance(data, Mapping):
+            return {par: self(value) for par, value in data.items()}
+        else:
+            raise TypeError(type(data))
+
+    @abstractmethod
+    def _adapt(self, qty: Quantity) -> Quantity:
+        """Adapt data."""
+        pass
+
+
+class MappingAdapter(Adapter):
+    """Adapt data using mappings for 1 or more dimension(s).
+
+    Parameters
+    ----------
+    maps : dict of sequence of (str, str)
+        Keys are names of dimensions. Values are sequences of 2-tuples; each tuple
+        consists of an original label and a target label.
+
+    Examples
+    --------
+    >>> a = MappingAdapter({"foo": [("a", "x"), ("a", "y"), ("b", "z")]})
+    >>> df = pd.DataFrame(
+    ...     [["a", "m", 1], ["b", "n", 2]], columns=["foo", "bar", "value"]
+    ... )
+    >>> a(df)
+      foo  bar  value
+    0   x    m      1
+    1   y    m      1
+    2   z    n      2
+    """
+
+    maps: Mapping
+
+    def __init__(self, maps: Mapping[str, Sequence[Tuple[str, str]]]):
+        self.maps = maps
+
+    def _adapt(self, qty: Quantity) -> Quantity:
+        result = qty
+
+        for dim, labels in self.maps.items():
+            if dim not in qty.dims:  # type: ignore [attr-defined]
+                continue
+            result = concat(
+                *[
+                    qty.sel(
+                        {dim: label[0]}, drop=True
+                    ).expand_dims(  # type: ignore [attr-defined]
+                        {dim: [label[1]]}
+                    )
+                    for label in labels
+                ]
+            )
+
+        return result
 
 
 def _load(

--- a/message_ix_models/util/node.py
+++ b/message_ix_models/util/node.py
@@ -138,21 +138,17 @@ def _df_R12(df: pd.DataFrame) -> pd.DataFrame:
             df[dim]
             .astype(str)
             .str.replace("R11_", "R12_")
-            .replace("R12_CPA", "R12_RCPA")
+            .str.replace("R12_CPA", "R12_RCPA")
         )
 
     # List of data frames to be concatenated
     result = [df.assign(**new_values)]
 
     # True for rows where R12_RCPA appears in any column
-    mask = (result[0][list(new_values.keys())] == "R12_CPA").any(axis=1)
+    mask = (result[0][list(new_values.keys())] == "R12_RCPA").any(axis=1)
 
-    # Copy R11_FSU data
-    result.extend(
-        [
-            result[0][mask].replace("R12_RCPA", "R12_CHN"),
-        ]
-    )
+    # Copy R11_CPA data
+    result.append(result[0][mask].replace("R12_RCPA", "R12_CHN"))
 
     # Concatenate and return
     return pd.concat(result, ignore_index=True)

--- a/message_ix_models/util/node.py
+++ b/message_ix_models/util/node.py
@@ -2,7 +2,7 @@
 import logging
 from collections.abc import Mapping
 from functools import singledispatch
-from typing import Any, Dict, Union
+from typing import Any
 
 import pandas as pd
 from message_ix import Scenario
@@ -32,7 +32,7 @@ def adapt_R11_R14(data: Any):
     The data is adapted by:
 
     - Renaming regions such as R11_NAM to R14_NAM.
-    - Copying the data for R11_FSU to R14_CAS, R14_RUS, R14_SCS, and R14_UBM.
+    - Copying the data for R11_FSU to each of R14_CAS, R14_RUS, R14_SCS, and R14_UBM.
 
     …wherever these appear in a column/dimension named ‘node’, ‘node_*’, or ‘n’.
 
@@ -43,6 +43,7 @@ def adapt_R11_R14(data: Any):
     - :class:`dict` mapping :class:`str` parameter names to values (either of the above
       types).
     """
+    raise TypeError(type(data))
 
 
 # NB here would prefer to annotate `data` as Dict[str, Union[pd.DataFrame, Quantity]]),
@@ -116,6 +117,7 @@ def adapt_R11_R12(data: Any):
 
     …wherever these appear in a column/dimension named ‘node’, ‘node_*’, or ‘n’.
     """
+    raise TypeError(type(data))
 
 
 # TODO this duplicates the analogous function for R11 → R14; remove


### PR DESCRIPTION
By analogy to `adapt_R11_R14()` that was added in #24. This PR also generalizes the code that performs this adaptation into a `MappingAdapter` class that can be reused; so the definition of the function is reduced to:
https://github.com/iiasa/message-ix-models/blob/66f7e816dd268974e07de1d6c0bf154b486c410b/message_ix_models/util/node.py#L58-L62

## How to review

Skim the diff; note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.