### PR TITLE
Adjust for pandas 1.5.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
-      # This should match the "Latest version testable on GitHub Actions"
-      # in pytest.yaml
-      # with:
-      #   python-version: "3.10"
+    - uses: actions/setup-python@v4
+      with:
+        # If the "Latest version testable on GitHub Actions" in pytest.yaml
+        # is not the latest 3.x stable version, adjust here to match:
+        # python-version: "3.x"
+        python-version: "3.10.6"  # Work around python/mypy#13627
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Adjust for pandas 1.5.0 (:pull:`81`).
 
 2022.8.17
 =========

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -2,6 +2,7 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import click.testing
 import message_ix
@@ -311,7 +312,8 @@ def export_test_data(context: Context):
         "tests", f"{scen.model}_{scen.scenario}_{'_'.join(technology)}.xlsx"
     )
     # Temporary file name
-    tmp_file = dest_file.with_name("export_test_data.xlsx")
+    td = TemporaryDirectory()
+    tmp_file = Path(td.name).joinpath("export_test_data.xlsx")
 
     # Ensure the target directory exists
     dest_file.parent.mkdir(exist_ok=True)
@@ -359,9 +361,8 @@ def export_test_data(context: Context):
         # Copy the sheet from temporary to final file
         reader.parse(name).to_excel(writer, sheet_name=name, index=False)
 
-    # Close and remove the temporary file
+    # Close the temporary file
     reader.close()
-    tmp_file.unlink()
 
     # Write the mapping
     ix_type_mapping.reset_index().to_excel(

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -359,17 +359,17 @@ def export_test_data(context: Context):
         # Copy the sheet from temporary to final file
         reader.parse(name).to_excel(writer, sheet_name=name, index=False)
 
+    # Close and remove the temporary file
+    reader.close()
+    tmp_file.unlink()
+
     # Write the mapping
     ix_type_mapping.reset_index().to_excel(
         writer, sheet_name="ix_type_mapping", index=False
     )
 
-    # Save the final file
-    writer.save()
-
-    # Close and remove the temporary file
-    reader.close()
-    tmp_file.unlink()
+    # Close the final file
+    writer.close()
 
     mark_time()
 

--- a/message_ix_models/tests/test_cli.py
+++ b/message_ix_models/tests/test_cli.py
@@ -50,13 +50,9 @@ def test_cli_export_test_data(monkeypatch, session_context, mix_models_cli, tmp_
     # Release the database lock
     mp.close_db()
 
-    try:
-        # Export works
-        result = mix_models_cli.assert_exit_0([f"--url={url}", "export-test-data"])
+    # Export works
+    result = mix_models_cli.assert_exit_0([f"--url={url}", "export-test-data"])
 
-        # The file is created in the expected location
-        assert str(dest_file) in result.output
-        assert dest_file.exists()
-    finally:
-        # Remove this temporary file
-        dest_file.unlink()
+    # The file is created in the expected location
+    assert str(dest_file) in result.output
+    assert dest_file.exists()

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -66,7 +66,7 @@ def test_broadcast(caplog):
     # Results have the expected length: original × cartesian product of 3, 4, and 1
     assert N_a * 3 * 4 * 1 == len(result)
     # Resulting array is completely full, no missing labels
-    assert not result.isna().any().any()
+    assert not result.isna().any(axis=None)
 
     # Length zero labels for one dimension—debug message is logged
     with caplog.at_level(logging.DEBUG, logger="message_ix_models"):
@@ -77,19 +77,19 @@ def test_broadcast(caplog):
     caplog.clear()
     assert N_a * 2 * 2 * 1 == len(result)  # Expected length
     assert result["d"].isna().all()  # Dimension d remains empty
-    assert not result.drop("d", axis=1).isna().any().any()  # Others completely full
+    assert not result.drop("d", axis=1).isna().any(axis=None)  # Others completely full
 
     # Using a DataFrame as the first/only positional argument, plus keyword arguments
     labels = pd.DataFrame(dict(b="b0 b1 b2".split(), c="c0 c1 c2".split()))
 
     result = base.pipe(broadcast, labels, d="d0 d1".split())
     assert N_a * 3 * 2 == len(result)  # (b, c) dimensions linked with 3 pairs of labels
-    assert not result.isna().any().any()  # Completely full
+    assert not result.isna().any(axis=None)  # Completely full
 
     # Using a positional argument with only 1 column
     result = base.pipe(broadcast, labels[["b"]], c="c0 c1 c2 c3".split(), d=["d0"])
     assert N_a * 3 * 4 * 1 == len(result)  # Expected length
-    assert not result.isna().any().any()  # Completely full
+    assert not result.isna().any(axis=None)  # Completely full
 
     # Overlap between columns in the positional argument and keywords
     with pytest.raises(ValueError):
@@ -275,7 +275,7 @@ def test_make_source_tech0():
         # Results have 2 nodes × 3 years
         assert len(df) == 2 * 3
         # No empty values
-        assert not df.isna().any(None)
+        assert not df.isna().any(axis=None)
 
     del values["var_cost"]
     with pytest.raises(ValueError, match=re.escape("needs values for {'var_cost'}")):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ module = [
   "matplotlib.*",
   "message_data.*",
   "pandas.*",
+  "pint._vendor",
   "pyam",
   "pycountry",
   "setuptools",


### PR DESCRIPTION
With [the release of pandas 1.5.0](https://pandas.pydata.org/docs/whatsnew/v1.5.0.html), we observed:

- `message_ix_models/tests/test_cli.py::test_cli_export_test_data` fails, e.g. [here](https://github.com/iiasa/message-ix-models/actions/runs/3087663077/jobs/4994576130#step:13:152).
- Multiple FutureWarnings.

This PR fixes both.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update doc/whatsnew.
