### PR TITLE
Improve Workflow API; handle configuration using dataclasses

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,7 +32,8 @@ jobs:
         - { os: windows-latest, python: "3.9" }
         upstream-version:
         - v3.4.0  # Minimum version given in setup.cfg
-        - v3.5.0  # Latest released version
+        - v3.5.0
+        - v3.6.0  # Latest released version
         - main    # Development version
 
       fail-fast: false

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -118,4 +118,4 @@ jobs:
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v3
       with:
-        directory: message-ix-models
+        root_dir: message-ix-models

--- a/doc/api/model-bare.rst
+++ b/doc/api/model-bare.rst
@@ -12,31 +12,11 @@ In contrast to :mod:`.model.create`, this module creates the RES 'from scratch'.
 :func:`.bare.get_spec` can also be used directly, to get a *description* of the RES based on certain settings/options, but without any need to connect to a database, load an existing Scenario, or call :func:`.bare.create_res`.
 This can be useful in code that processes data into a form compatible with MESSAGEix-GLOBIOM.
 
+Configuration
+=============
 
-Context settings
-================
+The code obeys the settings on the :class:`.model.Config` instance stored at ``context.model``.
 
-.. list-table::
-   :width: 100%
-   :widths: 25 25 50
-   :header-rows: 1
-
-   * - Setting
-     - Type
-     - Description
-   * - regions
-     - str
-     - The 'node' set (regional aggregation) to use; must be "R14" (default), "R11", "RCP" or "ISR".
-   * - years
-     - str
-     - The 'year' set (time periods) to use; must be "B" (default) or "A".
-   * - res_with_dummies
-     - bool
-     - If :obj:`True`, create and include dummy technologies.
-       See :func:`.get_dummy_data`.
-       Default :obj:`False`
-
-See documentation for further context settings in :ref:`context`.
 
 Code reference
 ==============

--- a/doc/api/model.rst
+++ b/doc/api/model.rst
@@ -12,7 +12,19 @@ Models and variants (:mod:`~message_ix_models.model`)
 .. currentmodule:: message_ix_models.model.structure
 
 .. automodule:: message_ix_models.model.structure
-   :members: codelists, process_units_anno
+   :members:
+   :exclude-members: get_codes
+
+   .. autosummary::
+
+      codelists
+      generate_product
+      generate_set_elements
+      get_codes
+      get_region_codes
+      process_units_anno
+      process_commodity_codes
+      process_technology_codes
 
 .. autofunction:: get_codes
 

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -155,6 +155,7 @@ Commonly used:
 
 .. automodule:: message_ix_models.util.node
    :members:
+   :exclude-members: identify_nodes
 
 :mod:`.util.scenarioinfo`
 =========================

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -75,6 +75,13 @@ Commonly used:
    Context is a subclass of :class:`dict`, so common methods like :meth:`~dict.copy` and :meth:`~dict.setdefault` may be used to handle settings.
    To be forgiving, it also provides attribute access; ``context.foo`` is equivalent to ``context["foo"]``.
 
+   A Context instance always has the following members:
+
+   - ``core``: an instance of :class:`message_ix_models.Config`.
+   - ``model``: an instance of :class:`message_ix_models.model.Config`.
+
+   Attributes of these classes may be accessed by shorthand, e.g. ``context.regions`` is shorthand for ``context.model.regions``.
+
    Context provides additional methods to do common tasks that depend on configurable settings:
 
    .. autosummary::
@@ -108,7 +115,7 @@ Commonly used:
          def foo(context, dest):
              scenario, mp = context.clone_to_dest()
 
-      or, store the settings ``dest_scenario`` and ``dest_platform`` on `context`:
+      or, store the settings :attr:`.Config.dest_scenario` and optionally :attr:`.Config.dest_platform` on `context`:
 
       .. code-block:: python
 

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -18,6 +18,11 @@ Commonly used:
 
 .. autosummary::
 
+   ~config.Config
+   ~config.ConfigHelper
+   ~context.Context
+   ~scenarioinfo.ScenarioInfo
+   ~scenarioinfo.Spec
    adapt_R11_R12
    adapt_R11_R14
    as_codes
@@ -41,9 +46,6 @@ Commonly used:
    private_data_path
    same_node
    series_of_pint_quantity
-   ~context.Context
-   ~scenarioinfo.ScenarioInfo
-   ~scenarioinfo.Spec
 
 .. automodule:: message_ix_models.util
    :members:
@@ -58,6 +60,15 @@ Commonly used:
 
 .. automodule:: message_ix_models.util.click
    :members:
+
+:mod:`.util.config`
+===================
+
+.. currentmodule:: message_ix_models.util.config
+
+.. automodule:: message_ix_models.util.config
+   :members:
+   :exclude-members: Config
 
 :mod:`.util.context`
 ====================

--- a/doc/api/workflow.rst
+++ b/doc/api/workflow.rst
@@ -20,22 +20,28 @@ The generic pattern for workflows is:
   These must exist before the target scenario can be created.
 - A workflow ‘step’ includes:
 
-  - The precursor scenario is cloned to the target scenario name.
-  - Modifications are applied.
-    These can be modifications to structure or to data. For example:
+  1. A precursor scenario is obtained.
 
-    - Setting up a model variant, e.g. adding the MESSAGEix-Materials structure to a base MESSAGEix-GLOBIOM model.
-    - Changing policy variables via constraint parameters.
-    - Any other possible modification.
+     It may be returned by a prior workflow step, or loaded from a :class:`Platform`.
+  2. (Optional) The precursor scenario is cloned to a target model name and scenario name.
+  3. A function is called to operate on the scenario.
+     This function may do zero or more of:
 
-  - The target scenario is optionally solved.
-  - The target scenario is optionally reported.
+     - Apply structure or data modifications, for example:
+
+       - Set up a model variant, e.g. adding the MESSAGEix-Materials structure to a base MESSAGEix-GLOBIOM model.
+       - Change policy variables via constraint parameters.
+       - Any other possible modification.
+
+     - Solve the target scenario.
+     - Invoke reporting.
+  4. The resulting function is passed to the next workflow step.
 
 - A workflow can consist of any number of scenarios and steps.
 - The same precursor scenario can be used as the basis for multiple target scenarios.
-- A workflow is ‘run’ starting with the earliest precursor scenario, ending with 1-to-many target scenarios.
+- A workflow is :meth:`.Workflow.run` starting with the earliest precursor scenario, ending with 1 or many target scenarios.
 
-The implementation is based on the observation that these form a graph (DAG) of nodes (scenarios) and edges (steps), in the same way that :mod:`message_ix.reporting` calculations do; and so the :mod:`dask` DAG features (via :mod:`genno`) can be used to organize the workflow.
+The implementation is based on the observation that these form a graph (specifically, a directed, acyclic graph, or DAG) of nodes (= scenarios) and edges (= steps), in the same way that :mod:`message_ix.reporting` calculations do; and so the :mod:`dask` DAG features (via :mod:`genno`) can be used to organize the workflow.
 
 Usage
 =====
@@ -43,22 +49,31 @@ Usage
 General
 -------
 
-Define a workflow using ordinary Python functions, each handling the modifications/manipulations in a single, atomic workflow step.
-These functions they **must**:
+Define a workflow using ordinary Python functions, each handling the modifications/manipulations in an atomic workflow step.
+These functions **must**:
 
-- Accept 1 argument: either the precursor scenario, or :obj:`None`.
+- Accept at least 2 arguments:
+
+  1. A :class:`Context` instance.
+  2. The precursor scenario.
+  3. Optionally additional, keyword-only arguments.
+
 - Return either:
 
-  - a :class:`.Scenario` object: required if the argument is :obj:`None`.
-  - :class:`None`. In this case, the modifications are reflected in the :class:`.Scenario` given as an argument.
+  - a :class:`.Scenario` object, that can be the same object provided as an argument, or a different scenario, e.g. a clone or a different scenario, even from a different platform.
+  - :class:`None`.
+    In this case, any modifications implemented by the step should be reflected in the :class:`.Scenario` given as an argument.
 
-The functions **may** call any other code, and can be from one to many lines; they **should** be reusable, i.e. respond in simple and obvious ways to a few clearly-defined arguments.
+The functions **may**:
+
+- call any other code, and
+- be as short (one line) or long (many lines) as desired;
+
+and they **should**:
+
+- respond in documented, simple ways to settings on the Context argument and/or their keyword argument(s), if any.
 
 .. code-block:: python
