### PR TITLE
Integrate R scripts

### DIFF
--- a/message_ix_models/tests/r/module.R
+++ b/message_ix_models/tests/r/module.R
@@ -1,0 +1,21 @@
+# Example of an R 'module'
+#
+# This is a library of functions retrieved through
+# message_ix_models.util.get_r_func()
+
+add <- function(x, y) {
+  return(x + y)
+}
+
+mul <- function(x, y) {
+  return(x * y)
+}
+
+get_df <- function(x = 1.0) {
+  return (
+    data.frame(
+      node_loc = c("AT", "CA"),
+      value = x * c(1.2, 3.4)
+    )
+  )
+}

--- a/message_ix_models/tests/util/test_r.py
+++ b/message_ix_models/tests/util/test_r.py
@@ -1,0 +1,13 @@
+from message_ix_models.util import get_r_func
+
+
+def test_get_func():
+    """R code can be sourced and called."""
+    get_df = get_r_func("tests.r.module:get_df")
+    get_df()
+
+    add = get_r_func("tests.r.module:add")
+    add(1.2, 3.4)
+
+    mul = get_r_func("tests.r.module:mul")
+    mul(1.2, 3.4)

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -20,6 +20,7 @@ from .common import (
     private_data_path,
 )
 from .node import adapt_R11_R14, identify_nodes
+from .r import get_r_func
 from .scenarioinfo import ScenarioInfo
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "cached",
     "check_support",
     "convert_units",
+    "get_r_func",
     "identify_nodes",
     "load_package_data",
     "load_private_data",

--- a/message_ix_models/util/r.py
+++ b/message_ix_models/util/r.py
@@ -1,0 +1,40 @@
+"""Utilities for compatibility with R code."""
+import re
+
+from .common import MESSAGE_DATA_PATH, MESSAGE_MODELS_PATH
+
+_SOURCED = set()
+
+
+def source_module(path):
+    from rpy2.robjects import r
+
+    path_parts = path.split(".")
+    package = (
+        path_parts.pop(0)
+        if re.match("message_(data|ix_models)", path_parts[0])
+        else "message_ix_models"
+    )
+
+    path = (
+        {
+            "message_data": MESSAGE_DATA_PATH,
+            "message_ix_models": MESSAGE_MODELS_PATH,
+        }[package]
+        .joinpath(*path_parts)
+        .with_suffix(".R")
+    )
+
+    if path not in _SOURCED:
+        _SOURCED.add(path)
+        r.source(str(path))
+
+
+def get_r_func(path):
+    from rpy2.robjects import r
+
+    path, name = path.rsplit(":", maxsplit=1)
+
+    source_module(path)
+
+    return r[name]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,11 @@ docs =
     genno[compat]
     sphinx >= 3.4.3
     sphinx_rtd_theme
+r =
+    rpy2
 tests =
     %(docs)s
+    %(r)s
     pytest
     pytest-cov
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-pycountry]
 ignore_missing_imports = True
+[mypy-rpy2.*]
+ignore_missing_imports = True
 [mypy-setuptools]
 ignore_missing_imports = True
 


### PR DESCRIPTION
This PR adds the two methods of invoking R code discussed in #40, and closes that issue.

Some things to be decided:
1. What kinds of conversions (see [rpy2 docs]()) should be provided by default for R code?
2. What environment variables, utility code, etc. do standalone R scripts need to use from message-ix-models & co.?

## How to review

TBA.

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Build the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

- [ ] Add CLI/helper for `Rscript` for invoking R scripts in a standard way.
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.