### PR TITLE
Run CI against multiple versions of `ixmp` and `message_ix`

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,7 +31,7 @@ jobs:
         - { os: ubuntu-latest, python: "3.10" }
         - { os: windows-latest, python: "3.9" }
         upstream-version:
-        - v3.3.0  # Minimum version given in setup.cfg
+        - v3.4.0  # Minimum version given in setup.cfg
         - v3.5.0  # Latest released version
         - main    # Development version
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -77,6 +77,9 @@ jobs:
       with:
         python-version: ${{ matrix.version.python }}
 
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+
     - name: Locate pip cache directory
       id: pip-cache
       run: echo "::set-output name=dir::$(pip cache dir)"
@@ -93,9 +96,6 @@ jobs:
       with:
         version: 25.1.1
         license: ${{ secrets.GAMS_LICENSE }}
-
-    - name: Upgrade pip, wheel, setuptools-scm
-      run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Install packages and dependencies
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,7 +31,7 @@ jobs:
         - { os: ubuntu-latest, python: "3.10" }
         - { os: windows-latest, python: "3.9" }
         upstream-version:
-        - v3.2.0  # Minimum version given in setup.cfg
+        - v3.3.0  # Minimum version given in setup.cfg
         - v3.5.0  # Latest released version
         - main    # Development version
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,42 +23,45 @@ jobs:
   pytest:
     strategy:
       matrix:
-        include:
         # One job per OS; latest python version testable on GitHub actions.
         # These should match the versions used in the "pytest" workflows of both
         # ixmp and message_ix.
-        - os: macos-latest
-          python-version: "3.10"
-        - os: ubuntu-latest
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "3.9"
+        version:
+        - { os: macos-latest, python: "3.10" }
+        - { os: ubuntu-latest, python: "3.10" }
+        - { os: windows-latest, python: "3.9" }
+        upstream-version:
+        - v3.2.0  # Minimum version given in setup.cfg
+        - v3.5.0  # Latest released version
+        - main    # Development version
 
       fail-fast: false
 
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}-py${{ matrix.python-version }}
+    runs-on: ${{ matrix.version.os }}
+    name: ${{ matrix.version.os }}-py${{ matrix.version.python }}-upstream-${{ matrix.upstream-version }}
 
     steps:
     - name: Cancel previous runs that have not completed
       uses: styfle/cancel-workflow-action@0.9.1
 
     - name: Check out ixmp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: iiasa/ixmp
+        ref: ${{ matrix.upstream-version }}
         path: ixmp
         fetch-depth: ${{ env.depth }}
 
     - name: Check out message-ix
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: iiasa/message_ix
+        ref: ${{ matrix.upstream-version }}
         path: message-ix
         fetch-depth: ${{ env.depth }}
 
     - name: Check out message-ix-models
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: message-ix-models
         fetch-depth: ${{ env.depth }}
@@ -70,20 +73,21 @@ jobs:
         (cd message-ix-models; git fetch --tags --depth=${{ env.depth }})
       shell: bash
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.version.python }}
+
+    - name: Locate pip cache directory
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache Python packages and GAMS installer
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: |
-          ~/.cache/pip
-          ~/Library/Caches/pip
-          ~/appdata/local/pip/cache
-        key: ${{ matrix.os }}-py${{ matrix.python-version }}
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ matrix.version.os }}-py${{ matrix.version.python }}
         restore-keys: |
-          ${{ matrix.os }}-
+          ${{ matrix.version.os }}
 
     - uses: iiasa/actions/setup-gams@main
       with:
@@ -104,12 +108,12 @@ jobs:
       run: pytest message_ix_models -rA --verbose --color=yes --cov-report=xml --cov-report=term-missing
 
     - name: Test documentation build using Sphinx
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      if: startsWith(matrix.os, 'ubuntu')
       env:
         RTD_TOKEN_MESSAGE_DATA: ${{ secrets.RTD_TOKEN_MESSAGE_DATA }}
       run: make --directory=message-ix-models/doc html
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         directory: message-ix-models

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Bump minimum required version of :mod:`message_ix` to v3.3.0 from v3.2.0 (:pull:`71`).
 - Add a documentation page on :doc:`distrib` (:pull:`59`).
 - Add :func:`.testing.not_ci` for marking tests not to be run on continuous integration services; improve :func:`~.testing.session_context` (:pull:`62`).
 - :fun:`.apply_spec` also adds elements of the "node" set using :meth:`.ixmp.Platform.add_region` (:pull:`62`).

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,7 +4,7 @@ What's new
 Next release
 ============
 