-
-    def base_scenario(arg=None) -> Scenario:
-        """Generate a base scenario."""
-        return testing.bare_res(request, test_context, solved=False)
 
     def changes_a(s: Scenario) -> None:
         """Change a scenario by modifying structure data, but not data."""
@@ -90,7 +105,7 @@ The functions **may** call any other code, and can be from one to many lines; th
         # Here, invoke other code to further modify `s`
 
 With the steps defined, the workflow is composed using a :class:`.Workflow` instance.
-Call :meth:`.Workflow.add` to define each target model with its precursor and the function that will create the former from the latter:
+Call :meth:`.Workflow.add_step` to define each target model with its precursor and the function that will create the former from the latter:
 
 .. code-block:: python
 
@@ -100,29 +115,35 @@ Call :meth:`.Workflow.add` to define each target model with its precursor and th
     ctx = Context.get_instance()
     wf = Workflow(ctx)
 
-    # "Model/base" is created from nothing by calling base_scenario()
-    wf.add("Model/base", None, base_scenario)
+    # "Model name/base" is loaded from an existing platform
+    wf.add_step(
+        "base",
+        None,
+        target="ixmp://example-platform/Model name/base#123",
+    )
 
     # "Model/A" is created from "Model/base" by calling changes_a()
-    wf.add("Model/A", "Model/base", changes_a)
+    wf.add_step("A", "base", changes_a, target="Model/A")
 
     # "Model/B1" is created from "Model/A" by calling changes_b() with the
     # default value
-    wf.add("Model/B1", "Model/A", changes_b)
+    wf.add_step("B1", "A", changes_b, target="Model/B1")
 
     # "Model/B2" is similar, but uses a different value
-    wf.add("Model/B2", "Model/A", partial(changes_b, value=200.0))
+    wf.add_step("B2", "A", partial(changes_b, value=200.0), target="model/B2")
 
-Finally, the workflow is triggered using :meth:`.Workflow.run`, giving either one scenario identifier or a list of identifiers.
-The indicated scenarios are created and solved; if this requires any precursor scenarios, those are first created and solved, etc. as required.
+Finally, the workflow is triggered using :meth:`.Workflow.run`, giving either one step name or a list of names.
+The indicated scenarios are created (and solved, if the workflow steps involve solving); if this requires any precursor scenarios, those are first created and solved, etc. as required.
 Other, unrelated scenarios/steps are not created.
 
 .. code-block:: python
 
-    s1, s2 = wf.run(["Model/B1", "Model/B2"])
+    s1, s2 = wf.run(["B1", "B2"])
 
-Common use cases
-----------------
+Usage examples
+--------------
+
+- :mod:`message_data.projects.navigate.workflow`
 
 .. todo::
 

--- a/doc/api/workflow.rst
+++ b/doc/api/workflow.rst
@@ -11,7 +11,7 @@ Concept & design
 Research with MESSAGEix models often involves multiple scenarios that are related to one another or derived from one another by certain modifications.
 Together, the solutions/reported information from these scenarios provide the output data used in research products, e.g. a plot comparing total emissions in a policy scenario to a reference scenario.
 
-:mod:`.model.build` provides tools to build models or scenarios based on (possibly empty) base scenarios; and :mod:`.tools` provides tools for manipulating scenarios or model input data (parameters).
+:mod:`.model.build` provides tools to build models or scenarios based on (possibly empty) base scenarios; and :mod:`~message_ix_models.tools` provides tools for manipulating scenarios or model input data (parameters).
 The :class:`.Workflow` API provided in this module allows researchers to use these pieces and atomic, reusable functions to define arbitrarily complex workflows involving many, related scenarios; and then to solve, report, or otherwise operate on those scenarios.
 
 The generic pattern for workflows is:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,8 +77,8 @@ autosummary_generate = True
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
 
 extlinks = {
-    "issue": ("https://github.com/iiasa/message-ix-models/issue/%s", "GH #"),
-    "pull": ("https://github.com/iiasa/message-ix-models/pull/%s", "PR #"),
+    "issue": ("https://github.com/iiasa/message-ix-models/issue/%s", "GH #%s"),
+    "pull": ("https://github.com/iiasa/message-ix-models/pull/%s", "PR #%s"),
 }
 
 

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -202,7 +202,7 @@ Other patterns
 
 Some other patterns exist, but should not be repeated in new code, and should be migrated to one of the above patterns.
 
-- SQL queries against a Oracle/JDBC database. See :ref:`data-iea`, below, and `issue #53 <https://github.com/iiasa/message_data/issues/53#issuecomment-669117393>`_ for a description of how to replace/simplify this code.
+- SQL queries against a Oracle/JDBC database. See :ref:`message_data:data-iea` (in :mod:`message_data`) and `issue #53 <https://github.com/iiasa/message_data/issues/53#issuecomment-669117393>`_ for a description of how to replace/simplify this code.
 
 
 Configuration

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -247,35 +247,16 @@ The settings are populated based on the command-line parameters given to ``mix-m
 Top-level settings
 ------------------
 
-See model- and project-specific documentation for further context settings, e.g. :mod:`.model.bare`.
+These are defined by :class:`message_ix_models.Config`.
 
-.. list-table::
-   :width: 100%
-   :widths: 25 25 50
-   :header-rows: 1
+Specific modules for model variants, projects, etc. **should**:
 
-   * - Setting
-     - Type
-     - Description
-   * - cache_path
-     - Path
-     - Base path cache, e.g. as given by the ``--cache-path`` CLI option.
-       Default :file:`{local_data}/cache/`.
-   * - dry_run
-     - bool
-     - Whether an operation should be carried out, or only previewed.
-   * - local_data
-     - Path
-     - Base path for system-specific (3) data, e.g. as given by the ``--local-data`` CLI option.
-   * - platform_info
-     - dict
-     - Dictionary with keyword arguments for the :class:`ixmp.Platform` constructor, from the ``--platform`` or ``--url`` CLI options.
-   * - scenario_info
-     - dict
-     - Dictionary with keys 'model' and 'scenario' as given by the ``--model``/``--scenario`` or ``--url`` CLI options.
-   * - url
-     - dict
-     - A scenario URL, e.g. as given by the ``--url`` CLI option.
-   * - units
-     - pint.UnitRegistry
-     - **Deprecated.** Use ``from iam_units import registry``.
+- Define a single :mod:`dataclass <dataclasses>` to express the configuration options they understand.
+  See for example :class:`.model.Config` (for constructing new models), and :class:`message_data.model.buildings.Config` (for the MESSAGEix-Buildings model variant / linkage).
+- Store this on the :class:`Context` at a simple key.
+  For example :class:`.model.Config` is stored at ``context.model`` or ``context["model"]``.
+- Retrieve and respect configuration from existing objects, i.e. only duplicate settings with the same meaning when strictly necessary.
+- Communicate to other modules by setting the appropriate configuration values.
+
+.. autoclass:: message_ix_models.Config
+   :members:

--- a/doc/repro.rst
+++ b/doc/repro.rst
@@ -47,7 +47,7 @@ Data are stored in a location described by the :class:`.Context` setting ``cache
 The test suite interacts with caches in two ways:
 
 - ``--local-cache``: Giving this option causes pytest to use whatever cache directory is configured for normal runs/usage of :mod:`message_ix_models` or :command:`mix-models`.
-- By default (without ``--local-cache``), the test suite uses :doc:`pytest's built-in cache fixture <pytest:cache>`.
+- By default (without ``--local-cache``), the test suite uses :ref:`pytest's built-in cache fixture <pytest:cache>`.
   This creates and uses a temporary directory, usually :file:`.pytest_cache/d/cache/` within the repository root.
   This location is used *only* by tests, and not by normal runs/usage of the code.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,10 @@ What's new
 Next release
 ============
 
+- New :class:`~message_ix_models.Config` and :class:`.model.Config` :py:mod:`dataclasses` for clearer description/handling of recognized settings stored on :class:`.Context` (:pull:`82`).
+  :class:`.ConfigHelper` for convenience/utility functionality in :mod:`message_ix_models`-based code.
+- New functions :func:`.generate_product`, :func:`.generate_set_elements`, :func:`.get_region_codes` in :mod:`.model.structure` (:pull:`82`).
+- Revise and improve the :doc:`Workflow API </api/workflow>` (:pull:`82`).
 - Adjust for pandas 1.5.0 (:pull:`81`).
 
 2022.8.17

