### PR TITLE
Add Zambia yaml file and function same_time, analogous of same_node

### DIFF
--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -45,6 +45,7 @@ Commonly used:
    package_data_path
    private_data_path
    same_node
+   same_time
    series_of_pint_quantity
 
 .. automodule:: message_ix_models.util

--- a/doc/pkg-data/node.rst
+++ b/doc/pkg-data/node.rst
@@ -77,3 +77,11 @@ Israel (``ISR``)
 
 .. literalinclude:: ../../message_ix_models/data/node/ISR.yaml
    :language: yaml
+
+.. _ZMB:
+
+Zambia (``ZMB``)
+----------------
+
+.. literalinclude:: ../../message_ix_models/data/node/ZMB.yaml
+   :language: yaml

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,8 @@ What's new
 Next release
 ============
 
+- Add the :ref:`ZMB` node code list (:pull:`83`).
+- Add the utility :func:`same_time`, to copy the set time in paramenters (:pull:`83`).
 - New :class:`~message_ix_models.Config` and :class:`.model.Config` :py:mod:`dataclasses` for clearer description/handling of recognized settings stored on :class:`.Context` (:pull:`82`).
   :class:`.ConfigHelper` for convenience/utility functionality in :mod:`message_ix_models`-based code.
 - New functions :func:`.generate_product`, :func:`.generate_set_elements`, :func:`.get_region_codes` in :mod:`.model.structure` (:pull:`82`).

--- a/message_ix_models/data/node/ZMB.yaml
+++ b/message_ix_models/data/node/ZMB.yaml
@@ -1,9 +1,10 @@
-# Codes for the "node" dimension of the MESSAGE-IL model
+# Codes for the "node" dimension of the MESSAGE-ZM model
 
 World:
   name: World
-  description: MESSAGE-ZA regions
+  description: MESSAGE-ZM regions
 
 Zambia:
   name: Zambia
   parent: World
+  child: [ZMB]

--- a/message_ix_models/data/node/ZMB.yaml
+++ b/message_ix_models/data/node/ZMB.yaml
@@ -1,0 +1,9 @@
+# Codes for the "node" dimension of the MESSAGE-IL model
+
+World:
+  name: World
+  description: MESSAGE-ZA regions
+
+Zambia:
+  name: Zambia
+  parent: World

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -19,7 +19,7 @@ from message_ix_models.util import as_codes, eval_anno
 @pytest.mark.parametrize(
     "kind, exp",
     [
-        ("node", ["ADVANCE", "ISR", "R11", "R12", "R14", "R32", "RCP"]),
+        ("node", ["ADVANCE", "ISR", "R11", "R12", "R14", "R32", "RCP", "ZMB"]),
         ("year", ["A", "B"]),
     ],
 )
@@ -42,6 +42,7 @@ class TestGetCodes:
             "node/R14",
             "node/R32",
             "node/RCP",
+            "node/ZMB",
             "technology",
             "year/A",
             "year/B",

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -463,6 +463,12 @@ def same_node(df: pd.DataFrame) -> pd.DataFrame:
     return df.assign(**{c: copy_column("node_loc") for c in cols})
 
 
+def same_time(df: pd.DataFrame) -> pd.DataFrame:
+    """Fill 'time_origin'/'time_dest' in `df` from 'time'."""
+    cols = list(set(df.columns) & {"time_origin", "time_dest"})
+    return df.assign(**{c: copy_column("time") for c in cols})
+
+
 def strip_par_data(
     scenario: message_ix.Scenario,
     set_name: str,


### PR DESCRIPTION
This PR makes to small additions:

- Adding a Zambia yaml file, needed to run the national model for different users in the LEAP-RE project
- Adding a new utility function `same_time` which does copy the sets `time` into either `time_origin` or `time_dest`. This function is the analogous of `same_node`

## How to review

There is not much to review or test. But please let me know if you notice something missing or needed

## PR checklist

- [x] Updated the automatic documentation
- [ ] Update doc/whatsnew. I did not, not sure if those changes are worth being mentioned there
