### PR TITLE
Upgrade broadcast function for multi-dimension variable expansion

### DIFF
--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -161,14 +161,29 @@ def aggregate_codes(df: pd.DataFrame, dim: str, codes):  # pragma: no cover
         print(key, group_series.replace({dim: mapping}))
 
 
-def broadcast(df, **kwargs):
+def broadcast(df, *args, **kwargs):
     """Fill missing data in `df` by broadcasting.
 
     Arguments
     ---------
+    args
+        tuble/dataframe mapping multiple dimensions to be fill.
     kwargs
         Keys are dimensions. Values are labels along that dimension to fill.
+ 
     """
+    labels = pd.DataFrame(*args)
+    if not labels.empty:
+        for cc in labels.columns:
+            if cc in df.columns:
+                assert df[cc].isna().all(), f"Dimension {dim} was not empty\n\n{df.head()}"
+                df.drop(cc, axis=1,inplace = True)
+                # add dummy common variable between df and labels
+        df['tmp'] = 1
+        labels['tmp'] = 1
+        df = pd.merge(df,labels).drop(columns ={'tmp'})
+    
+    # broadcasting 1-D variables
     for dim, levels in kwargs.items():
         # Checks
         assert df[dim].isna().all(), f"Dimension {dim} was not empty\n\n{df.head()}"


### PR DESCRIPTION
The PR upgrades the `broadcast` function to allow it to work with multiple dimensions correlated in a dataframe

What it was doing before: expand dataframes with an additional dimension
what it does with the update: expand a dataframe with another dataframe with multiple dimensions

example, where the function it is used in combination with the function `pipe()` to pass arguments:

```python
import pandas as pd
from message_ix import make_df
from message_ix_models.util import broadcast

inp0 = make_df(
        "input",
            technology="irrigation_oilcrops",
            value=1,
            unit="-",
            level="water_supply",
            commodity="freshwater",
            mode="M1",
            time="year",
            time_origin="year",
            node_origin=['AFR','NAM'],
    )

# often used to fill one additional variable
inp1 = inp0.pipe(broadcast, year_vtg=[2010,2020])
# it can also be used to add multiple variables distinctly
inp2 = inp0.pipe(broadcast, year_vtg=[2010,2020], 
           year_act=[2010,2020])

# but in this case the variables in inp2 should be mapped
map_v_a = pd.DataFrame({
    'year_vtg' : [2010,2010,2020],
    'year_act' : [2010,2020,2020] }).astype(object)

# this upgrade allows to expand inp0 with the new dataframe map_v_a
inp3 = inp0.pipe(broadcast, map_v_a)
```
I adopted the suggestions from @khaeru in #73 , but I could not get rid of the if block, otherwise I would get error when *args is empty

## How to review

Check if it works, spot cases that might not be covered or that need warning/error messages.
Code improvement/edit suggestions

## PR checklist

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  doc/whatsnew.rst, where '999' is the GitHub pull request number:

  - Title or single-sentence description from above (:pull:`999`:).

  Commit with a message like “Add #999 to doc/whatsnew”
  -->