--- a/message_ix_models/__init__.py
+++ b/message_ix_models/__init__.py
@@ -5,13 +5,14 @@ from iam_units import registry
 from pkg_resources import DistributionNotFound, get_distribution
 
 from message_ix_models.util._logging import setup as setup_logging
+from message_ix_models.util.config import Config
 from message_ix_models.util.context import Context
 from message_ix_models.util.importlib import MessageDataFinder
 from message_ix_models.util.scenarioinfo import ScenarioInfo, Spec
 from message_ix_models.workflow import Workflow
 
 # Expose utility classes
-__all__ = ["Context", "ScenarioInfo", "Spec", "Workflow"]
+__all__ = ["Config", "Context", "ScenarioInfo", "Spec", "Workflow"]
 
 try:
     # Version string for reference in other code

--- a/message_ix_models/data/commodity.yaml
+++ b/message_ix_models/data/commodity.yaml
@@ -26,7 +26,6 @@ freshwater_supply:
   name: (?) Fresh water
   description: >-
     FIXME provide an unambiguous description of what this commodity represents.
-  units: foo bar
 
 fueloil:
   name: Fuel oil

--- a/message_ix_models/data/technology.yaml
+++ b/message_ix_models/data/technology.yaml
@@ -2494,7 +2494,7 @@ co2_tr_dis:
   sector: other conversion
   output: [exports, secondary]
 
-back_RC:
+back_rc:
   name: back_RC
   description: Backstop for diagnosing model infeasibility
   type: useful
@@ -2550,7 +2550,7 @@ foil_rc:
 
 h2_rc:
   name: h2_rc
-  description: Hydrogen (gaseous) catalytic heating in
+  description: Hydrogen (gaseous) catalytic heating in the residential/commercial sector
   type: secondary
   sector: residential/commercial
   input: [hydrogen, final]

--- a/message_ix_models/model/__init__.py
+++ b/message_ix_models/model/__init__.py
@@ -1,0 +1,4 @@
+"""Code for constructing models/scenarios in the MESSAGEix-GLOBIOM model family."""
+from .config import Config
+
+__all__ = ["Config"]

--- a/message_ix_models/model/config.py
+++ b/message_ix_models/model/config.py
@@ -6,7 +6,7 @@ from message_ix_models.util.context import _ALIAS
 
 @dataclass
 class Config:
-    """Settings and valid values."""
+    """Settings and valid values for :mod:`message_ix_models.model` and submodules."""
 
     #: The 'node' codelist (regional aggregation) to use. Must be one of the lists of
     #: nodes described at :doc:`/pkg-data/node`.

--- a/message_ix_models/model/config.py
+++ b/message_ix_models/model/config.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, fields
+
+from message_ix_models.model.structure import codelists
+from message_ix_models.util.context import _ALIAS
+
+
+@dataclass
+class Config:
+    """Settings and valid values."""
+
+    #: The 'node' codelist (regional aggregation) to use. Must be one of the lists of
+    #: nodes described at :doc:`/pkg-data/node`.
+    regions: str = "R14"
+
+    #: The 'year' codelist (time periods) to use, Must be one of the lists of periods
+    #: described at :doc:`/pkg-data/year`.
+    years: str = "B"
+
+    #: Create the reference energy system with dummy commodities and technologies. See
+    #: :func:`.bare.get_spec`.
+    res_with_dummies: bool = False
+
+    def check(self):
+        """Check the validity of :attr:`regions` and :attr:`years`."""
+        if self.regions not in codelists("node"):
+            raise ValueError(f"regions={self.regions!r} not among {codelists('node')}")
+        if self.years not in codelists("year"):
+            raise ValueError(f"regions={self.years!r} not among {codelists('year')}")
+
+
+# Extend the list of settings that can be set directly on a Context instance.
+_ALIAS.update({f.name: "model" for f in fields(Config)})

--- a/message_ix_models/model/data.py
+++ b/message_ix_models/model/data.py
@@ -5,7 +5,7 @@ log = logging.getLogger(__name__)
 
 def get_data(scenario, context, spec, **options):
     """Data for the bare RES."""
-    if context.res_with_dummies:
+    if context.model.res_with_dummies:
         log.warning("get_dummy_data() not migrated")
         # return get_dummy_data(scenario, spec)
     else:

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -1,15 +1,17 @@
 import logging
 from collections import ChainMap
 from functools import lru_cache
-from typing import List
+from itertools import product
+from typing import Dict, List, Mapping, MutableMapping, Tuple
 
 import click
 import pandas as pd
 import pycountry
+import xarray as xr
 from iam_units import registry
 from sdmx.model import Annotation, Code
 
-from message_ix_models.util import load_package_data, package_data_path
+from message_ix_models.util import eval_anno, load_package_data, package_data_path
 from message_ix_models.util.sdmx import as_codes
 
 log = logging.getLogger(__name__)
@@ -86,6 +88,110 @@ def get_codes(name: str) -> List[Code]:
         process_technology_codes(data)
 
     return data
+
+
+@lru_cache()
+def get_region_codes(codelist: str) -> List[Code]:
+    """Return the codes that are children of "World" in the specified `codelist`."""
+    nodes = get_codes(f"node/{codelist}")
+    return nodes[nodes.index(Code(id="World"))].child
+
+
+def generate_product(
+    data: Mapping, name: str, template: Code
+) -> Tuple[List[Code], Dict[str, xr.DataArray]]:
+    """Generates codes using a `template` by Cartesian product along ≥1 dimensions.
+
+    :func:`generate_set_elements` is called for each of the `dims`, and these values
+    are used to format `base`.
+
+    Parameters
+    ----------
+    data
+        Mapping from dimension IDs to lists of codes.
+    name : str
+        Name of the set.
+    template : .Code
+        Must have Python format strings for its its :attr:`id` and :attr:`name`
+        attributes.
+    """
+    # eval() and remove the original annotation
+    dims = eval_anno(template, "_generate")
+    template.pop_annotation(id="_generate")
+
+    def _base(dim, match):
+        """Return codes along dimension `dim`; if `match` is given, only children."""
+        dim_codes = data[dim]["add"]
+        return dim_codes[dim_codes.index(match)].child if match else dim_codes
+
+    codes = []  # Accumulate codes and indices
+    indices = []
+
+    # Iterate over the product of filtered codes for each dimension in
+    for item in product(*[_base(*dm) for dm in dims.items()]):
+        result = template.copy()  # Duplicate the template
+
+        fmt = dict(zip(dims.keys(), item))  # Format the ID and name
+        result.id = result.id.format(**fmt)
+        result.name = str(result.name).format(**fmt)  # type: ignore [assignment]
+
+        codes.append(result)  # Store code and indices
+        indices.append(item)
+
+    # - Convert length-N sequence of D-tuples to D iterables each of length N.
+    # - Convert to D × 1-dimensional xr.DataArrays, each of length N.
+    tmp = zip(*indices)
+    indexers = {d: xr.DataArray(list(i), dims=name) for d, i in zip(dims.keys(), tmp)}
+    # Corresponding indexer with the full code IDs
+    indexers[name] = xr.DataArray([c.id for c in codes], dims=name)
+
+    return codes, indexers
+
+
+def generate_set_elements(data: MutableMapping, name) -> None:
+    """Generate elements for set `name`.
+
+    This function converts lists of codes in `data`, calling :func:`generate_product`
+    and :func:`process_units_anno` as appropriate.
+
+    Parameters
+    ----------
+    data
+        Mapping from dimension IDs to lists of codes.
+    name : str
+        Name of the set for which to generate elements e.g. "commodity" or "technology".
+    """
+    hierarchical = name in {"technology"}
+
+    codes = []  # Accumulate codes
+    deferred = []
+    for code in as_codes(data[name].get("add", [])):
+        if name in {"commodity", "technology"}:
+            process_units_anno(name, code, quiet=True)
+
+        if eval_anno(code, "_generate"):
+            # Requires a call to generate_product(); do these last
+            deferred.append(code)
+            continue
+
+        codes.append(code)
+
+        if hierarchical:
+            # Store the children of `code`
+            codes.extend(filter(lambda c: c not in codes, code.child))
+
+    # Store codes processed so far, in case used recursively by generate_product()
+    data[name]["add"] = codes
+
+    # Use generate_product() to generate codes and indexers based on other sets
+    for code in deferred:
+        generated, indexers = generate_product(data, name, code)
+
+        # Store
+        data[name]["add"].extend(generated)
+
+        # NB if there are >=2 generated groups, only indexers for the last are kept
+        data[name]["indexers"] = indexers
 
 
 def process_units_anno(set_name: str, code: Code, quiet: bool = False) -> None:

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -9,11 +9,13 @@ import pycountry
 from iam_units import registry
 from sdmx.model import Annotation, Code
 
