### PR TITLE
Add units to atol in np.isclose

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,10 +17,13 @@ jobs:
     with:
       # If the "Latest version testable on GitHub Actions" in pytest.yaml
       # is not the latest 3.x stable version, adjust here to match:
+      # NB pint is normally implied by iam-units, but we force an earlier
+      #    version to work around https://github.com/hgrecco/pint/issues/1767
       python-version: "3.10"
       type-hint-packages: >-
         genno
         iam-units
+        "pint < 0.21"
         pytest
         sdmx1
         types-PyYAML

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -154,7 +154,10 @@ def test_convert_units(recwarn):
 
     # With store="quantity", a series of pint.Quantity is returned
     result = convert_units(*args, store="quantity")
-    assert all(np.isclose(a, b, atol=1e-4 * registry.kg) for a, b in zip(exp.values, result.values))
+    assert all(
+        np.isclose(a, b, atol=1e-4 * registry.kg)
+        for a, b in zip(exp.values, result.values)
+    )
 
     # With store="magnitude", a series of floats
     exp = pd.Series([q.magnitude for q in exp.values], name="bar")

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -154,7 +154,7 @@ def test_convert_units(recwarn):
 
     # With store="quantity", a series of pint.Quantity is returned
     result = convert_units(*args, store="quantity")
-    assert all(np.isclose(a, b, atol=1e-4) for a, b in zip(exp.values, result.values))
+    assert all(np.isclose(a, b, atol=1e-4 * registry.kg) for a, b in zip(exp.values, result.values))
 
     # With store="magnitude", a series of floats
     exp = pd.Series([q.magnitude for q in exp.values], name="bar")


### PR DESCRIPTION
Changed in pint 0.21: [atol in numpy.isclose() now requires units](https://github.com/hgrecco/pint/issues/1658) to be specified, see e.g. [their commit](https://github.com/jules-ch/pint/commit/babed18e04b140b49c9a2eb9c84e71d954c2a5f7) that resolved their tests issues introduced by this change.

hgrecco/pint/issues/1277 might also occur somewhere in our code as workarounds that we can now possibly remove. 

Adding a unit to `atol` in `tests/test_util.py`'s `test_convert_units()`. Do we use `numpy.isclose()` or `numpy.allclose()` with units anywhere else? Does the new behaviour need documentation for our users?

<!-- Optional: write a longer description to help a reviewer understand the PR in ~3 minutes. -->

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~Add, expand, or update documentation.~
- ~Update doc/whatsnew.~