### PR TITLE
Handling flaky tests

### DIFF
--- a/message_ix_models/tests/util/test_context.py
+++ b/message_ix_models/tests/util/test_context.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import re
+import sys
 from copy import deepcopy
 from pathlib import Path
 
@@ -134,6 +136,9 @@ class TestContext:
         with pytest.raises(ValueError):
             test_context.get_scenario()
 
+    @pytest.mark.flaky(
+        reruns=5, condition="GITHUB_ACTIONS" in os.environ and sys.platform == "darwin"
+    )
     def test_set_scenario(self, test_context):
         mp = test_context.get_platform()
         s = Scenario(mp, "foo", "bar", version="new")

--- a/message_ix_models/tests/util/test_context.py
+++ b/message_ix_models/tests/util/test_context.py
@@ -1,7 +1,7 @@
 import logging
 import os
+import platform
 import re
-import sys
 from copy import deepcopy
 from pathlib import Path
 
@@ -137,7 +137,10 @@ class TestContext:
             test_context.get_scenario()
 
     @pytest.mark.flaky(
-        reruns=5, condition="GITHUB_ACTIONS" in os.environ and sys.platform == "darwin"
+        reruns=5,
+        rerun_delay=2,
+        condition="GITHUB_ACTIONS" in os.environ and platform.system() == "Darwin",
+        reason="Flaky; see iiasa/message-ix-models#112",
     )
     def test_set_scenario(self, test_context):
         mp = test_context.get_platform()


### PR DESCRIPTION
Closes #112 by marking the test as flaky. Through discussion with @khaeru, we agreed that this is the best option for now; should the test make more issues in the future, we can still identify its root cause.

Note that the second commit here is temporary until iiasa/ixmp#490 is merged. The additional dependency here can then be dropped again.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Mark a test; coverage checks both ✅