-from message_ix_models.util import as_codes, load_package_data, package_data_path
+from message_ix_models.util import load_package_data, package_data_path
+from message_ix_models.util.sdmx import as_codes
 
 log = logging.getLogger(__name__)
 
 
+@lru_cache()
 def codelists(kind: str) -> List[str]:
     """Return a valid IDs for code lists of `kind`.
 

--- a/message_ix_models/testing.py
+++ b/message_ix_models/testing.py
@@ -232,8 +232,6 @@ def bare_res(request, context: Context, solved: bool = False) -> message_ix.Scen
     """
     from message_ix_models.model import bare
 
-    context.use_defaults(bare.SETTINGS)
-
     name = bare.name(context)
     mp = context.get_platform()
 
@@ -241,7 +239,7 @@ def bare_res(request, context: Context, solved: bool = False) -> message_ix.Scen
         base = message_ix.Scenario(mp, name, "baseline")
     except ValueError:
         log.info(f"Create '{name}/baseline' for testing")
-        context.scenario_info.update(dict(model=name, scenario="baseline"))
+        context.scenario_info.update(model=name, scenario="baseline")
         base = bare.create_res(context)
 
     if solved and not base.has_solution():

--- a/message_ix_models/tests/model/test_bare.py
+++ b/message_ix_models/tests/model/test_bare.py
@@ -2,6 +2,7 @@ import message_ix
 import pytest
 
 from message_ix_models import testing
+from message_ix_models.model.bare import Config
 
 #: Number of items in the respective YAML files.
 SET_SIZE = dict(
@@ -40,7 +41,7 @@ SET_SIZE = dict(
 )
 def test_create_res(request, test_context, settings, expected):
     # Apply settings to the temporary context
-    test_context.update(settings)
+    test_context.model = Config(**settings)
 
     # Call bare.create_res() via testing.bare_res(). This ensures the slow step of
     # creating the scenario occurs only once per test session. If it fails, it will
@@ -55,4 +56,13 @@ def test_create_res(request, test_context, settings, expected):
     sets = SET_SIZE.copy()
     sets.update(expected)
     for name, size in sets.items():
-        assert size == len(scenario.set(name))
+        values = scenario.set(name)
+        assert size == len(values), (name, values)
+
+
+class TestConfig:
+    def test_init(self):
+        c = Config()
+        c.regions = "R999"
+
+        # TODO expand

--- a/message_ix_models/tests/model/test_config.py
+++ b/message_ix_models/tests/model/test_config.py
@@ -1,0 +1,27 @@
+import pytest
+
+from message_ix_models.model import Config
+
+
+class TestConfig:
+    @pytest.mark.parametrize(
+        "values",
+        [
+            dict(regions="R11", years="A"),
+            pytest.param(
+                dict(regions="R99", years="A"),
+                marks=pytest.mark.xfail(
+                    raises=ValueError, reason="regions='R99' not among […]"
+                ),
+            ),
+            pytest.param(
+                dict(regions="R11", years="C"),
+                marks=pytest.mark.xfail(
+                    raises=ValueError, reason="regions='C' not among ['A', 'B']"
+                ),
+            ),
+        ],
+    )
+    def test_check(self, values):
+        c = Config(**values)
+        c.check()

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -124,8 +124,8 @@ def test_check_support(test_context):
     args = [test_context, dict(regions=["R11", "R14"]), "Test data available"]
 
     # Setting not set → KeyError
-    with pytest.raises(KeyError, match="regions"):
-        check_support(*args)
+    with pytest.raises(KeyError, match="baz"):
+        check_support(test_context, dict(baz=["baz"]), "Baz is not set")
 
     # Accepted value
     test_context.regions = "R11"

--- a/message_ix_models/tests/test_workflow.py
+++ b/message_ix_models/tests/test_workflow.py
@@ -32,6 +32,15 @@ def changes_b(c, s, value=None):
 
 
 class TestWorkflowStep:
+    def test_call(self, test_context):
+        def action(c, s):
+            pass  # pragma: no cover
+
+        ws = WorkflowStep(action=action)
+
+        with pytest.raises(RuntimeError):
+            ws(test_context, None)
+
     def test_repr(self):
         assert "<Step load>" == repr(WorkflowStep(None))
 

--- a/message_ix_models/tests/test_workflow.py
+++ b/message_ix_models/tests/test_workflow.py
@@ -36,23 +36,31 @@ class TestWorkflowStep:
 
 def test_workflow(caplog, request, test_context):
     base_scenario = testing.bare_res(request, test_context, solved=False)
+    base_url = base_scenario.url
+    base_platform = base_scenario.platform.name
+    del base_scenario
+
     caplog.clear()
 
     # Create the workflow
     wf = Workflow(test_context)
 
     # Model/base is created from nothing by calling base_scenario
-    wf.add_step("Model/base", None, target=base_scenario.url)
+    wf.add_step("Model/base", None, target=base_url)
     # Model/A is created from Model/base by calling changes_a
     wf.add_step("Model/A", "Model/base", changes_a)
     # Model/B is created from Model/A by calling changes_b
     wf.add_step("Model/B", "Model/A", changes_b, value=100.0)
 
-    wf.add_step("B solved", "Model/B", solve)
+    # "B solved" is created from "Model/B" by clone and running solve()
+    # clone=True without target= raises an exception
+    with pytest.raises(TypeError, match="target= must be supplied"):
+        wf.add_step("B solved", "Model/B", solve, clone=True)
+
+    wf.add_step("B solved", "Model/B", solve, clone=True, target="foo/bar")
 
     # Trigger the creation and solve of Model/B and all required precursor scenarios
     s = wf.run("B solved")
-    print(s)
 
     # Scenario contains changes from the first and second step
     assert "test_tech" in set(s.set("technology"))
@@ -60,6 +68,7 @@ def test_workflow(caplog, request, test_context):
     # Scenario was solved
     assert s.has_solution()
 
+    # Log messages reflect workflow steps executed
     mp = "message-ix-models"
     m = "MESSAGEix-GLOBIOM R14 YB"
     messages = [
@@ -73,7 +82,8 @@ def test_workflow(caplog, request, test_context):
         "Execute <function changes_b at [^>]*>",
         f"…nothing returned, continue with {m}/test_workflow#1",
         f"Step runs on ixmp://{mp}/{m}/test_workflow#1",
-        "  with context.dest_scenario={}",
+        "  with context.dest_scenario={'model': 'foo', 'scenario': 'bar'}",
+        "Clone to foo/bar",
         "Execute <function solve at [^>]*>",
     ]
     for expr, message in zip(messages, caplog.messages[1:]):
@@ -82,3 +92,9 @@ def test_workflow(caplog, request, test_context):
     # Now truncate the workflow at "Model/A"
     with pytest.raises(RuntimeError, match="Unable to locate platform info for"):
         wf.truncate("Model/A")
+
+    # Add a full URL including platform info
+    wf.add_step("Model/base", None, target=f"ixmp://{base_platform}/{base_url}")
+    wf.truncate("Model/A")
+
+    assert "Foo" == wf.describe("Model/A")

--- a/message_ix_models/tests/test_workflow.py
+++ b/message_ix_models/tests/test_workflow.py
@@ -1,15 +1,19 @@
+import re
+
+import pytest
 from message_ix import make_df
 
 from message_ix_models import Workflow, testing
+from message_ix_models.workflow import WorkflowStep, solve
 
 
-def changes_a(s):
+def changes_a(c, s):
     """Change a scenario by modifying structure data, but not data."""
     with s.transact():
         s.add_set("technology", "test_tech")
 
 
-def changes_b(s):
+def changes_b(c, s, value=None):
     """Change a scenario by modifying parameter data, but not structure."""
     with s.transact():
         s.add_par(
@@ -19,29 +23,36 @@ def changes_b(s):
                 node_loc=s.set("node")[0],
                 year_vtg=s.set("year")[0],
                 technology="test_tech",
-                value=100.0,
+                value=value,
                 unit="y",
             ),
         )
 
 
