### PR TITLE
Adjust for sdmx1 v2.10.0

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,7 @@ What's new
 v2023.5.13 (2023-05-13)
 =======================
 
+- Adjust :mod:`sdmx` usage for version 2.10.0 (:pull:`101`).
 - Adjust :func:`.generate_product` for pandas 2.0.0 (:pull:`98`).
 
 2023.4.2

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from copy import copy
 from functools import partial
 from itertools import product
 from typing import List, Mapping, MutableMapping, Sequence, Union
@@ -94,7 +95,7 @@ def get_spec(
                 Annotation(id="input", text=repr(input)),
                 Annotation(id="output", text=repr(output)),
             ]
-            + [a.copy() for a in other_anno],
+            + [copy(a) for a in other_anno],
         )
 
         # "commodity" set elements to add

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from collections import ChainMap
+from copy import copy
 from functools import lru_cache
 from itertools import product
 from typing import Dict, List, Mapping, MutableMapping, Tuple
@@ -142,7 +143,7 @@ def generate_product(
 
     # Iterate over the product of filtered codes for each dimension in
     for item in product(*[_base(*dm) for dm in dims.items()]):
-        result = template.copy()  # Duplicate the template
+        result = copy(template)  # Duplicate the template
 
         fmt = dict(zip(dims.keys(), item))  # Format the ID and name
         result.id = result.id.format(**fmt)
@@ -262,7 +263,7 @@ def process_units_anno(set_name: str, code: Code, quiet: bool = False) -> None:
 
     # Also annotate child codes
     for c in code.child:
-        c.annotations.append(units_anno.copy())
+        c.annotations.append(copy(units_anno))
 
 
 def process_commodity_codes(codes):


### PR DESCRIPTION
As of `sdmx1` v2.10, objects in the Information Model no longer have `.copy()` methods; the [release notes](https://sdmx1.readthedocs.io/en/latest/whatsnew.html#v2-10-0-2023-05-20) recommend using `copy.copy()` from the standard library instead.

This PR makes that change.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- [x] Update doc/whatsnew.