-- Bump minimum required version of :mod:`message_ix` to v3.3.0 from v3.2.0 (:pull:`71`).
+- Bump minimum required version of :mod:`message_ix` to v3.4.0 from v3.2.0 (:pull:`71`).
 - Add a documentation page on :doc:`distrib` (:pull:`59`).
 - Add :func:`.testing.not_ci` for marking tests not to be run on continuous integration services; improve :func:`~.testing.session_context` (:pull:`62`).
 - :fun:`.apply_spec` also adds elements of the "node" set using :meth:`.ixmp.Platform.add_region` (:pull:`62`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,29 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools", "setuptools-scm"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=message_ix_models --cov-report="
+# Disable faulthandler plugin on Windows to prevent spurious console noise
+addopts = "-p no:faulthandler --cov=message_ix_models --cov-report="
 filterwarnings = "ignore:distutils Version classes.*:DeprecationWarning"
 
-[tool.setuptools_scm]
+[tool.isort]
+profile = "black"
+
+[[tool.mypy.overrides]]
+module = [
+  "dask.*",
+  "colorama.*",
+  "jpype.*",
+  "matplotlib.*",
+  "message_data.*",
+  "pandas.*",
+  "pint.*",
+  "pyam.*",
+  "pycountry",
+  "setuptools",
+  # For ixmp.testing
+  "nbclient.*",
+  "nbformat.*",
+  "memory_profiler.*",
+]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,19 +11,18 @@ profile = "black"
 
 [[tool.mypy.overrides]]
 module = [
-  "dask.*",
-  "colorama.*",
-  "jpype.*",
+  "dask",
+  "colorama",
+  "jpype",
   "matplotlib.*",
   "message_data.*",
   "pandas.*",
-  "pint.*",
-  "pyam.*",
+  "pyam",
   "pycountry",
   "setuptools",
   # For ixmp.testing
-  "nbclient.*",
-  "nbformat.*",
-  "memory_profiler.*",
+  "nbclient",
+  "nbformat",
+  "memory_profiler",
 ]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     # When the minimum is greater than the minimum in the latest ixmp
     genno >= 1.8.0
     iam_units
-    message_ix >= 3.2.0
+    message_ix >= 3.3.0
     pyam-iamc >= 0.6
     pycountry
     PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,11 @@ zip_safe = True
 install_requires =
     click
     colorama
-    # When the minimum is greater than the minimum in the latest ixmp
+    # When the minimum is greater than the minimum via message_ix; e.g.
+    # message_ix >= 3.4.0 → ixmp >= 3.4.0 → genno >= 1.6.0
     genno >= 1.8.0
     iam_units
-    message_ix >= 3.3.0
+    message_ix >= 3.4.0
     pyam-iamc >= 0.6
     pycountry
     PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,45 +44,5 @@ docs =
 console_scripts =
     mix-models = message_ix_models.cli:main
 
-[tool:pytest]
-# Disable faulthandler plugin on Windows to prevent spurious console noise
-addopts = -p no:faulthandler
-
-[isort]
-profile = black
-
 [flake8]
 max-line-length = 88
-
-[mypy]
-# Empty section required as of mypy 0.800;
-# see https://github.com/python/mypy/issues/9940
-
-[mypy-dask.*]
-ignore_missing_imports = True
-[mypy-colorama.*]
-ignore_missing_imports = True
-[mypy-jpype.*]
-ignore_missing_imports = True
-[mypy-matplotlib.*]
-ignore_missing_imports = True
-[mypy-message_data.*]
-ignore_missing_imports = True
-[mypy-pandas.*]
-ignore_missing_imports = True
-[mypy-pint.*]
-ignore_missing_imports = True
-[mypy-pyam.*]
-ignore_missing_imports = True
-[mypy-pycountry]
-ignore_missing_imports = True
-[mypy-setuptools]
-ignore_missing_imports = True
-
-# For ixmp.testing
-[mypy-nbclient.*]
-ignore_missing_imports = True
-[mypy-nbformat.*]
-ignore_missing_imports = True
-[mypy-memory_profiler.*]
-ignore_missing_imports = True


### PR DESCRIPTION
Test against multiple versions of `ixmp` and `message_ix`. This allows us to confirm which minimum versions are required for `message-ix-models` and in turn `message_data`, as well as notice potentially breaking changes in the lower levels of the stack.

Other changes:
- Bump versions for third party actions.
- Move some tool config from setup.cfg → pyproject.toml.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- [x] Update doc/whatsnew.