### PR TITLE
Ensure str indexers from generate_product()

### DIFF
--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -149,7 +149,7 @@ def generate_product(
         result.name = str(result.name).format(**fmt)  # type: ignore [assignment]
 
         codes.append(result)  # Store code and indices
-        indices.append(item)
+        indices.append(tuple(map(str, item)))
 
     # - Convert length-N sequence of D-tuples to D iterables each of length N.
     # - Convert to D × 1-dimensional xr.DataArrays, each of length N.


### PR DESCRIPTION
This prevents a "TypeError: … Code has no len()" that appears to occur only on pandas 2.0.0, and causes trouble in message_data. cf. iiasa/message_data#442

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update doc/whatsnew.~