-def test_workflow(request, test_context):
-    def base_scenario(arg):
-        """Generate a base scenario."""
-        return testing.bare_res(request, test_context, solved=False)
+class TestWorkflowStep:
+    def test_repr(self):
+        assert "<Step load>" == repr(WorkflowStep(None))
+
+
+def test_workflow(caplog, request, test_context):
+    base_scenario = testing.bare_res(request, test_context, solved=False)
+    caplog.clear()
 
     # Create the workflow
     wf = Workflow(test_context)
 
     # Model/base is created from nothing by calling base_scenario
-    wf.add("Model/base", None, base_scenario)
+    wf.add_step("Model/base", None, target=base_scenario.url)
     # Model/A is created from Model/base by calling changes_a
-    wf.add("Model/A", "Model/base", changes_a)
+    wf.add_step("Model/A", "Model/base", changes_a)
     # Model/B is created from Model/A by calling changes_b
-    wf.add("Model/B", "Model/A", changes_b)
+    wf.add_step("Model/B", "Model/A", changes_b, value=100.0)
+
+    wf.add_step("B solved", "Model/B", solve)
 
     # Trigger the creation and solve of Model/B and all required precursor scenarios
-    s = wf.run("Model/B")
+    s = wf.run("B solved")
+    print(s)
 
     # Scenario contains changes from the first and second step
     assert "test_tech" in set(s.set("technology"))
@@ -49,14 +60,25 @@ def test_workflow(request, test_context):
     # Scenario was solved
     assert s.has_solution()
 
-    # Same test, except with solve=False
-    wf = Workflow(test_context, solve=False)
-    wf.add("Model/base", None, base_scenario)
-    wf.add("Model/A", "Model/base", changes_a)
-    wf.add("Model/B", "Model/A", changes_b)
-    s = wf.run("Model/B")
+    mp = "message-ix-models"
+    m = "MESSAGEix-GLOBIOM R14 YB"
+    messages = [
+        f"Loaded ixmp://{mp}/{m}/test_workflow#1",
+        f"Step runs on ixmp://{mp}/{m}/test_workflow#1",
+        "  with context.dest_scenario={}",
+        "Execute <function changes_a at [^>]*>",
+        f"…nothing returned, continue with {m}/test_workflow#1",
+        f"Step runs on ixmp://{mp}/{m}/test_workflow#1",
+        "  with context.dest_scenario={}",
+        "Execute <function changes_b at [^>]*>",
+        f"…nothing returned, continue with {m}/test_workflow#1",
+        f"Step runs on ixmp://{mp}/{m}/test_workflow#1",
+        "  with context.dest_scenario={}",
+        "Execute <function solve at [^>]*>",
+    ]
+    for expr, message in zip(messages, caplog.messages[1:]):
+        assert re.match(expr, message)
 
-    # Same assertions, except scenario was NOT solved
-    assert "test_tech" in set(s.set("technology"))
-    assert 1 == len(s.par("technical_lifetime"))
-    assert not s.has_solution()
+    # Now truncate the workflow at "Model/A"
+    with pytest.raises(RuntimeError, match="Unable to locate platform info for"):
+        wf.truncate("Model/A")

--- a/message_ix_models/tests/test_workflow.py
+++ b/message_ix_models/tests/test_workflow.py
@@ -1,5 +1,6 @@
 import re
 
+import ixmp
 import pytest
 from genno import KeyExistsError
 from message_ix import make_df
@@ -35,6 +36,10 @@ class TestWorkflowStep:
         assert "<Step load>" == repr(WorkflowStep(None))
 
 
+@pytest.mark.skipif(
+    condition=ixmp.__version__ < "3.5",
+    reason="ixmp.TimeSeries.url not available prior to ixmp 3.5.0",
+)
 def test_workflow(caplog, request, test_context):
     # FIXME disentangle this to fewer tests of atomic behaviour
     base_scenario = testing.bare_res(request, test_context, solved=False)

--- a/message_ix_models/tests/util/test_config.py
+++ b/message_ix_models/tests/util/test_config.py
@@ -1,0 +1,132 @@
+from dataclasses import dataclass, field
+
+import pytest
+
+from message_ix_models.util.config import ConfigHelper
+
+
+class TestConfigHelper:
+    @pytest.fixture
+    def cls(self):
+        """A class which inherits from ConfigHelper."""
+
+        @dataclass
+        class Config(ConfigHelper):
+            foo_1: int = 1
+            foo_2: str = ""
+            foo_3: bool = True
+
+        return Config
+
+    @pytest.fixture
+    def cls2(self, cls):
+        """A class with an attribute."""
+
+        @dataclass
+        class Config3:
+            """NOT a ConfigHelper subclass."""
+
+            baz_1: int = 1
+            baz_2: int = 2
+
+        @dataclass
+        class Config2(ConfigHelper):
+            bar_1: float = 0.01
+            subconfig_a: cls = field(default_factory=cls)
+            subconfig_b: Config3 = field(default_factory=Config3)
+
+        return Config2
+
+    @pytest.fixture
+    def c(self, cls):
+        return cls(foo_1=99, foo_2="bar", foo_3=False)
+
+    @pytest.fixture
+    def c2(self, cls, cls2):
+        result = cls2(bar_1=3.14, subconfig_a=cls(foo_1=99, foo_2="bar", foo_3=False))
+        result.subconfig_b.baz_1 = 2
+        result.subconfig_b.baz_2 = 1
+        return result
+
+    def test_canonical_name(self, cls):
+        assert "foo_1" == cls._canonical_name("foo 1")
+        assert "foo_2" == cls._canonical_name("foo-2")
+        assert "foo_3" == cls._canonical_name("foo_3")
+        assert None is cls._canonical_name("foo 4")
+
+    def test_from_dict(self, cls, c):
+        values = {"foo 1": 99, "foo-2": "bar", "foo_3": False}
+        assert c == cls.from_dict({"foo 1": 99, "foo-2": "bar", "foo_3": False})
+
+        values.update(foo_4=3.14)
+        with pytest.raises(ValueError):
+            cls.from_dict(values)
+
+    def test_read_file(self, caplog, tmp_path, cls, cls2, c, c2):
+        # Write a YAML snippet to file
+        yaml_path = tmp_path.joinpath("config.yaml")
+        yaml_path.write_text(
+            """
+foo 1: 99
+
+foo-2: bar
+
+foo_3: false
+
+foo_4: 3.14
+            """
+        )
+
+        obj1 = cls()
+        # Method runs
+        obj1.read_file(yaml_path, fail=False)
+        # Values are read
+        assert c == obj1, obj1
+        # Messages are logged
+        assert [
+            "Config has no attribute for file section 'foo_4'; ignored"
+        ] == caplog.messages
+        caplog.clear()
+
+        yaml_path.write_text(
+            """
+bar_1: 3.14
+subconfig a:
+  foo 1: 99
+  foo-2: bar
+  foo_3: false
+subconfig-b:  # No name manipulation for subkeys here
+  baz_1: 2
+  baz_2: 1
+            """
+        )
+
+        obj2 = cls2()
+        # Method runs
+        obj2.read_file(yaml_path, fail=False)
+        # Values are read
+        assert c2 == obj2, obj2
+
+        json_path = tmp_path.joinpath("config.json")
+        json_path.write_text(
+            """{
+"foo 1": 99,
+"foo-2": "bar",
+"foo_3": false
+}           """
+        )
+
+        obj3 = cls()
+        # Method runs
+        obj3.read_file(json_path)
+        # Values are read
+        assert c == obj3, obj3
+
+        obj4 = cls()
+        with pytest.raises(NotImplementedError):
+            obj4.read_file(yaml_path.with_suffix(".xlsx"))
+
+    def test_replace(self, c):
+        result = c.replace(foo_2="baz")
+        assert result is not c
+        assert "baz" == result.foo_2

--- a/message_ix_models/tests/util/test_context.py
+++ b/message_ix_models/tests/util/test_context.py
@@ -37,9 +37,8 @@ class TestContext:
         c = deepcopy(ctx)
 
         # Force the base scenario info to be empty
