### PR TITLE
Improve session_context, add .testing.not_ci

### DIFF
--- a/doc/api/testing.rst
+++ b/doc/api/testing.rst
@@ -3,5 +3,31 @@ Test utilities and fixtures (:mod:`.testing`)
 
 .. currentmodule:: message_ix_models.testing
 
+:doc:`Fixtures <pytest:explanation/fixtures>`:
+
+.. autosummary::
+
+   mix_models_cli
+   session_context
+   test_context
+   user_context
+
+:doc:`Marks <pytest:how-to/mark>`:
+
+.. autosummary::
+
+   NIE
+   not_ci
+
+Others:
+
+.. autosummary::
+
+   EXPORT_OMIT
+   CliRunner
+   bare_res
+   export_test_data
+   pytest_addoption
+
 .. automodule:: message_ix_models.testing
    :members:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,8 @@ What's new
 Next release
 ============
 
+- Add :func:`.testing.not_ci` for marking tests not to be run on continuous integration services; improve :func:`~.testing.session_context` (:pull:`62`).
+- :fun:`.apply_spec` also adds elements of the "node" set using :meth:`.ixmp.Platform.add_region` (:pull:`62`).
 - Add new logo the documentation (:pull:`68`).
 - Add :class:`.Workflow`; see :doc:`api/workflow` (:pull:`60`).
 

--- a/message_ix_models/model/build.py
+++ b/message_ix_models/model/build.py
@@ -126,6 +126,11 @@ def apply_spec(
                 set_name,
                 element.id if isinstance(element, Code) else element,
             )
+            if set_name == "node":
+                scenario.platform.add_region(
+                    element.id if isinstance(element, Code) else element,
+                    "region",
+                )
 
         if len(add):
             log.info(f"  Add {len(add)} element(s)")

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -55,9 +55,23 @@ def pytest_sessionstart():
 
 @pytest.fixture(scope="session")
 def session_context(pytestconfig, tmp_env):
-    """A Context connected to a temporary, in-memory database.
+    """A :class:`.Context` connected to a temporary, in-memory database.
 
-    Uses the :func:`.tmp_env` fixture from ixmp.
+    This Context is suitable for modifying and running test code that does not affect
+    the user/developer's filesystem and configured :mod:`ixmp` databases.
+
+    Uses the :func:`.tmp_env` fixture from ixmp. This fixture also sets:
+
+    - :attr:`.Context.cache_path`, depending on whether the :program:`--local-cache` CLI
+      option was given:
+
+      - If not given: pytest's :doc:`standard cache directory <pytest:how-to/cache>`.
+      - If given: the :file:`/cache/` directory under the user's "message local data"
+        directory.
+
+    - the "message local data" config key to a temporary directory :file:`/data/` under
+      the :ref:`pytest tmp_path directory <pytest:tmp_path>`.
+
     """
     ctx = Context.only()
 

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from copy import deepcopy
 from pathlib import Path
 
@@ -362,3 +363,14 @@ def export_test_data(context: Context):
 #: Shorthand for marking a parametrized test case that is expected to fail because it is
 #: not implemented.
 NIE = pytest.mark.xfail(raises=NotImplementedError)
+
+
+def not_ci(reason=None, action="skip"):
+    """Mark a test as xfail or skipif if on CI infrastructure.
+
+    Checks the ``GITHUB_ACTIONS`` environment variable; returns a pytest mark.
+    """
+    action = "skipif" if action == "skip" else action
+    return getattr(pytest.mark, action)(
+        condition="GITHUB_ACTIONS" in os.environ, reason=reason
+    )

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -87,18 +87,15 @@ def session_context(pytestconfig, tmp_env):
         # Create some subdirectories
         util.MESSAGE_DATA_PATH.joinpath("data", "tests").mkdir(parents=True)
 
-    platform_name = "message-ix-models"
-
     # Add a platform connected to an in-memory database
-    # NB cannot call Config.add_platform() here because it does not support supplying a
-    #    URL for a HyperSQL database.
-    # TODO add that feature upstream.
-    ixmp_config.values["platform"][platform_name] = {
-        "class": "jdbc",
-        "driver": "hsqldb",
-        "url": f"jdbc:hsqldb:mem://{platform_name}",
-        "jvmargs": pytestconfig.option.jvmargs,
-    }
+    platform_name = "message-ix-models"
+    ixmp_config.add_platform(
+        platform_name,
+        "jdbc",
+        "hsqldb",
+        url=f"jdbc:hsqldb:mem://{platform_name}",
+        jvmargs=pytestconfig.option.jvmargs,
+    )
 
     # Launch Platform and connect to testdb (reconnect if closed)
     mp = Platform(name=platform_name)

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -76,6 +76,9 @@ def session_context(pytestconfig, tmp_env):
     # Other local data in the temporary directory for this session only
     ctx.local_data = session_tmp_dir
 
+    # Also set the "message local data" key in the ixmp config
+    ixmp_config.set("message local data", session_tmp_dir)
+
     # If message_data is not installed, use a temporary path for private_data_path()
     message_data_path = util.MESSAGE_DATA_PATH
     if util.MESSAGE_DATA_PATH is None:

--- a/message_ix_models/tests/test_testing.py
+++ b/message_ix_models/tests/test_testing.py
@@ -1,7 +1,9 @@
+import os
+
 import click
 import pytest
 
-from message_ix_models.testing import bare_res
+from message_ix_models.testing import bare_res, not_ci
 
 
 def test_bare_res_no_request(test_context):
@@ -21,3 +23,14 @@ def test_bare_res_solved(request, test_context):
 def test_cli_runner(mix_models_cli):
     with pytest.raises(click.exceptions.UsageError, match="No such command 'foo'"):
         mix_models_cli.assert_exit_0(["foo", "bar"])
+
+
+@not_ci(reason="foo", action="skip")
+def test_not_ci_skip():
+    """Test not_ci(action="skip")."""
+
+
+@not_ci(reason="foo", action="xfail")
+def test_not_ci_xfail():
+    """Test not_ci(action="skip")."""
+    assert "GITHUB_ACTIONS" not in os.environ

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -261,10 +261,10 @@ def test_maybe_query():
     assert 2 == len(maybe_query(s, "bar == 'c'"))
 
 
-def test_local_data_path(pytestconfig, tmp_env):
-    assert Path(pytestconfig.invocation_dir).joinpath("foo", "bar") == local_data_path(
-        "foo", "bar"
-    )
+def test_local_data_path(tmp_path_factory, session_context):
+    assert tmp_path_factory.getbasetemp().joinpath(
+        "data0", "foo", "bar"
+    ) == local_data_path("foo", "bar")
 
 
 def test_package_data_path():


### PR DESCRIPTION
This makes slight improvements to the `session_context` test fixture, and adds a test marker to skip/xfail tests on CI. These migrate changes originally made downstream in message_data for testing MESSAGEix-Transport.

## How to review

Read the diff, note CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.