### PR TITLE
Add pyam to mypy's ignore_missing_imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-pint.*]
 ignore_missing_imports = True
+[mypy-pyam.*]
+ignore_missing_imports = True
 [mypy-pycountry]
 ignore_missing_imports = True
 [mypy-setuptools]


### PR DESCRIPTION
This PR aims to fix the failing lint workflow (e.g. [here](https://github.com/iiasa/message-ix-models/runs/6286453794?check_suite_focus=true#step:10:120)) in PR https://github.com/iiasa/message-ix-models/pull/62 and https://github.com/iiasa/message-ix-models/pull/68.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