-        c["scenario_info"] = dict()
-
-        c["dest_scenario"] = dict(model=model_name, scenario=scenario_name)
+        c.scenario_info.clear()
+        c.dest_scenario = dict(model=model_name, scenario=scenario_name)
 
         # Fails with create=False
         with pytest.raises(
@@ -56,19 +55,19 @@ class TestContext:
         # Works with a URL to parse and no base scenario
         url = f"ixmp://{platform_name}/{model_name}/{scenario_name}"
 
-        c = deepcopy(ctx)
-        c["scenario_info"] = dict()
-        c["dest"] = url
-        s = c.clone_to_dest()
+        c2 = deepcopy(ctx)
+        c2.scenario_info.clear()
+        c2.dest = url
+        s = c2.clone_to_dest()
         assert model_name == s.model and scenario_name == s.scenario
 
         del s
 
         # Works with a base scenario
-        c.handle_cli_args(url=url)
-        c["dest_scenario"] = dict(model="baz model", scenario="baz scenario")
-        del c["dest_platform"]
-        s = c.clone_to_dest()
+        c2.handle_cli_args(url=url)
+        c2.dest_scenario = dict(model="baz model", scenario="baz scenario")
+        c2.dest_platform.clear()
+        s = c2.clone_to_dest()
 
         assert s.model.startswith("baz") and s.scenario.startswith("baz")
 
@@ -178,7 +177,7 @@ class TestContext:
 
     def test_repr(self):
         c = Context()
-        assert re.fullmatch("<Context object at [^ ]+ with 4 keys>", repr(c))
+        assert re.fullmatch("<Context object at [^ ]+ with 2 keys>", repr(c))
 
     def test_use_defaults(self, caplog):
         caplog.set_level(logging.INFO)

--- a/message_ix_models/tests/util/test_context.py
+++ b/message_ix_models/tests/util/test_context.py
@@ -71,6 +71,21 @@ class TestContext:
 
         assert s.model.startswith("baz") and s.scenario.startswith("baz")
 
+    def test_dealias(self, caplog):
+        """Aliasing works with :meth:`Context.__init__`, :meth:`Context.update`."""
+        c = Context()
+        c.update(regions="R99")
+        assert [] == caplog.messages  # No log warnings for core Config, .model.Config
+        assert "R99" == c.model.regions
+
+        c = Context(regions="R98")
+        assert [
+            "Create a Config instance instead of passing ['regions'] to Context()"
+        ] == caplog.messages
+        caplog.clear()
+        assert "R98" == c.model.regions == c.regions
+        assert [] == caplog.messages  # No log warnings for access
+
     def test_default_value(self, test_context):
         # Setting is missing
         with pytest.raises(AttributeError):

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -1,13 +1,11 @@
 import logging
 from collections import ChainMap, defaultdict
-from copy import copy
-from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence, Union
+from typing import Dict, Mapping, MutableMapping, Optional, Sequence, Union
 
 import message_ix
 import pandas as pd
 import pint
 from message_ix.models import MESSAGE_ITEMS
-from sdmx.model import Annotation, Code
 
 from ._convert_units import convert_units, series_of_pint_quantity
 from .cache import cached
@@ -22,7 +20,7 @@ from .common import (
 )
 from .node import adapt_R11_R12, adapt_R11_R14, identify_nodes, nodes_ex_world
 from .scenarioinfo import ScenarioInfo
-from .sdmx import eval_anno
+from .sdmx import CodeLike, as_codes, eval_anno
 
 __all__ = [
     "MESSAGE_DATA_PATH",
@@ -92,74 +90,6 @@ def add_par_data(
             raise
 
     return total
-
-
-def as_codes(data: Union[List[str], Dict[str, Union[Dict, Code]]]) -> List[Code]:
-    """Convert *data* to a :class:`list` of :class:`.Code` objects.
-
-    Various inputs are accepted:
-
-    - :class:`list` of :class:`str`.
-    - :class:`dict`, in which keys are :attr:`.Code.id` and values are further
-      :class:`dict` with keys matching other :class:`.Code` attributes.
-    """
-    # Assemble results as a dictionary
-    result: Dict[str, Code] = {}
-
-    if isinstance(data, list):
-        # FIXME typing ignored temporarily for PR#9
-        data = dict(zip(data, data))  # type: ignore [arg-type]
-    elif not isinstance(data, Mapping):
-        raise TypeError(data)
-
-    for id, info in data.items():
-        # Pass through Code; convert other types to dict()
-        if isinstance(info, Code):
-            result[info.id] = info
-            continue
-        elif isinstance(info, str):
-            info = dict(name=info)
-        elif isinstance(info, Mapping):
-            info = copy(info)
-        else:
-            raise TypeError(info)
-
-        # Create a Code object
-        code = Code(
-            id=str(id),
-            name=info.pop("name", str(id).title()),
-        )
-
-        # Store the description, if any
-        try:
-            code.description = info.pop("description")
-        except KeyError:
-            pass
-
-        # Associate with a parent
-        try:
-            parent_id = info.pop("parent")
-        except KeyError:
-            pass  # No parent
-        else:
-            result[parent_id].append_child(code)
-
-        # Associate with any children
-        for id in info.pop("child", []):
-            try:
-                code.append_child(result[id])
-            except KeyError:
-                pass  # Not parsed yet
-
-        # Convert other dictionary (key, value) pairs to annotations
-        for id, value in info.items():
-            code.annotations.append(
-                Annotation(id=id, text=value if isinstance(value, str) else repr(value))
-            )
-
-        result[code.id] = code
-
-    return list(result.values())
 
 
 def aggregate_codes(df: pd.DataFrame, dim: str, codes):  # pragma: no cover
@@ -306,7 +236,7 @@ def copy_column(column_name):
 
 
 def ffill(
-    df: pd.DataFrame, dim: str, values: Sequence[Union[str, Code]], expr: str = None
+    df: pd.DataFrame, dim: str, values: Sequence[CodeLike], expr: str = None
 ) -> pd.DataFrame:
     """Forward-fill `df` on `dim` to cover `values`.
 

--- a/message_ix_models/util/cache.py
+++ b/message_ix_models/util/cache.py
@@ -10,7 +10,9 @@ included in the computed cache key:
 - :class:`ScenarioInfo`: only the :attr:`~ScenarioInfo.set` entries are hashed.
 
 """
+import json
 import logging
+from dataclasses import asdict, is_dataclass
 from typing import Callable
 
 import genno.caching
@@ -38,6 +40,11 @@ PATHS_SEEN = set()
 @genno.caching.Encoder.register
 def _sdmx_identifiable(o: sdmx.model.IdentifiableArtefact):
     return str(o)
+
+
+@genno.caching.Encoder.register
+def _dataclass(o: object):
+    return asdict(o) if is_dataclass(o) else json.JSONEncoder().default(o)
 
 
 @genno.caching.Encoder.register

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -1,0 +1,63 @@
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import MutableMapping, Optional
+
+import ixmp
+
+ixmp.config.register("message local data", Path, Path.cwd())
+
+
+def _local_data_factory():
+    return (
+        Path(
+            os.environ.get("MESSAGE_LOCAL_DATA", None)
+            or ixmp.config.get("message local data")
+        )
+        .expanduser()
+        .resolve()
+    )
+
+
+@dataclass
+class Config:
+    """Top-level configuration for :mod:`message_ix_models` and :mod:`message_data`."""
+
+    #: Base path for :ref:`system-specific data <local-data>`, i.e. as given by the
+    #: :program:`--local-data` CLI option or `message local data` key in the ixmp
+    #: configuration file.
+    local_data: Path = field(default_factory=_local_data_factory)
+
+    #: Keyword arguments—especially `name`—for the :class:`ixmp.Platform` constructor,
+    #: from the :program:`--platform` or :program:`--url` CLI option.
+    platform_info: MutableMapping[str, str] = field(default_factory=dict)
+
+    #: Keyword arguments—`model`, `scenario`, and optionally `version`—for the
+    #: :class:`ixmp.Scenario` constructor, as given by the :program:`--model`/
+    #: :program:`--scenario` or :program:`--url` CLI options.
+    scenario_info: MutableMapping[str, str] = field(default_factory=dict)
+
+    #: Like :attr:`platform_info`, used by e.g. :meth:`clone_to_dest`.
+    dest_platform: MutableMapping[str, str] = field(default_factory=dict)
+
+    #: Like :attr:`scenario_info`, used by e.g. :meth:`clone_to_dest`.
+    dest_scenario: MutableMapping[str, str] = field(default_factory=dict)
+
+    #: A scenario URL, e.g. as given by the :program:`--url` CLI option.
+    url: Optional[str] = None
+
+    #: Like :attr:`url`, used by e.g. :meth:`clone_to_dest`.
+    dest: Optional[str] = None
+
+    #: Base path for cached data, e.g. as given by the :program:`--cache-path` CLI
+    #: option. Default: :file:`{local_data}/cache/`.
+    cache_path: Optional[str] = None
+
+    #: Whether an operation should be carried out, or only previewed. Different modules
+    #: will respect :attr:`dry_run` in distinct ways, if at all, and **should** document
+    #: behaviour.
+    dry_run: bool = False
+
+    #: Flag for causing verbose output to logs or stdout. Different modules will respect
+    #: :attr:`verbose` in distinct ways.
+    verbose: bool = False

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -26,13 +26,14 @@ def _local_data_factory():
 class ConfigHelper:
     """Mix-in for :class:`dataclass`-based configuration classes.
 
-    This provides 3 methods—:meth:`read_file`, :meth:`replace`, and :meth:`from_dict`
-    that help to use :class:`dataclass` classes.
+    This provides 3 methods—:meth:`read_file`, :meth:`replace`, and :meth:`from_dict`—
+    that help to use :class:`dataclass` classes for handling :mod:`message_ix_models`
+    configuration.
 
     All 3 methods take advantage of name manipulations: the characters "-" and " " are
     replaced with underscores ("_"). This allows to write the names of attributes in
-    legible ways e.g. "attribute name" instead of "attribute_name" in configuration
-    files and/or code.
+    legible ways—e.g. "attribute name" or “attribute-name” instead of "attribute_name"—
+    in configuration files and/or code.
     """
 
     @classmethod

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -85,7 +85,7 @@ class ConfigHelper:
         else:
             raise NotImplementedError(f"Read from {path.suffix}")
 
-        for key, value in self._munge_dict(data, "raise", "file section"):
+        for key, value in self._munge_dict(data, fail, "file section"):
             existing = getattr(self, key, None)
             if is_dataclass(existing):
                 # Attribute value is also a dataclass; update it recursively

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -22,7 +22,7 @@ _ALIAS = dict()
 _ALIAS.update({f.name: "core" for f in fields(Config)})
 
 
-def _dealiased(base, data):
+def _dealiased(base: str, data: dict) -> dict:
     """Separate values from `data` which belong on `base` according to `_ALIAS`."""
     result = {}
     for name, path in filter(lambda ap: ap[1] == base, _ALIAS.items()):
@@ -77,8 +77,8 @@ class Context(dict):
             log.info("Create root Context")
 
         # Handle keyword arguments going to known config dataclasses
-        kwargs["core"] = Config(**_dealiased(kwargs, "core"))
-        kwargs["model"] = ModelConfig(**_dealiased(kwargs, "model"))
+        kwargs["core"] = Config(**_dealiased("core", kwargs))
+        kwargs["model"] = ModelConfig(**_dealiased("model", kwargs))
 
         # Store any keyword arguments
         super().__init__(*args, **kwargs)
@@ -90,7 +90,7 @@ class Context(dict):
         base = _ALIAS[name]
 
         # Warn about direct reference to aliased attributes
-        if base not in {"core", "model"}:
+        if base not in {"core", "model"}:  # pragma: no cover
             log.warnings(f"Use Context.{base}.{name} instead of Context.{name}")
 
         return getattr(self, base), name

--- a/message_ix_models/util/sdmx.py
+++ b/message_ix_models/util/sdmx.py
@@ -1,10 +1,82 @@
 """Utilities for handling objects from :mod:`sdmx`."""
 import logging
+from copy import copy
+from typing import Dict, List, Mapping, Union
 
 from iam_units import registry
-from sdmx.model import AnnotableArtefact
+from sdmx.model import AnnotableArtefact, Annotation, Code, InternationalString
 
 log = logging.getLogger(__name__)
+
+CodeLike = Union[str, Code]
+
+
+def as_codes(data: Union[List[str], Dict[str, CodeLike]]) -> List[Code]:
+    """Convert *data* to a :class:`list` of :class:`.Code` objects.
+
+    Various inputs are accepted:
+
+    - :class:`list` of :class:`str`.
+    - :class:`dict`, in which keys are :attr:`.Code.id` and values are further
+      :class:`dict` with keys matching other :class:`.Code` attributes.
+    """
+    # Assemble results as a dictionary
+    result: Dict[str, Code] = {}
+
+    if isinstance(data, list):
+        # FIXME typing ignored temporarily for PR#9
+        data = dict(zip(data, data))  # type: ignore [arg-type]
+    elif not isinstance(data, Mapping):
+        raise TypeError(data)
+
+    for id, info in data.items():
+        # Pass through Code; convert other types to dict()
+        if isinstance(info, Code):
+            result[info.id] = info
+            continue
+        elif isinstance(info, str):
+            _info = dict(name=info)
+        elif isinstance(info, Mapping):
+            _info = copy(info)
+        else:
+            raise TypeError(info)
+
+        # Create a Code object
+        code = Code(
+            id=str(id),
+            name=_info.pop("name", str(id).title()),
+        )
+
+        # Store the description, if any
+        try:
+            code.description = InternationalString(value=_info.pop("description"))
+        except KeyError:
+            pass
+
+        # Associate with a parent
+        try:
+            parent_id = _info.pop("parent")
+        except KeyError:
+            pass  # No parent
+        else:
+            result[parent_id].append_child(code)
+
+        # Associate with any children
+        for id in _info.pop("child", []):
+            try:
+                code.append_child(result[id])
+            except KeyError:
+                pass  # Not parsed yet
+
+        # Convert other dictionary (key, value) pairs to annotations
+        for id, value in _info.items():
+            code.annotations.append(
+                Annotation(id=id, text=value if isinstance(value, str) else repr(value))
+            )
+
+        result[code.id] = code
+
+    return list(result.values())
 
 
 def eval_anno(obj: AnnotableArtefact, id: str):

--- a/message_ix_models/workflow.py
+++ b/message_ix_models/workflow.py
@@ -85,7 +85,7 @@ class WorkflowStep:
             # No base scenario
             if self.action:
                 raise RuntimeError(
-                    "Workflow step with action {self.action!r} requires a base scenario"
+                    f"Step with action {self.action!r} requires a base scenario"
                 )
             # Use Context to retrieve the identified scenario
             context.platform_info.update(self.platform_info)
@@ -97,10 +97,12 @@ class WorkflowStep:
             context.set_scenario(scenario)
             context.dest_scenario.update(self.scenario_info)
             s = scenario
+            log.info(f"Step runs on ixmp://{s.platform.name}/{s.url}")
+            log.info(f" with context.dest_scenario={context.dest_scenario}")
 
         if self.clone:
             # Clone to target model/scenario name
-            log.info(f"Clone to {repr(self.scenario_info)}")
+            log.info(f"Clone to {model}/{scenario}".format(**self.scenario_info))
             s = s.clone(**self.scenario_info, keep_solution=False)
 
         if not self.action:

--- a/message_ix_models/workflow.py
+++ b/message_ix_models/workflow.py
@@ -1,115 +1,206 @@
 """Tools for modeling workflows."""
-from typing import Callable, List, Optional, Union, cast
+import logging
+from typing import Callable, List, Optional, Union
 
 from genno import Computer
+from ixmp.utils import parse_url
 from message_ix import Scenario
 
 from message_ix_models.util.context import Context
+
+log = logging.getLogger(__name__)
+
+CallbackType = Callable[[Context, Scenario], Scenario]
 
 
 class WorkflowStep:
     """Single step in a multi-scenario workflow.
 
+    Nothing occurs when the WorkflowStep is instantiated. When called:
+
+    1. A base scenario is obtained:
+
+      - if the `scenario` argument is provided, this is used directly.
+      - if the `scenario` argument and :attr:`action` are both :data:`None`: the
+        scenario identified by :attr:`platform_info`, :attr:`scenario_info` is loaded.
+
+    2. If attr:`clone` is :obj:`True`, this scenario is then cloned with
+       `keep_solution=False`.
+
+    3. The :attr:`action`, if any, is called on the scenario. This function may return
+       the base scenario (equivalently :data:`None`) or a different scenario.
+
+    The step returns the resulting scenario.
+
     Parameters
     ----------
     name : str
         ``"model name/scenario name"`` for the :class:`.Scenario` produced by the step.
-    callback : Callable
+    action : CallbackType, optional
         Function to be executed to modify the base into the target Scenario.
-    solve : bool, optional
-        If :obj:`True`, the created scenario is solved when it is created.
-    report: bool, optional
-        If :obj:`True`, the created scenario is reported after it is created and maybe
-        (according to `solve`) solved.
+    target : str, optional
+        URL for the scenario produced by the workflow step.
+    clone : bool, optional
+        :obj:`True` to clone the base scenario the target.
+    kwargs
+        Keyword arguments for `action`.
     """
 
-    model_name: str
-    scenario_name: str
-    solve: bool = True
-    report: bool = False
+    #: Function to be executed on the subject scenario.
+    action: Optional[CallbackType] = None
 
-    def __init__(self, name: str, callback: Callable, solve=True):
-        # Unpack the target model/scenario name
-        self.model_name, self.scenario_name = name.split("/")
+    #: :obj:`True` to clone before :attr:`action` is executed.
+    clone: bool = False
+
+    #: Keyword arguments passed to :attr:`action`.
+    kwargs: dict
+
+    #: Target platform name and additional options.
+    platform_info: dict
+
+    #: Target model name, scenario name, and optional version.
+    scenario_info: dict
+
+    def __init__(
+        self, action: Optional[CallbackType], target=None, clone=False, **kwargs
+    ):
+        try:
+            # Store platform and scenario info by parsing the `target` URL
+            self.platform_info, self.scenario_info = parse_url(target)
+        except (AttributeError, ValueError):
+            if clone:
+                raise TypeError("target= must be supplied for clone=True")
+            self.platform_info = self.scenario_info = dict()
 
         # Store the callback and options
-        self.callback = callback
-        self.solve = solve
+        self.action = action
+        self.clone = clone
+        self.kwargs = kwargs
 
-    def __call__(self, scenario: Optional[Scenario]) -> Scenario:
+    def __call__(
+        self, context: Context, scenario: Optional[Scenario] = None
+    ) -> Scenario:
         """Execute the workflow step."""
         if scenario is None:
-            s = None  # No precursor scenario
+            # No base scenario
+            if self.action:
+                raise RuntimeError(
+                    "Workflow step with action {self.action!r} requires a base scenario"
+                )
+            # Use Context to retrieve the identified scenario
+            context.platform_info.update(self.platform_info)
+            context.scenario_info.update(self.scenario_info)
+            s = context.get_scenario()
+            log.info(f"Loaded ixmp://{s.platform.name}/{s.url}")
         else:
+            # Modify the context to identify source and destination scenarios
+            context.set_scenario(scenario)
+            context.dest_scenario.update(self.scenario_info)
+            s = scenario
+
+        if self.clone:
             # Clone to target model/scenario name
-            s = scenario.clone(
-                model=self.model_name, scenario=self.scenario_name, keep_solution=False
-            )
+            log.info(f"Clone to {repr(self.scenario_info)}")
+            s = s.clone(**self.scenario_info, keep_solution=False)
 
         # Invoke the callback. If it does not return, assume `s` contains the
         # modifications
-        result = cast(Scenario, self.callback(s) or s)
-
-        if self.solve:
-            result.solve()
-
-        if self.report:  # pragma: no cover
-            raise NotImplementedError  # TODO
+        if self.action:
+            log.info("Execute {self.action!r}")
+            result = self.action(context, s, **self.kwargs)
+            if result is None:
+                log.info("…nothing returned, continue with {s.url}")
+                result = s
+        else:
+            result = s
 
         return result
 
     def __repr__(self):
-        return f"<Step {repr(self.callback)}>"
+        action = f"{self.action.__name__}()" if self.action else "load"
+        dest = ""
+        if self.scenario_info:
+            dest = " -> {model}/{scenario}".format(**self.scenario_info)
+        return f"<Step {action}{dest}>"
 
 
 class Workflow:
-    """Workflow containing multiple :class:`Scenarios <.Scenario>`.
+    """Workflow for operations on multiple :class:`Scenarios <.Scenario>`.
 
     Parameters
     ----------
     context : .Context
         Context object with settings common to the entire workflow.
-    solve : bool, optional
-        Passed to every :class:`.WorkflowStep` created using :meth:`.add`.
     """
 
     _computer: Computer
 
-    def __init__(self, context: Context, solve=True):
-        # NB has no effect; only an example of how Context settings can control the
-        #    workflow
-        self.reporting_only = context.get("run_reporting_only", False)
-        self.solve = solve
-
+    def __init__(self, context: Context):
         self._computer = Computer()
+        self._computer.add("context", context)
 
-    def add(self, name: str, base: Optional[str], callback: Callable):
-        """Add a step to the workflow.
+    def add_step(
+        self,
+        name: str,
+        base: Optional[str] = None,
+        action: Optional[CallbackType] = None,
+        **kwargs,
+    ) -> WorkflowStep:
+        """Add a :class:`WorkflowStep` to the workflow.
 
         Parameters
         ----------
         name : str
-            ``"model name/scenario name"`` for the :class:`.Scenario` produced by the
-            step.
+            Name for the new step.
         base : str or None
-            Base scenario, if any.
-        callback : Callable
+            Previous step that produces the a pre-requisite scenario for this step.
+        action : CallbackType
             Function to be executed to modify the base into the target Scenario.
+        kwargs
+            Keyword arguments for `action`; passed to and stored on the
+            :class:`WorkflowStep` until used.
+
+        Returns
+        -------
+        WorkflowStep
+            a reference to the added step, for optional further modification.
         """
         # Create the workflow step
-        step = WorkflowStep(name, callback, solve=self.solve)
+        step = WorkflowStep(action, **kwargs)
 
         # Add to the Computer
-        self._computer.add_single(name, step, base, strict=True)
+        self._computer.add_single(name, step, "context", base, strict=True)
 
-        print(self._computer.graph)  # DEBUG
+        return step
 
-    def run(self, scenarios: Union[str, List[str]]):
-        """Run the workflow to generate one or more scenarios.
+    def run(self, name_or_names: Union[str, List[str]]):
+        """Run all workflow steps necessary to produce `name_or_names`.
 
         Parameters
         ----------
-        scenarios: str or list of str
-            Identifier(s) of scenario(s) to generate.
+        name_or_names: str or list of str
+            Identifier(s) of steps to run.
         """
-        return self._computer.get(scenarios)
+        return self._computer.get(name_or_names)
+
+    def truncate(self, name: str):
+        """Truncate the workflow at the step `name`.
+
+        The step `name` is replaced with a new :class:`WorkflowStep` that simply loads
+        the target :class:`Scenario` that would be produced by the original step.
+
+        Raises
+        ------
+        KeyError
+            if step `name` does not exist.
+        """
+        # Retrieve the existing step
+        existing = self._computer.graph[name][0]
+
+        # Generate a new step that merely loads the scenario identified by `existing`
+        step = WorkflowStep(None)
+        step.platform_info = existing.platform_info
+        step.scenario_info = existing.scenario_info
+
+        # Replace the existing step
+        self._computer.add_single(name, step, "context", None)

--- a/message_ix_models/workflow.py
+++ b/message_ix_models/workflow.py
@@ -102,7 +102,7 @@ class WorkflowStep:
 
         if self.clone:
             # Clone to target model/scenario name
-            log.info(f"Clone to {model}/{scenario}".format(**self.scenario_info))
+            log.info("Clone to {model}/{scenario}".format(**self.scenario_info))
             s = s.clone(**self.scenario_info, keep_solution=False)
 
         if not self.action:

--- a/message_ix_models/workflow.py
+++ b/message_ix_models/workflow.py
@@ -112,7 +112,7 @@ class WorkflowStep:
         try:
             # Invoke the callback
             result = self.action(context, s, **self.kwargs)
-        except Exception:
+        except Exception:  # pragma: no cover
             s.platform.close_db()  # Avoid locking the scenario
             raise
 
@@ -215,8 +215,8 @@ class Workflow(Computer):
                 raise RuntimeError(
                     f"Unable to locate platform info for {step.scenario_info}"
                 )
-            else:
-                raise
+            else:  # pragma: no cover
+                raise  # Something else
 
         # Replace the existing step
         self.add_single(name, step, "context", None)


### PR DESCRIPTION
- Changes for/linked to iiasa/message_data#407:
  - Create **`Config` dataclasses** to collect, document, and make explicit the configuration settings obeyed by the code.
  - Create a `ConfigHelper` mix-in for Config classes in modules/other packages, e.g. `message_data`.
  - Revise/improve the `Workflow` API based on experience with the NAVIGATE case.
- Add ixmp/message-ix v3.6.0 to the CI job matrix, distinct from `main`.
- Correct small errors in the RES commodity.yaml and technology.yaml files.
- Migrate `get_region_codes`, `generate_product`, `generate_set_elements` from non-public `message_data`.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.