### PR TITLE
Adjust for iiasa/message_ix#738

### DIFF
--- a/message_ix_models/data/report/global.yaml
+++ b/message_ix_models/data/report/global.yaml
@@ -558,11 +558,6 @@ combine:
 
 
 general:
-# List of model periods only, excluding those before or after
-- key: "y::model"
-  comp: model_periods
-  inputs: [ "y", "cat_year" ]
-
 - key: Liquids:nl-ya
   comp: apply_units
   inputs: [liquids:nl-ya]


### PR DESCRIPTION
- Only add "y::model", "y0" if not already defined. After iiasa/message_ix#738 (that is, first message_ix release after 3.7.0), these will be defined in the Reporter by default.
- Add a new "defaults" callback to hold settings and computations always used.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- ~Update doc/whatsnew.~ Covered by #116.