### PR TITLE
Add data providers for SSP data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Reduce the number of merge conflicts
 doc/whatsnew.rst merge=union
 # Git LFS
-*.csv.gz filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
 *.xlsx filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -38,20 +38,21 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
 .benchmarks
+.cache
 .coverage
 .coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
 .hypothesis/
+.nox/
 .pytest_cache/
 .ruff_cache
+.tox/
+*.cover
+*.py,cover
+coverage.xml
+htmlcov/
+nosetests.xml
+/prof/
 
 # Translations
 *.mo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - "mypy <1.5"
+    - mypy
     - pytest
     - sdmx1
     - types-PyYAML

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 prune message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline
+prune message_ix_models/data/test/ssp

--- a/doc/api/project.rst
+++ b/doc/api/project.rst
@@ -1,7 +1,11 @@
 .. currentmodule:: message_ix_models.project
 
-Specific research projects (:mod:`.project`)
-********************************************
+Specific research projects (:mod:`~message_ix_models.project`)
+**************************************************************
+
+.. contents::
+   :local:
+   :backlinks: none
 
 .. automodule:: message_ix_models.project
    :members:
@@ -12,5 +16,41 @@ Specific research projects (:mod:`.project`)
 Shared Socioeconomic Pathways (:mod:`.project.ssp`)
 ===================================================
 
+Structure
+---------
+
+The enumerations :obj:`SSP_2017` and :obj:`SSP_2024` contain one member from the corresponding SDMX code lists.
+These can be used to uniquely identify both an SSP narrative *and* the set in which it occurs, in applications where this distinction is meaningful:
+
+.. code-block:: py
+
+   >>> from message_ix_models.project.ssp import SSP_2017, SSP_2024
+   >>> x = SSP_2017["2"]
+   >>> y = SSP_2024["2"]
+   >>> str(y)
+   "ICONICS:SSP(2024).2"
+   >>> x == y
+   False
+
 .. automodule:: message_ix_models.project.ssp
    :members:
+
+Data
+----
+
+.. automodule:: message_ix_models.project.ssp.data
+   :members:
+
+   Although free, neither the 2017 or 2024 SSP data can be downloaded automatically.
+   Both sources require that users first submit personal information to register before being able to retrieve the data.
+   :mod:`message_ix_models` does not circumvent this requirement.
+   Thus:
+
+   - A copy of the data are stored in :mod:`message_data`.
+   - :mod:`message_ix_models` contains only a ‘fuzzed’ version of the data (same structure, random values) for testing purposes.
+
+   .. todo:: Allow users without access to :mod:`message_data` to read a local copy of this data from a :attr:`.Config.local_data` subdirectory.
+
+   .. autosummary::
+      SSPOriginal
+      SSPUpdate

--- a/doc/api/report/index.rst
+++ b/doc/api/report/index.rst
@@ -25,7 +25,7 @@ Not public:
 Introduction
 ============
 
-See :doc:`the discussion in the MESSAGEix docs <message_ix:reporting>` about the stack.
+See :doc:`the discussion in the MESSAGEix docs <message-ix:reporting>` about the stack.
 In short, :mod:`message_ix` must not contain reporting code that references ``coal_ppl``, because not every model built on the MESSAGE framework will have a technology with this name.
 Any reporting specific to ``coal_ppl`` must be in :mod:`message_ix_models`, since all models in the MESSAGEix-GLOBIOM family will have this technology.
 
@@ -95,14 +95,24 @@ API reference
 
    .. autosummary::
 
+      Config
       prepare_reporter
       register
       report
 
+.. currentmodule:: message_ix_models.report.plot
+
+Plots
+-----
+
+.. automodule:: message_ix_models.report.plot
+   :members:
+
+.. currentmodule:: message_ix_models.report.computations
+
 Operators
 ---------
 
-.. currentmodule:: message_ix_models.report.computations
 .. automodule:: message_ix_models.report.computations
    :members:
 
@@ -110,6 +120,10 @@ Operators
 
    .. autosummary::
 
+      codelist_to_groups
+      compound_growth
+      exogenous_data
+      filter_ts
       from_url
       get_ts
       gwp_factors

--- a/doc/api/report/index.rst
+++ b/doc/api/report/index.rst
@@ -172,7 +172,7 @@ Utilities
 
 
 Command-line interface
-----------------------
+======================
 
 .. currentmodule:: message_ix_models.report.cli
 .. automodule:: message_ix_models.report.cli
@@ -206,3 +206,11 @@ Command-line interface
      -o, --output PATH     Write output to file instead of console.
      --from-file FILE      Report multiple Scenarios listed in FILE.
      --help                Show this message and exit.
+
+Testing
+=======
+
+
+.. currentmodule:: message_ix_models.report.sim
+.. automodule:: message_ix_models.report.sim
+   :members:

--- a/doc/api/tools.rst
+++ b/doc/api/tools.rst
@@ -24,7 +24,7 @@ Exogenous data (:mod:`.tools.exo_data`)
 
 .. automodule:: message_ix_models.tools.exo_data
    :members:
-   :exclude-members: ExoDataSource
+   :exclude-members: ExoDataSource, prepare_computer
 
    .. autosummary::
 
@@ -32,8 +32,25 @@ Exogenous data (:mod:`.tools.exo_data`)
       SOURCES
       DemoSource
       ExoDataSource
+      iamc_like_data_for_query
       prepare_computer
       register_source
+
+.. autofunction:: prepare_computer
+
+   The first returned key, like ``{measure}:n-y``, triggers the following computations:
+
+   1. Load data by invoking a :class:`ExoDataSource`.
+   2. Aggregate on the |n| (node) dimension according to :attr:`.Config.regions`.
+   3. Interpolate on the |y| (year) dimension according to :attr:`.Config.years`.
+
+   Additional key(s) include:
+
+   - ``{measure}:n-y:y0 indexed``: same as ``{measure}:n-y``, indexed to values as of |y0| (the first model year).
+
+   See particular data source classes, like :class:`.SSPOriginal`, for particular examples of usage.
+
+   .. todo:: Extend to also prepare to compute values indexed to a particular |n|.
 
 .. autoclass:: ExoDataSource
    :members:

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -57,7 +57,6 @@ Commonly used:
 
 .. autodata:: message_ix_models.util.cache.SKIP_CACHE
 
-
 :mod:`.util.click`
 ==================
 
@@ -65,6 +64,11 @@ Commonly used:
 
 .. automodule:: message_ix_models.util.click
    :members:
+
+   :data:`PARAMS` contains, among others:
+
+   - :program:`--urls-from-file=…` Path to a file containing scenario URLs, one per line.
+     These are parsed and stored on :attr:`.Config.scenarios`.
 
 :mod:`.util.config`
 ===================
@@ -181,6 +185,13 @@ Commonly used:
 .. automodule:: message_ix_models.util.pooch
    :members:
 
+:mod:`.util.pycountry`
+======================
+
+.. currentmodule:: message_ix_models.util.pycountry
+
+.. automodule:: message_ix_models.util.pycountry
+   :members:
 
 :mod:`.util.scenarioinfo`
 =========================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,9 +53,16 @@ nitpick_ignore_regex = {
 }
 
 rst_prolog = """
+.. role:: py(code)
+   :language: python
+
 .. |Code| replace:: :class:`~sdmx.model.common.Code`
 .. |Platform| replace:: :class:`~ixmp.Platform`
 .. |Scenario| replace:: :class:`~message_ix.Scenario`
+
+.. |n| replace:: :math:`n`
+.. |y| replace:: :math:`y`
+.. |y0| replace:: :math:`y_0`
 """
 
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,24 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- New providers for exogenous data from the :class:`.SSPOriginal` and :class:`.SSPUpdate` (:pull:`125`) sources.
+- Improved :class:`.ScenarioInfo` (:pull:`125`):
+
+  - New attributes :attr:`~.ScenarioInfo.model`, :attr:`~.ScenarioInfo.scenario`, :attr:`~.ScenarioInfo.version`, and (settable) :attr:`~.ScenarioInfo.url`; class method :meth:`~.ScenarioInfo.from_url` to allow storing |Scenario| identifiers on ScenarioInfo objects.
+  - New property :attr:`~.ScenarioInfo.path`, giving a valid path name for scenario-specific file I/O.
+
+- Improvements to :mod:`~message_ix_models.report` (:pull:`125`):
+
+  - New :class:`.report.Config` class collecting recognized settings for the module.
+  - :py:`context["report"]` always exists as an instance of :class:`.report.Config`.
+  - New submodule :class:`.report.plot` with base class and 5 plots of time-series data stored on Scenarios (:pull:`125`).
+  - New operator :func:`.filter_ts` (:pull:`125`).
+
+- New reusable command-line option :program:`--urls-from-file` in :mod:`.util.click` (:pull:`125`).
+- Add `pyarrow <https://pypi.org/project/pyarrow/>`_ to dependencies (:pull:`125`).
 
 v2023.9.12
 ==========

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -14,8 +14,9 @@ Next release
 
   - New :class:`.report.Config` class collecting recognized settings for the module.
   - :py:`context["report"]` always exists as an instance of :class:`.report.Config`.
-  - New submodule :class:`.report.plot` with base class and 5 plots of time-series data stored on Scenarios (:pull:`125`).
-  - New operator :func:`.filter_ts` (:pull:`125`).
+  - New submodule :class:`.report.plot` with base class and 5 plots of time-series data stored on Scenarios.
+  - Submodule :class:`.report.sim` provides :func:`add_simulated_solution` for testing reporting configuration.
+  - New operator :func:`.filter_ts`.
 
 - New reusable command-line option :program:`--urls-from-file` in :mod:`.util.click` (:pull:`125`).
 - Add `pyarrow <https://pypi.org/project/pyarrow/>`_ to dependencies (:pull:`125`).

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e433c07354b799c820ece98b7138085caf2b8e3d6d8a86539c3da63f89698f4e
+size 1119595

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_ALL_MODES_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_ALL_MODES_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5aa1010c0dddba54aa1d0a801e89c3192d1f4360bdaf578ec45626eb7fdc316
+size 100

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_ALL_MODES_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_ALL_MODES_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac8693e1c3e9b50551a03d646daf2bdeacc9a38a138a27a11371b0bf01fb6043
+size 100

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edd096c38db7e0a39e26f5a6af481d66c60ff38007a4e8ed73da7d2f4538749c
+size 348853

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75de3ceae9062278c128cb750542dba94c24b6c0d969b0ce06a3cdafd717df96
+size 83105

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BY_RATING.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_BY_RATING.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:029b808065ecf6e10c16429b99096c331817617442245354d18e4000626fd143
+size 99

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4a5afeb2f41aaa663d98e5104bf8240b5418929d0cfbbdd5ec4c88c9b3b3974
+size 143041

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df73e159a53f1b727a596c2f2bb7444366adaee489981b4e71274b6e9b53d5fe
+size 179283

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_RATING_TOTAL.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_RATING_TOTAL.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b85f2517fc01c92f57d2ceed3ff733cb9e807e4b42f515354a621a1bbaf1300
+size 102

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_SOFT_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_SOFT_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bf71ddbc84d5a71d79b22dfe02f661aef9a3a5b8cf8cf5badea4f13a81d1741
+size 179445

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_SOFT_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACTIVITY_SOFT_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6515181be154c86c6157cdf6085ec935c88d0f6836768731e6a78c4858781062
+size 193834

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c98deb30aa75efeebe922b4550a924a104b5cde6259bb255fa68f4e5cb6debbd
+size 316292

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT_RATING.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT_RATING.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a9b8701343252903b66220e11c6c868d3c6b7d1e698dd8bfcb4c1d765454bb8
+size 119

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ACT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21dc4e66daef3882bb41998528ac734a8e75403789a6dae1367f79c452f36f2c
+size 320194

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ADDON_ACTIVITY_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ADDON_ACTIVITY_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af963fb032e65c2e90283a87d8848dbc00626616d0ca44da1db268c6356c80d0
+size 92

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ADDON_ACTIVITY_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/ADDON_ACTIVITY_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab312790ecfecebb21e5944eb7c45bb747e134102aae4c4b80ef60b5e356ebf7
+size 92

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27bf53613717d2780f6343bfb6a0db0ef551d679ec0feb94ab10e24b1599f084
+size 778593

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17082ce84c47fcabcaef80939de648590492531c13fcb43914cf9f4dfe6aba7d
+size 718481

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_MAINTENANCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_MAINTENANCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86fafb476b64dba76621cb333dc3d37ed1387f5f3dacfa142e1dc700c034772
+size 745591

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_MAINTENANCE_HIST.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_MAINTENANCE_HIST.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d2aa3a84b3875d03fb4701c1c061da755e857c338c17ef314f6e88b1ea05f9
+size 69622

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_MAINTENANCE_NEW.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAPACITY_MAINTENANCE_NEW.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1f08163b93db37146c07b26ee12b7a4080552f71c855b8d27f757081df112b9
+size 330366

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_FIRM.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_FIRM.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a12ae231e2073edf413cd900c2dc544275a23f64b4621aac315d798ad9d9157
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_NEW.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_NEW.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43ef04e1f32d5c7dc76a8874114dc309e16f1f89d8a664c5fccecfe7aec977b4
+size 179351

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_NEW_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_NEW_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:891d39e3f37233bd2200112c9c42af2cb0d150e08fe7c28306c501131a5abc55
+size 87

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_NEW_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/CAP_NEW_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba1b62b75ac4843650fdb7dc7653f4b0e10271e7f5f65b368df1fa6cc9ac4206
+size 7283

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_BALANCE_GT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_BALANCE_GT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d35dd8ebfdd544dce144373c3c7a0ab00046f51249ebe41e4ec299afbc2a130f
+size 84196

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_BALANCE_LT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_BALANCE_LT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00531dc0f1938e8eb5cdc190f78d24dfc9c8e5adbac24057a993b6927130c7df
+size 95

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_USE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_USE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0956f96a9ef4bfdd2288e8bc3fe860233fbd1ed0335b978a3ff888f6428cd6b
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_USE_LEVEL.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COMMODITY_USE_LEVEL.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8275da1b03c128dfb952453f6860ead12701b9314fecb19bf5765ef2506b037
+size 94

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COST_ACCOUNTING_NODAL.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COST_ACCOUNTING_NODAL.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:824d2f002b4da42a72d0398cfc7b6bfa9c071b38864c3767beec71419603accc
+size 879

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COST_NODAL.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COST_NODAL.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0b71e31d74852181a8a71c596d19842eea5959e2eba43948e3f547076815fe
+size 2448

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COST_NODAL_NET.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/COST_NODAL_NET.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94a339253fea267a1fdfe8b68c395c5380d4fc2d538236114a733cd223ac0fdd
+size 2399

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DEMAND.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DEMAND.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3334223695badec19f0a01d9063e77cbb88fcad70090b97be3a34b90e239790d
+size 7351

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_SCEN_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_SCEN_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51ddb8ce9e5d57ad296d8bf6e4f6a42ec7b4dc14a89915a4234b7602e7ce181e
+size 53834

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_SCEN_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_SCEN_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f66490705a08ff2e1df75fe3aec54116f0cb93c0303bf046316e321aa77a34f7
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_TYPE_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_TYPE_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b472c85d718e06d93b1f352fcc96938cb24d53720242b6c3ba1988f3cbdc3a7f
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_TYPE_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DYNAMIC_LAND_TYPE_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba06172def776c57da5c19f25c7fa3898895f85101fc0389854bf114896dc3b3
+size 3557

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EMISS.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EMISS.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be8910fd63cfb04302468f77d4ad6af9b52a2de7defff2b6b91e75948dfd606f
+size 326505

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EMISSION_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EMISSION_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67ee01dca27fba3b186ee7b0f335bf738698c8898142b07e2272154f08082f54
+size 92

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EMISSION_EQUIVALENCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EMISSION_EQUIVALENCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f69facd22f18d5eaca5a46095f7a3b53cdfbe321383ef00e2a79c7058117942
+size 283712

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EXT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EXT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8365f142aea1114519d2c8bf0979e277b0c4c6856b91bd5d18c77ec45e32a593
+size 31593

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EXTRACTION_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EXTRACTION_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7109987a35159af0d85b0371cfc0ffb6c4518022f404dd87a7b246b78217349d
+size 1227

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EXTRACTION_EQUIVALENCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/EXTRACTION_EQUIVALENCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f94beffa45e00f8f32116bd1432f767f8ccb80337d6a6c054d51f00acfe0cf78
+size 27099

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/FIRM_CAPACITY_PROVISION.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/FIRM_CAPACITY_PROVISION.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:825fff5f8d5a69c025503d841ae84d26d45bcface9716a39fc4f699d31ccfc6e
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/GDP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/GDP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08727680d1a6d4c99188b4db1710690cfc9222865fd1c6a081599e8f8868722a
+size 75

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/LAND.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/LAND.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:880a4572c42cb5d0bdf8e836845286729bf311b31024db7dead2bb13c2d411bb
+size 146878

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/LAND_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/LAND_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c11d522defc939b33b81ad1415b2978dec2dc069a4b1ad509f1552c2d395b3df
+size 2121

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/MIN_UTILIZATION_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/MIN_UTILIZATION_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edcd485cc4c93ad535a891506267c8eebb57483b9cc9463e703b163b9bf30f96
+size 99

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0296de1b644c4d4a388595e9576cd2cb684d698908ed3fb6a3e9792bdf6af967
+size 1681

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7283ca771db832f55690a1e946af6a243b1c260599d2169e70a662ba429d337b
+size 5486

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af32c839021c0d9ffc89b1c0e3010013ba216fbe506572fd2e0b17cd8a15cc45
+size 380

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:836fbfa7a70e52ff68edc3f2ce1a0fabb936c3f35194d92f057cc47c3c21d944
+size 24127

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_SOFT_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_SOFT_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71f5e00d8086605679733ca14fcc4daff7bd401d8e34abdcda658e58d131cb08
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_SOFT_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/NEW_CAPACITY_SOFT_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d40a2063c1f0e6e7e58aeba1b259764b576a7697f359402062c66e6db0e5b45c
+size 5763

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/OBJ.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/OBJ.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0bf9752137ca3809e668a7c163785b1088f2a8e788382aefa09cac3050c7d19
+size 89

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/OBJECTIVE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/OBJECTIVE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a259aa6d9c2e3642f4a1125aea5f7dd82f83395af3c5ff2143443ebba069c6b1
+size 75

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/OPERATION_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/OPERATION_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a054afa0bbbb1cbb445974c83c00160b9f2721d34c03347e62c1492290b3dc24
+size 93

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/PRICE_COMMODITY.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/PRICE_COMMODITY.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f8b4f607990bbd14e3f6a427e1ad00fafffb76ddf7b5fb3a3465d5e98f95963
+size 69902

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/PRICE_EMISSION.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/PRICE_EMISSION.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:849cba6d7ca497aed4b7ce6edf00f587e573c592253beb1cf6da803e0885ba23
+size 106

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/REL.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/REL.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd06586d4084feb1f6083bd8764ede1afc9ebeef6cdc5ed129cbfe3d6bd7986e
+size 238737

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RELATION_CONSTRAINT_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RELATION_CONSTRAINT_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a87083f2eb1ce3540ddfe6ebe25c7f8f766c68beb47d22ae29e08de4e32f309
+size 115234

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RELATION_CONSTRAINT_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RELATION_CONSTRAINT_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e03419d2da28b6cce3b7850eac447e3a081a11634779fcf2f425b777fb9a0042
+size 144407

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RELATION_EQUIVALENCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RELATION_EQUIVALENCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30383bfef3913fa4a9eb95b6d594d7fc93aff0f85218ec1c438f47c19987ab94
+size 176891

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/REN.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/REN.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b0fb1ffb135d5438408d8562e54cf07391a8a5c665cba52f68aa15963e833d4
+size 100

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RENEWABLES_CAPACITY_REQUIREMENT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RENEWABLES_CAPACITY_REQUIREMENT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0e25cf252c3cb8091142a13ca71cd8f07c80144322487bb32ebc85e79ec5d23
+size 104

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RENEWABLES_EQUIVALENCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RENEWABLES_EQUIVALENCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:470c55fb094afe673f6ab349311834838fbfb09d933c31ce40c8fa63d5951c88
+size 97

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RENEWABLES_POTENTIAL_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RENEWABLES_POTENTIAL_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5e934da27a5525e5a371359e81b360749f220f7965f77222abcb39cdb3158b5
+size 104

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RESOURCE_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RESOURCE_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0543af0b6c6478bcc78d20d185c6ef405751498fce96697464b52c32706d5f23
+size 18136

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RESOURCE_HORIZON.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/RESOURCE_HORIZON.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa24d6fb316eb2d89ae4720858b41ccfeb64bada23f4b63b9eaa0573c2dad2b9
+size 4428

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_COMMODITY_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_COMMODITY_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cc21d796366cf7809c83a65390b9f5d43248fd0d86d3c6c43e5e7bda4122b77
+size 102

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_COMMODITY_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_COMMODITY_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eca51cf2dc8ff606ca94a98a14e589cc4d3482d486558161307cab524a74f1
+size 102

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_MODE_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_MODE_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:615fc7b3fbf093700d0ac7262668e92753dc521e3f41e1999ecfa81127c198c0
+size 102

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_MODE_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SHARE_CONSTRAINT_MODE_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fc3c3acfeecdb0caf0b54da3d570f8e0181b8fef847fe5634823561b541a29c
+size 102

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd1aef4b207566c8c86d72651479cd5cb6b163f79ba6e0c42a9dd3f3078bc65b
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb2958a3dd90e4660bca4d7afcc4bee58cef18865ff5688dea89a2d2d2d38a96
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_DYNAMIC_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_DYNAMIC_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:218b30b2f8d8572c234974662aa28c6c589b7a468775ad43d6385d6970ba9e18
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_DYNAMIC_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_ACT_DYNAMIC_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8ed98c5639b593cd01d65cfd0b52fb77757755391f9d8dae78455b97a7cc99c
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:220b671273ddb13ff930818eb30502f6cf102cfe7e6e4b23d3ec230a0a54401e
+size 99

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27aeba80d88e716cb958f00e090bc1246b189a4fd655d82bad9433e57b0a2d9b
+size 99

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_DYNAMIC_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_DYNAMIC_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09420999b386543c028a616921cd9573c97825551246557c275823b0b59f53cc
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_DYNAMIC_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_NEW_DYNAMIC_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55657401b4fe17b2b01c037a019677b9aa066c9e0b4e8a6af9c927b81398009b
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_TOTAL_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_TOTAL_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed09f97168fb57b2bc9a43a3c7436ef3c2f17b9377d0cdfb68b7f7ddad630e45
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_TOTAL_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_CAP_TOTAL_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02d264bcc5e00d21af708d7a2b4b5b24a3af1451ea324b41cd2dc841fd1f1625
+size 101

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_COMMODITY_EQUIVALENCE_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_COMMODITY_EQUIVALENCE_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:207c23f421c6d1cbb293f4c643f7d790a0f5af311a1a2edbec76aa0dbbfb5382
+size 124

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_COMMODITY_EQUIVALENCE_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_COMMODITY_EQUIVALENCE_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee76e9e744391ceb4f8d43ecaf79fde17338331cdb22fd5feea7303556392d0
+size 124

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_SCEN_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_SCEN_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d6ab62a9417667f527fe4b01315c75be66c0a18cd29886035ebd7dd23b0bb4b
+size 105

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_SCEN_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_SCEN_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e7125cc74a7f511a180061d2da69e2188ebc236a3be8a7f71db714d528c6cf0
+size 105

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_TYPE_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_TYPE_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a93a90461bd8bfab9230192dfc44e142cee2059df3a9be7a5c68d871dcb9f5b
+size 100

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_TYPE_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_LAND_TYPE_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47dbd459b84da95cef4d260708ea7a2f6b2a371f6aee73cce4396256f1b74fb0
+size 100

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_RELATION_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_RELATION_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:321a45f905880aab52202062d807ab981c980dc6ba5992a1b32731edd14b5a64
+size 105

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_RELATION_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SLACK_RELATION_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10d4d0264169ff676431b3aa7102adef68e6dd6ed5f57dbd151e9c138ff579fe
+size 105

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STOCK.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STOCK.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aaa482b1c53438ec44c3425b34bac206a4918f9018b4fc8f4f369db20186000f
+size 2511

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STOCKS_BALANCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STOCKS_BALANCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce7b9a8c5f9395d121a1b967c18c5f3242c5995d201d3e9db38896aa0ae62ed2
+size 2185

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STOCK_CHG.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STOCK_CHG.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe5a0a7a0ddc55dea4c63d6e3c9f600c8cb74e95137cc50e011ce9d7e0ecc07d
+size 836

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:460b723a702a8392b19a17b82df90965c46f1252e2543c7f9be4490e660a6a65
+size 107

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_BALANCE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_BALANCE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df0a23d0094e687e8447b36b1641eae97bebec81c9352775f0b46e2979e3ffa7
+size 98

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_BALANCE_INIT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_BALANCE_INIT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bea5128e4371709310cf3e844b6c76eceb0f873a4569af2af9a1ceb67647d13
+size 103

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_CHANGE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_CHANGE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c611fed6c89f09e2386bd65f8d86484389b227ef963a96030b05d5e9058f6470
+size 95

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_CHARGE.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_CHARGE.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32f2530f3969ccc2b73c8dbfe1f4143d1a83390d960508224d695ad73a4c9648
+size 114

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_INPUT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/STORAGE_INPUT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1723b15013f140644e2f79606183d570f684abb7a8d5b468ab276df156051953
+size 99

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SYSTEM_FLEXIBILITY_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SYSTEM_FLEXIBILITY_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69f3eb3aeb2d689231c7ecf213d2ee470cfefd1f510552fd3272f30841439b85
+size 104

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SYSTEM_RELIABILITY_CONSTRAINT.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/SYSTEM_RELIABILITY_CONSTRAINT.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fc24520d97e21232afbf3935c545657313f0fe4a86c98ddf9967dbc77e50b41
+size 104

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/TOTAL_CAPACITY_BOUND_LO.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/TOTAL_CAPACITY_BOUND_LO.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f01dc9d892f36f3abfcb400b9ccc5d049851592421bb2fc881f23dd9374cd0c6
+size 790

--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/TOTAL_CAPACITY_BOUND_UP.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/TOTAL_CAPACITY_BOUND_UP.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fccc0c30213e4b9a14d22e678d4c795eecbee8cf1fafe15e7d065f06d8decf
+size 254

--- a/message_ix_models/data/test/ssp/SSP-Review-Phase-1.csv.gz
+++ b/message_ix_models/data/test/ssp/SSP-Review-Phase-1.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a82b38c086510e5162a5681d7bfca489c9ec0189864d8f9394255e8af72c53b8
+size 14612126

--- a/message_ix_models/data/test/ssp/SspDb_country_data_2013-06-12.csv.zip
+++ b/message_ix_models/data/test/ssp/SspDb_country_data_2013-06-12.csv.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1220e19892a27928af159233f087c2abea4337b2cb73af56913612eea6a0bfc
+size 6013242

--- a/message_ix_models/model/snapshot.py
+++ b/message_ix_models/model/snapshot.py
@@ -92,9 +92,16 @@ def read_excel(scenario: Scenario, path: Path) -> None:
     base = unpack(path)
 
     scenario.read_excel(base.joinpath("sets.xlsx"))
-    with scenario.transact(f"Read snapshot from {path}"):
+
+    parameters = set(scenario.par_list())
+
+    with scenario.transact(f"Read snapshot data from {path}"):
         for p in base.glob("*.csv.gz"):
             name = p.name.split(".")[0]
+
+            if name not in parameters:
+                continue  # Variable or equation data: don't read
+
             data = pd.read_csv(p)
 
             # Correct units

--- a/message_ix_models/project/ssp/__init__.py
+++ b/message_ix_models/project/ssp/__init__.py
@@ -78,7 +78,7 @@ def gen_structures(context, **kwargs):
         ["SSP-Review-Phase-1.csv.gz", "SspDb_country_data_2013-06-12.csv.zip"]
     ),
 )
-def make_test_data(filename):
+def make_test_data(filename):  # pragma: no cover
     """Create random data for testing."""
     from pathlib import Path
 

--- a/message_ix_models/project/ssp/__init__.py
+++ b/message_ix_models/project/ssp/__init__.py
@@ -71,7 +71,14 @@ def gen_structures(context, **kwargs):
 
 
 @cli.command("make-test-data")
-def make_test_data():
+@click.argument(
+    "filename",
+    metavar="FILENAME",
+    type=click.Choice(
+        ["SSP-Review-Phase-1.csv.gz", "SspDb_country_data_2013-06-12.csv.zip"]
+    ),
+)
+def make_test_data(filename):
     """Create random data for testing."""
     from pathlib import Path
 
@@ -81,7 +88,7 @@ def make_test_data():
     from message_ix_models.util import package_data_path, private_data_path
 
     # Paths
-    p = Path("ssp", "SSP-Review-Phase-1.csv.gz")
+    p = Path("ssp", filename)
     path_in = private_data_path(p)
     path_out = package_data_path("test", p)
 

--- a/message_ix_models/project/ssp/__init__.py
+++ b/message_ix_models/project/ssp/__init__.py
@@ -68,3 +68,35 @@ def cli():
 def gen_structures(context, **kwargs):
     """(Re)Generate the SSP data structures in SDMX."""
     generate(context)
+
+
+@cli.command("make-test-data")
+def make_test_data():
+    """Create random data for testing."""
+    from pathlib import Path
+
+    import pandas as pd
+    from numpy import char, random
+
+    from message_ix_models.util import package_data_path, private_data_path
+
+    # Paths
+    p = Path("ssp", "SSP-Review-Phase-1.csv.gz")
+    path_in = private_data_path(p)
+    path_out = package_data_path("test", p)
+
+    # Read the data
+    df = pd.read_csv(path_in, engine="pyarrow")
+
+    # Determine its numeric columns (2000, 2001, etc.) and shape
+    cols = list(filter(char.isnumeric, df.columns))
+    size = (df.shape[0], len(cols))
+    # - Generate random data of this shape.
+    # - Keep only the elements corresponding to non-NA elements of `df`.
+    # - Update `df` with these values.*
+    generator = random.default_rng()
+    df.update(df.where(df.isna(), pd.DataFrame(generator.random(size), columns=cols)))
+
+    # Write to file, keeping only a few decimal points
+    path_out.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path_out, index=False, float_format="%.2f")

--- a/message_ix_models/project/ssp/data.py
+++ b/message_ix_models/project/ssp/data.py
@@ -34,7 +34,7 @@ class SSPOriginal(ExoDataSource):
 
       - "model": one of:
 
-          - IIASA POP
+          - IIASA GDP
           - IIASA-WiC POP
           - NCAR
           - OECD Env-Growth

--- a/message_ix_models/project/ssp/data.py
+++ b/message_ix_models/project/ssp/data.py
@@ -34,6 +34,19 @@ class SSPOriginal(ExoDataSource):
 
     id = "SSP"
 
+    #: One-to-one correspondence between "model" codes and date fragments in scenario
+    #: codes.
+    model_date = {
+        "IIASA GDP": "130219",
+        "IIASA-WiC POP": "130115",
+        "NCAR": "130115",
+        "OECD Env-Growth": "130325",
+        "PIK GDP-32": "130424",
+    }
+
+    #: Replacements to apply when loading the data.
+    replace = {"billion US$2005/yr": "billion USD_2005/yr"}
+
     def __init__(self, source, source_kw):
         s = "ICONICS:SSP(2017)."
         if not source.startswith(s):
@@ -52,13 +65,7 @@ class SSPOriginal(ExoDataSource):
         self.model = _kw.pop("model", None)
 
         # Determine the date based on the model ID. There is a 1:1 correspondence.
-        self.date = {
-            "IIASA GDP": "130219",
-            "IIASA-WiC POP": "130115",
-            "NCAR": "130115",
-            "OECD Env-Growth": "130325",
-            "PIK GDP-32": "130424",
-        }.get(self.model)
+        self.date = self.model_date[self.model]
 
         if len(_kw):
             raise ValueError(_kw)
@@ -82,7 +89,7 @@ class SSPOriginal(ExoDataSource):
             path = package_data_path("test", *parts)
             log.warning(f"Reading random data from {path}")
 
-        return iamc_like_data_for_query(path, query)
+        return iamc_like_data_for_query(path, query, replace=self.replace)
 
 
 @register_source

--- a/message_ix_models/project/ssp/data.py
+++ b/message_ix_models/project/ssp/data.py
@@ -12,6 +12,11 @@ from message_ix_models.util import (
     private_data_path,
 )
 
+__all__ = [
+    "SSPOriginal",
+    "SSPUpdate",
+]
+
 log = logging.getLogger(__name__)
 
 
@@ -19,17 +24,34 @@ log = logging.getLogger(__name__)
 class SSPOriginal(ExoDataSource):
     """Provider of exogenous data from the original SSP database.
 
-    In the `source_kw` to :func:`.exo_data.prepare_computer`, the following are valid:
+    To use data from this source, call :func:`.exo_data.prepare_computer` with the
+    arguments:
 
-    ``model``
-       - IIASA POP
-       - IIASA-WiC POP
-       - NCAR
-       - OECD Env-Growth
-       - PIK GDP-32
+    - `source`: Any value from :data:`.SSP_2017` or equivalent string, for instance
+      "ICONICS:SSP(2017).2". The specific SSP for which data is returned is determined
+      from the value.
+    - `source_kw` including:
 
-    The measures available differ according to the model; see the source data for
-    details.
+      - "model": one of:
+
+          - IIASA POP
+          - IIASA-WiC POP
+          - NCAR
+          - OECD Env-Growth
+          - PIK GDP-32
+
+      - "measure": The measures available differ according to the model; see the source
+        data for details.
+
+    Example
+    -------
+    >>> keys = prepare_computer(
+    ...     context,
+    ...     computer,
+    ...     source="ICONICS:SSP(2015).3",
+    ...     source_kw=dict(measure="POP", model="IIASA-WiC POP"),
+    ... )
+    >>> result = computer.get(keys[0])
     """
 
     id = "SSP"
@@ -94,7 +116,24 @@ class SSPOriginal(ExoDataSource):
 
 @register_source
 class SSPUpdate(ExoDataSource):
-    """Provider of exogenous data from the SSP Update database."""
+    """Provider of exogenous data from the SSP Update database.
+
+    To use data from this source, call :func:`.exo_data.prepare_computer` with the
+    arguments:
+
+    - `source`: Any value from :data:`.SSP_2024` or equivalent string, for instance
+      "ICONICS:SSP(2024).2".
+
+    Example
+    -------
+    >>> keys = prepare_computer(
+    ...     context,
+    ...     computer,
+    ...     source="ICONICS:SSP(2024).3",
+    ...     source_kw=dict(measure="GDP", model="IIASA GDP 2023"),
+    ... )
+    >>> result = computer.get(keys[0])
+    """
 
     id = "SSP update"
 

--- a/message_ix_models/project/ssp/data.py
+++ b/message_ix_models/project/ssp/data.py
@@ -1,0 +1,47 @@
+from message_ix_models.tools.exo_data import (
+    ExoDataSource,
+    iamc_like_data_for_query,
+    register_source,
+)
+from message_ix_models.util import private_data_path
+
+
+@register_source
+class SSPUpdate(ExoDataSource):
+    """Provider of exogenous data from the SSP Update database."""
+
+    id = "SSP update"
+
+    def __init__(self, source, source_kw):
+        s = "ICONICS:SSP(2024)."
+        if not source.startswith(s):
+            raise ValueError(source)
+
+        *parts, self.ssp_number = source.partition(s)
+
+        # Map the `measure` keyword to a string appearing in the data
+        self.measure = {
+            "GDP": "GDP|PPP",
+            "POP": "Population",
+        }[source_kw.pop("measure")]
+
+        # Store the model ID, if any
+        self.model = source_kw.pop("model", None)
+
+        if len(source_kw):
+            raise ValueError(source_kw)
+
+    def __call__(self):
+        # Assemble a query string
+        query = " and ".join(
+            [
+                f"Scenario == 'SSP{self.ssp_number} - Review Phase 1'",
+                f"Variable == '{self.measure}'",
+                f"Model == '{self.model}'" if self.model else "True",
+            ]
+        )
+
+        path = private_data_path("ssp", "SSP-Review-Phase-1.csv.gz")
+        assert path.exists(), "TODO handle the case where message_data is not insalled"
+
+        return iamc_like_data_for_query(path, query)

--- a/message_ix_models/project/ssp/data.py
+++ b/message_ix_models/project/ssp/data.py
@@ -16,6 +16,76 @@ log = logging.getLogger(__name__)
 
 
 @register_source
+class SSPOriginal(ExoDataSource):
+    """Provider of exogenous data from the original SSP database.
+
+    In the `source_kw` to :func:`.exo_data.prepare_computer`, the following are valid:
+
+    ``model``
+       - IIASA POP
+       - IIASA-WiC POP
+       - NCAR
+       - OECD Env-Growth
+       - PIK GDP-32
+
+    The measures available differ according to the model; see the source data for
+    details.
+    """
+
+    id = "SSP"
+
+    def __init__(self, source, source_kw):
+        s = "ICONICS:SSP(2017)."
+        if not source.startswith(s):
+            raise ValueError(source)
+
+        *parts, self.ssp_number = source.partition(s)
+
+        # Map the `measure` keyword to a string appearing in the data
+        _kw = copy(source_kw)
+        self.measure = {
+            "GDP": "GDP|PPP",
+            "POP": "Population",
+        }[_kw.pop("measure")]
+
+        # Store the model ID, if any
+        self.model = _kw.pop("model", None)
+
+        # Determine the date based on the model ID. There is a 1:1 correspondence.
+        self.date = {
+            "IIASA GDP": "130219",
+            "IIASA-WiC POP": "130115",
+            "NCAR": "130115",
+            "OECD Env-Growth": "130325",
+            "PIK GDP-32": "130424",
+        }.get(self.model)
+
+        if len(_kw):
+            raise ValueError(_kw)
+
+    def __call__(self):
+        # Assemble a query string
+        extra = "d" if self.ssp_number == "4" and self.model == "IIASA-WiC POP" else ""
+        query = " and ".join(
+            [
+                f"SCENARIO == 'SSP{self.ssp_number}{extra}_v9_{self.date}'",
+                f"VARIABLE == '{self.measure}'",
+                f"MODEL == '{self.model}'" if self.model else "True",
+            ]
+        )
+        log.debug(query)
+
+        parts = ("ssp", "SspDb_country_data_2013-06-12.csv.zip")
+        if HAS_MESSAGE_DATA:
+            path = private_data_path(*parts)
+        else:
+            path = package_data_path("test", *parts)
+            log.warning(f"Reading random data from {path}")
+
+        return iamc_like_data_for_query(path, query)
+
+
+@register_source
 class SSPUpdate(ExoDataSource):
     """Provider of exogenous data from the SSP Update database."""
 

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -16,7 +16,10 @@ from message_ix import Reporter, Scenario
 from message_ix_models import Context, ScenarioInfo
 from message_ix_models.util._logging import mark_time
 
+from .config import Config
+
 __all__ = [
+    "Config",
     "prepare_reporter",
     "register",
     "report",

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -215,6 +215,14 @@ def report(context: Context, *args, **kwargs):
     - ``report/config`` is set to :file:`report/globa.yaml`, if not set.
 
     """
+    try:
+        from ixmp.utils import discard_on_error
+    except ImportError:
+        from contextlib import nullcontext
+
+        def discard_on_error(*args):
+            return nullcontext()
+
     # Handle deprecated usage that appears in:
     # - .model.cli.new_baseline()
     # - .model.create.solve()
@@ -257,7 +265,8 @@ def report(context: Context, *args, **kwargs):
     if context.dry_run:
         return
 
-    result = rep.get(key)
+    with discard_on_error(rep.graph["scenario"]):
+        result = rep.get(key)
 
     # Display information about the result
     log.info(f"Result:\n\n{result}\n")
@@ -475,3 +484,4 @@ def defaults(rep: Reporter, context: Context) -> None:
 
 
 register(defaults)
+register("message_ix_models.report.plot")

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -196,8 +196,8 @@ def report(context: Context, *args, **kwargs):
         The code responds to:
 
         - :attr:`.dry_run`: if :obj:`True`, reporting is prepared but nothing is done.
-        - :attr:`.scenario_info` and :attr:`.platform_info`: used to retrieve the
-          Scenario to be reported.
+        - :attr:`~.Config.scenario_info` and :attr:`~.Config.platform_info`: used to
+          retrieve the Scenario to be reported.
 
         - :py:`context.report`, which is an instance of :class:`.report.Config`; see
           there for available configuration settings.

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -181,37 +181,23 @@ def log_before(context, rep, key) -> None:
 
 
 def report(context: Context, *args, **kwargs):
-    """Run complete reporting on a :class:`.message_ix.Scenario`.
+    """Report (post-process) solution data in a |Scenario| and store time series data.
 
-    This function provides a single, common interface to call both the 'new'
-    (:mod:`.reporting`) and 'legacy' (:mod:`.tools.post_processing`) reporting codes.
+    This function provides a single, common interface to call both the :mod:`genno`
+    -based (:mod:`message_ix_models.report`) and ‘legacy’ (
+    :mod:`message_data.tools.post_processing`) reporting codes.
 
-    The code responds to the following settings on `context`:
+    Parameters
+    ----------
+    context : Context
+        The code responds to:
 
-    .. list-table::
-       :width: 100%
-       :widths: 25 25 50
-       :header-rows: 1
+        - :attr:`.dry_run`: if :obj:`True`, reporting is prepared but nothing is done.
+        - :attr:`.scenario_info` and :attr:`.platform_info`: used to retrieve the
+          Scenario to be reported.
 
-       * - Setting
-         - Type
-         - Description
-       * - scenario_info
-         -
-         - Identifies the (solved) scenario to be reported.
-       * - report/dry_run
-         - bool
-         - Only show what would be done. Default: :data:`False`.
-       * - report/legacy
-         - dict or None
-         - If given, the old-style reporting in :mod:`.iamc_report_hackathon` is used,
-           with `legacy` as keyword arguments.
-
-    As well:
-
-    - ``report/key`` is set to ``default``, if not set.
-    - ``report/config`` is set to :file:`report/globa.yaml`, if not set.
-
+        - :py:`context.report`, which is an instance of :class:`.report.Config`; see
+          there for available configuration settings.
     """
     try:
         from ixmp.utils import discard_on_error
@@ -301,39 +287,11 @@ def prepare_reporter(
 ) -> Tuple[Reporter, Key]:
     """Return a :class:`message_ix.Reporter` and `key` prepared to report a |Scenario|.
 
-    The code responds to the following settings on `context`:
-
-    .. list-table::
-       :width: 100%
-       :widths: 25 25 50
-       :header-rows: 1
-
-       * - Setting
-         - Type
-         - Description
-       * - scenario_info
-         -
-         - Identifies the (solved) scenario to be reported.
-       * - report/key
-         - str or :class:`ixmp.reporting.Key`
-         - Quantity or node to compute. The computation is not triggered (i.e.
-           :meth:`get <ixmp.reporting.Reporter.get>` is not called); but the
-           corresponding, full-resolution Key, if any, is returned.
-       * - report/config
-         - dict or Path-like or None
-         - If :class:`dict`, then this is passed to
-           :meth:`message_ix.Reporter.configure`. If Path-like, then this is the path to
-           the reporting configuration file. If not given, defaults to
-           :file:`report/global.yaml`.
-       * - report/output_path
-         - Path-like, *optional*
-         - Path to write reporting outputs. If given, a computation ``cli-output`` is
-           added to the Reporter which writes ``report/key`` to this path.
-
     Parameters
     ----------
     context : Context
-        Containing settings in the ``report/*`` tree.
+        The code responds to :py:`context.report`, which is an instance of
+        :class:`.report.Config`.
     scenario : Scenario, *optional*
         Scenario to report. If not given, :meth:`.Context.get_scenario` is used to
         retrieve a Scenario.
@@ -346,9 +304,12 @@ def prepare_reporter(
     .Reporter
         Reporter prepared with MESSAGEix-GLOBIOM calculations; if `reporter` is given,
         this is a reference to the same object.
+
+        If :attr:`.cli_output` is given, a task with the key "cli-output" is added that
+        writes the :attr:`.Config.key` to that path.
     .Key
-        Same as ``context.report["key"]`` if any, but in full resolution; else one of
-        ``default`` or ``cli-output`` according to the other settings.
+        Same as :attr:`.Config.key` if any, but in full resolution; else either
+        "default" or "cli-output" according to the other settings.
     """
     from importlib.metadata import version
 

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -146,12 +146,12 @@ def register(name_or_callback: Union[Callable, str]) -> Optional[str]:
     if isinstance(name_or_callback, str):
         # Resolve a string
         for name in [
+            # As a fully-resolved package/module name
+            name_or_callback,
             # As a submodule of message_ix_models
             f"message_ix_models.{name_or_callback}.report",
             # As a submodule of message_data
             f"message_data.{name_or_callback}.report",
-            # As a fully-resolved package/module name
-            name_or_callback,
         ]:
             try:
                 mod = import_module(name)

--- a/message_ix_models/report/cli.py
+++ b/message_ix_models/report/cli.py
@@ -6,7 +6,6 @@ import click
 import yaml
 
 from message_ix_models.report import register, report
-from message_ix_models.util import local_data_path, private_data_path
 from message_ix_models.util._logging import mark_time
 from message_ix_models.util.click import common_params
 
@@ -52,11 +51,13 @@ def cli(context, config_file, legacy, module, output_path, from_file, key, dry_r
     With --from-file, read multiple Scenario identifiers from FILE, and report each one.
     In this usage, --output-path may only be a directory.
     """
+    from message_ix_models.util import local_data_path, package_data_path
+
     # --config: use the option value as if it were an absolute path
     config = Path(config_file)
     if not config.exists():
         # Path doesn't exist; treat it as a stem in the metadata dir
-        config = private_data_path("report", config_file).with_suffix(".yaml")
+        config = package_data_path("report", config_file).with_suffix(".yaml")
 
     if not config.exists():
         # Can't find the file

--- a/message_ix_models/report/cli.py
+++ b/message_ix_models/report/cli.py
@@ -1,19 +1,24 @@
 import logging
-from copy import copy
 from pathlib import Path
 
 import click
-import yaml
 
-from message_ix_models.report import register, report
-from message_ix_models.util._logging import mark_time
 from message_ix_models.util.click import common_params
 
 log = logging.getLogger(__name__)
 
 
+def _modules_arg(context, param, value):
+    """--module/-m: load extra reporting config from modules."""
+    from . import register
+
+    for m in filter(len, value.split(",")):
+        name = register(m)
+        log.info(f"Registered reporting from {name}")
+
+
 @click.command(name="report")
-@common_params("dry_run")
+@common_params("dry_run urls_from_file")
 @click.option(
     "--config",
     "config_file",
@@ -21,25 +26,27 @@ log = logging.getLogger(__name__)
     show_default=True,
     help="Path or stem for reporting config file.",
 )
-@click.option("--legacy", "-L", is_flag=True, help="Invoke legacy reporting.")
+@click.option("--legacy", "-L", is_flag=True, help="Invoke 'legacy' reporting.")
 @click.option(
-    "--module", "-m", metavar="MODULES", help="Add extra reporting for MODULES."
+    "--module",
+    "-m",
+    "modules",
+    metavar="MODULES",
+    default="",
+    help="Add extra reporting for MODULES.",
+    callback=_modules_arg,
 )
 @click.option(
-    "-o",
     "--output",
-    "output_path",
-    type=Path,
-    help="Write output to file instead of console.",
-)
-@click.option(
-    "--from-file",
-    type=click.Path(exists=True, dir_okay=False),
-    help="Report multiple Scenarios listed in FILE.",
+    "-o",
+    "cli_output",
+    metavar="PATH",
+    type=click.Path(writable=True, resolve_path=True, path_type=Path),
+    help="Write output to PATH instead of console or default locations.",
 )
 @click.argument("key", default="message::default")
 @click.pass_obj
-def cli(context, config_file, legacy, module, output_path, from_file, key, dry_run):
+def cli(context, config_file, legacy, cli_output, key, **kwargs):
     """Postprocess results.
 
     KEY defaults to the comprehensive report 'message::default', but may also be the
@@ -48,75 +55,42 @@ def cli(context, config_file, legacy, module, output_path, from_file, key, dry_r
     --config can give either the absolute path to a reporting configuration file, or
     the stem (i.e. name without .yaml extension) of a file in data/report.
 
-    With --from-file, read multiple Scenario identifiers from FILE, and report each one.
-    In this usage, --output-path may only be a directory.
+    With --urls-from-file, read multiple Scenario identifiers from FILE, and report each
+    one. In this usage, --output-path may only be a directory.
     """
-    from message_ix_models.util import local_data_path, package_data_path
+    from copy import deepcopy
 
-    # --config: use the option value as if it were an absolute path
-    config = Path(config_file)
-    if not config.exists():
-        # Path doesn't exist; treat it as a stem in the metadata dir
-        config = package_data_path("report", config_file).with_suffix(".yaml")
+    from message_ix_models.util._logging import mark_time
 
-    if not config.exists():
-        # Can't find the file
-        raise FileNotFoundError(f"Reporting configuration --config={config}")
+    from . import report
+    from .config import Config
 
-    # --output/-o: handle "~"
-    output_path = output_path.expanduser() if output_path else None
+    # Update the reporting configuration from command-line parameters
+    context.report = Config(
+        from_file=config_file, key=key, cli_output=cli_output, _legacy=legacy
+    )
 
-    # --module/-m: load extra reporting config from modules
-    module = module or ""
-    for m in filter(len, module.split(",")):
-        name = register(m)
-        log.info(f"Registered reporting from {name}")
-
-    # Common settings to apply in all contexts
-    common = dict(config=config, key=key)
-
-    # --legacy/-L: cue report() to invoke the legacy, instead of genno-based reporting
-    if legacy:
-        common["legacy"] = dict()
-
-    # Prepare a list of Context objects, each referring to one Scenario
+    # Prepare a list of Context objects, each referring to one Scenario.
     contexts = []
 
-    if from_file:
-        # Multiple URLs
-        if not output_path.is_dir():
-            raise click.BadOptionUsage(
-                "--output-path must be directory with --from-file"
+    # - If --urls-from-file was given, then `context.scenarios` will contain a list of
+    #   ScenarioInfo objects that point to the platform and (model, scenario, version)
+    #   identifiers.
+    # - Otherwise, the user gave identifiers for a single Scenario to the top-level CLI
+    #   (--url/--platform/--model/--scenario/--version) and these are stored in
+    #   `context.platform_info` and `context.scenario_info`.
+    for si in context.scenarios or [context.scenario_info]:
+        ctx = deepcopy(context)
+        ctx.platform_info = dict(
+            name=getattr(
+                si, "platform_name", context.platform_info.get("name", "default")
             )
-
-        for item in yaml.safe_load(open(from_file)):
-            # Copy the existing Context to a new object
-            ctx = copy(context)
-
-            # Update with Scenario info from file
-            ctx.handle_cli_args(**item)
-
-            # Construct an output path from the parsed info/URL
-            ctx.output_path = Path(
-                output_path,
-                "_".join(
-                    [
-                        ctx.platform_info["name"],
-                        ctx.scenario_info["model"],
-                        ctx.scenario_info["scenario"],
-                    ]
-                ),
-            ).with_suffix(".xlsx")
-
-            contexts.append(ctx)
-    else:
-        # Single Scenario; identifiers were supplied to the top-level CLI
-        context.output_path = output_path
-        context["report"] = dict(output_dir=local_data_path("report"))
-        contexts.append(context)
+        )
+        ctx.scenario_info = dict(si)
+        contexts.append(ctx)
 
     for ctx in contexts:
-        # Update with common settings
-        context["report"].update(common)
-        report(ctx)
         mark_time()
+        report(ctx)
+
+    mark_time()

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -88,10 +88,16 @@ def add_exogenous_data(
     )
 
 
-def filter_ts(df: pd.DataFrame, expr: re.Pattern) -> pd.DataFrame:
-    """Filter time series data in `df`."""
-    return df[df["variable"].str.fullmatch(expr)].assign(
-        variable=df["variable"].str.replace(expr, r"\1", regex=True)
+def filter_ts(df: pd.DataFrame, expr: re.Pattern, *, column="variable") -> pd.DataFrame:
+    """Filter time series data in `df`.
+
+    1. Keep only rows in `df` where `expr` is a full match (
+       :meth:`~pandas.Series.str.fullmatch`) for the entry in `column`.
+    2. Retain only the first match group ("...(...)...") from `expr` as the `column`
+       entry.
+    """
+    return df[df[column].str.fullmatch(expr)].assign(
+        variable=df[column].str.replace(expr, r"\1", regex=True)
     )
 
 

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -43,12 +43,14 @@ def codelist_to_groups(
     The returned value is suitable for use with :func:`genno.computations.aggregate`.
 
     If this is a list of nodes per :func:`.get_codes`, then the mapping is from regions
-    to the ISO 3166-1 alpha-3 codes of the countries within each region.
+    to the ISO 3166-1 alpha-3 codes of the countries within each region. The code for
+    the region itself is also included in the values to be aggregated, so that already-
+    aggregated data will pass through.
     """
 
     groups = dict()
     for code in filter(lambda c: len(c.child), codes):
-        groups[code.id] = list(map(str, code.child))
+        groups[code.id] = [code.id] + list(map(str, code.child))
 
     return {dim: groups}
 

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -74,7 +74,7 @@ def exogenous_data():
 @exogenous_data.helper
 def add_exogenous_data(
     func, c: "Computer", *, context=None, source=None, source_kw=None
-) -> Tuple["Key"]:
+) -> Tuple["Key", ...]:
     """Prepare `c` to compute exogenous data from `source`."""
     from message_ix_models.tools.exo_data import prepare_computer
 

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -1,6 +1,7 @@
 """Atomic reporting operations for MESSAGEix-GLOBIOM."""
 import itertools
 import logging
+import re
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Set, Tuple, Union
 
 import ixmp
@@ -20,6 +21,10 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "codelist_to_groups",
+    "compound_growth",
+    "exogenous_data",
+    "filter_ts",
     "from_url",
     "get_ts",
     "gwp_factors",
@@ -80,6 +85,13 @@ def add_exogenous_data(
 
     return prepare_computer(
         context or Context.get_instance(-1), c, source=source, source_kw=source_kw
+    )
+
+
+def filter_ts(df: pd.DataFrame, expr: re.Pattern) -> pd.DataFrame:
+    """Filter time series data in `df`."""
+    return df[df["variable"].str.fullmatch(expr)].assign(
+        variable=df["variable"].str.replace(expr, r"\1", regex=True)
     )
 
 

--- a/message_ix_models/report/config.py
+++ b/message_ix_models/report/config.py
@@ -93,7 +93,7 @@ class Config(ConfigHelper):
                 )
             )
         except StopIteration:
-            raise FileNotFoundError(f"Reporting configuration in {file_path}")
+            raise FileNotFoundError(f"Reporting configuration in '{file_path}(.yaml)'")
 
         # Store for genno to handle
         self.genno_config["path"] = path

--- a/message_ix_models/report/config.py
+++ b/message_ix_models/report/config.py
@@ -14,7 +14,11 @@ log = logging.getLogger(__name__)
 
 @dataclass
 class Config(ConfigHelper):
-    """Settings for :mod:`message_ix_models.report`."""
+    """Settings for :mod:`message_ix_models.report`.
+
+    When initializing a new instance, the `from_file` and `_legacy` parameters are
+    respected.
+    """
 
     #: Shorthand to call :func:`use_file` on a new instance.
     from_file: InitVar[Optional[Path]] = package_data_path("report", "global.yaml")
@@ -51,9 +55,10 @@ class Config(ConfigHelper):
         self.legacy.update(use=_legacy)
 
     def set_output_dir(self, arg: Optional[Path]) -> None:
-        """Set the output directory.
+        """Set :attr:`output_dir`, the output directory.
 
-        The value is also passed to :mod:`genno` as the "output_dir" configuration key.
+        The value is also stored to be passed to :mod:`genno` as the "output_dir"
+        configuration key.
         """
         if arg:
             self.output_dir = arg.expanduser()
@@ -64,7 +69,7 @@ class Config(ConfigHelper):
         """Use genno configuration from a (YAML) file at `file_path`.
 
         See :mod:`genno.config` for the format of these files. The path is stored at
-        :py:`.genno_config["path]`, where it is picked up by genno's configuration
+        :py:`.genno_config["path"]`, where it is picked up by genno's configuration
         mechanism.
 
         Parameters

--- a/message_ix_models/report/config.py
+++ b/message_ix_models/report/config.py
@@ -1,0 +1,104 @@
+import logging
+from dataclasses import InitVar, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+from message_ix_models.util import local_data_path, package_data_path
+from message_ix_models.util.config import ConfigHelper
+
+if TYPE_CHECKING:
+    from genno.core.key import KeyLike
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class Config(ConfigHelper):
+    """Settings for :mod:`message_ix_models.report`."""
+
+    #: Shorthand to call :func:`use_file` on a new instance.
+    from_file: InitVar[Optional[Path]] = package_data_path("report", "global.yaml")
+
+    #: Shorthand to set :py:`legacy["use"]` on a new instance.
+    _legacy: InitVar[Optional[bool]] = False
+
+    #: Path to write reporting outputs when invoked from the command line.
+    cli_output: Optional[Path] = None
+
+    #: Configuration to be handled by :mod:`genno.config`.
+    genno_config: Dict = field(default_factory=dict)
+
+    #: Key for the Quantity or computation to report.
+    key: Optional["KeyLike"] = None
+
+    #: Directory for output.
+    output_dir: Optional[Path] = field(
+        default_factory=lambda: local_data_path("report")
+    )
+
+    #: :data:`True` to use an output directory based on the scenario's model name and
+    #: name.
+    use_scenario_path: bool = True
+
+    #: Keyword arguments for the ‘legacy’ reporting entry point
+    #: (:func:`message_data.tools.post_processing.iamc_report_hackathon.report`), plus
+    #: the special key "use", which should be :data:`True` if legacy reporting is to
+    #: be used.
+    legacy: Dict = field(default_factory=lambda: dict(use=False, merge_hist=True))
+
+    def __post_init__(self, from_file, _legacy) -> None:
+        self.use_file(from_file)
+        self.legacy.update(use=_legacy)
+
+    def set_output_dir(self, arg: Optional[Path]) -> None:
+        """Set the output directory.
+
+        The value is also passed to :mod:`genno` as the "output_dir" configuration key.
+        """
+        if arg:
+            self.output_dir = arg.expanduser()
+
+        self.genno_config["output_dir"] = self.output_dir
+
+    def use_file(self, file_path: Union[str, Path, None]) -> None:
+        """Use genno configuration from a (YAML) file at `file_path`.
+
+        See :mod:`genno.config` for the format of these files. The path is stored at
+        :py:`.genno_config["path]`, where it is picked up by genno's configuration
+        mechanism.
+
+        Parameters
+        ----------
+        file_path : PathLike, *optional*
+            This may be:
+
+            1. The complete path to any existing file.
+            2. A stem like "global" or "other". This is interpreted as referring to a
+               file named, for instance, :file:`global.yaml`.
+            3. A partial path like "project/report.yaml". This or (2) is interpreted
+               as referring to a file within :file:`MESSAGE_MODELS_PATH/data/report/`;
+               that is, a file packaged and distributed with :mod:`message_ix_models`.
+        """
+        if file_path is None:
+            return
+        try:
+            path = next(
+                filter(
+                    Path.exists,
+                    (
+                        Path(file_path),
+                        # Path doesn't exist; treat it as a stem in the metadata dir
+                        package_data_path("report", file_path).with_suffix(".yaml"),
+                    ),
+                )
+            )
+        except StopIteration:
+            raise FileNotFoundError(f"Reporting configuration in {file_path}")
+
+        # Store for genno to handle
+        self.genno_config["path"] = path
+
+    def mkdir(self) -> None:
+        """Ensure the :attr:`output_dir` exists."""
+        if self.output_dir:
+            self.output_dir.mkdir(exist_ok=True, parents=True)

--- a/message_ix_models/report/plot.py
+++ b/message_ix_models/report/plot.py
@@ -1,7 +1,7 @@
 """Plots for MESSAGEix-GLOBIOM reporting.
 
-The current set functions on time series data stored on the scenario by :mod:`.report`
-or legacy reporting.
+The current set functions on time series data stored on the scenario by
+:mod:`message_ix_models.report` or :mod:`message_data` legacy reporting.
 """
 import logging
 import re
@@ -18,6 +18,17 @@ if TYPE_CHECKING:
     from message_ix import Scenario
 
     from message_ix_models import Context
+
+__all__ = [
+    "PLOTS",
+    "EmissionsCO2",
+    "FinalEnergy0",
+    "FinalEnergy1",
+    "Plot",
+    "PrimaryEnergy0",
+    "PrimaryEnergy1",
+    "callback",
+]
 
 log = logging.getLogger(__name__)
 
@@ -198,6 +209,7 @@ class PrimaryEnergy1(FinalEnergy1):
     inputs_regex = [re.compile(rf"Primary Energy\|((?!{'|'.join(_omit)})[^\|]*)")]
 
 
+#: All plot classes.
 PLOTS = (
     EmissionsCO2,
     FinalEnergy0,
@@ -208,6 +220,10 @@ PLOTS = (
 
 
 def callback(c: Computer, context: "Context") -> None:
+    """Add all :data:`PLOTS` to `c`.
+
+    Also add a key "plot all" to triggers the generation of all plots.
+    """
     all_keys = [c.add(f"plot {p.basename}", p, "scenario") for p in PLOTS]
     c.add("plot all", all_keys)
     log.info(f"Add 'plot all' collecting {len(all_keys)} plots")

--- a/message_ix_models/report/plot.py
+++ b/message_ix_models/report/plot.py
@@ -1,0 +1,186 @@
+"""Plots for MESSAGEix-GLOBIOM reporting.
+
+The current set functions on time series data stored on the scenario by :mod:`.report`
+or legacy reporting.
+"""
+import logging
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional, Sequence
+
+import genno.compat.plotnine
+import pandas as pd
+import plotnine as p9
+from genno import Computer, Key
+
+if TYPE_CHECKING:
+    from message_ix import Scenario
+
+    from message_ix_models import Context
+
+log = logging.getLogger(__name__)
+
+
+class Plot(genno.compat.plotnine.Plot):
+    """Base class for plots."""
+
+    #: 'Static' geoms: list of plotnine objects that are not dynamic.
+    static = [p9.theme(figure_size=(11.7, 8.3))]
+
+    #: Fixed plot title string. If not given, the first line of the class docstring is
+    #: used.
+    title = None
+
+    #: Units expression for plot title.
+    unit = None
+
+    #: Scenario URL for plot title.
+    url: Optional[str] = None
+
+    # NB only here to narrow typing
+    inputs: Sequence[str] = []
+    #: List of regular expressions corresponding to :attr:`inputs`.
+    inputs_regex: List[re.Pattern] = []
+
+    def ggtitle(self, value=None) -> p9.ggtitle:
+        """Return :class:`plotnine.ggtitle` including the current date & time."""
+        title_pieces = [
+            (self.title or self.__doc__ or "").splitlines()[0].rstrip("."),
+            f"[{self.unit}]" if self.unit else None,
+            value,
+            "\n",
+            self.url,
+            f"({datetime.now().isoformat(timespec='minutes')})",
+        ]
+        return p9.ggtitle(" ".join(filter(None, title_pieces)))
+
+    def groupby_plot(self, data: pd.DataFrame, *args):
+        """Combination of groupby and ggplot().
+
+        Groups by `args` and yields a series of :class:`plotnine.ggplot` objects, one
+        per group, with :attr:`static` geoms and :func:`ggtitle` appended to each.
+        """
+        for group_key, group_df in data.groupby(*args):
+            yield group_key, (
+                p9.ggplot(group_df)
+                + self.static
+                + self.ggtitle(
+                    group_key if isinstance(group_key, str) else repr(group_key)
+                )
+            )
+
+
+class EmissionsCO2(Plot):
+    """CO₂ Emissions."""
+
+    basename = "emission-CO2"
+    inputs = ["Emissions|CO2::iamc", "scenario"]
+
+    static = Plot.static + [
+        p9.aes(x="year", y="value", color="region"),
+        p9.geom_line(),
+        p9.geom_point(),
+        p9.labs(x="Period", y=None, color="Region"),
+    ]
+
+    def generate(self, data: pd.DataFrame, scenario: "Scenario"):
+        self.url = scenario.url
+        self.unit = data["unit"].unique()[0]
+
+        for _, ggplot in self.groupby_plot(data, data.region.str.contains("GLB")):
+            y_max = max(ggplot.data["value"])
+            yield ggplot + p9.expand_limits(y=[0, y_max]) + self.ggtitle("")
+
+
+class FinalEnergy0(EmissionsCO2):
+    """Final Energy."""
+
+    basename = "fe0"
+    inputs = ["Final Energy::iamc", "scenario"]
+
+
+class FinalEnergy1(Plot):
+    """Final Energy."""
+
+    basename = "fe1"
+    inputs = ["fe1-0::iamc", "scenario"]
+
+    _c = [
+        "Electricity",
+        "Gases",
+        "Geothermal",
+        "Heat",
+        "Hydrogen",
+        "Liquids",
+        "Solar",
+        "Solids",
+    ]
+    inputs_regex = [re.compile(rf"Final Energy\|({'|'.join(_c)})")]
+
+    static = Plot.static + [
+        p9.aes(x="year", y="value", fill="variable"),
+        p9.geom_bar(stat="identity", size=5.0),  # 5.0 is the minimum spacing of "year"
+        p9.labs(x="Period", y=None, fill="Commodity"),
+    ]
+
+    def generate(self, data: pd.DataFrame, scenario: "Scenario"):
+        self.url = scenario.url
+        self.unit = data["unit"].unique()[0]
+
+        for _, ggplot in self.groupby_plot(data, "region"):
+            yield ggplot
+
+
+class PrimaryEnergy0(EmissionsCO2):
+    """Primary Energy."""
+
+    basename = "pe0"
+    inputs = ["Primary Energy::iamc", "scenario"]
+
+
+class PrimaryEnergy1(FinalEnergy1):
+    """Primary Energy."""
+
+    basename = "pe1"
+    inputs = ["pe1-0::iamc", "scenario"]
+
+    _omit = ["Fossil", "Non-Biomass Renewables", "Secondary Energy Trade"]
+    inputs_regex = [re.compile(rf"Primary Energy\|((?!{'|'.join(_omit)})[^\|]*)")]
+
+
+PLOTS = (
+    EmissionsCO2,
+    FinalEnergy0,
+    FinalEnergy1,
+    PrimaryEnergy0,
+    PrimaryEnergy1,
+)
+
+
+def callback(c: Computer, context: "Context") -> None:
+    from copy import copy
+    from itertools import zip_longest
+
+    all_keys = []
+
+    # Retrieve all time series data, for advanced filtering
+    c.add("all::iamc", "get_ts", "scenario")
+
+    for p in PLOTS:
+        # TODO move these into an override of Plot.add_tasks()
+        if len(p.inputs_regex):
+            # Iterate over matched items from `inputs` and `inputs_regex`
+            for key, expr in zip_longest(p.inputs, p.inputs_regex):
+                if expr is None:
+                    break
+                # Filter the data given by `expr` from all::iamc
+                c.add(key, "filter_ts", "all::iamc", copy(expr))
+        else:
+            for key in map(Key, p.inputs):
+                # Add a computation to get the time series data for a specific variable
+                c.add(key, "get_ts", "scenario", dict(variable=key.name))
+
+        # Add the plot itself
+        all_keys.append(c.add(f"plot {p.basename}", p))
+
+    c.add("plot all", all_keys)

--- a/message_ix_models/report/plot.py
+++ b/message_ix_models/report/plot.py
@@ -210,3 +210,4 @@ PLOTS = (
 def callback(c: Computer, context: "Context") -> None:
     all_keys = [c.add(f"plot {p.basename}", p, "scenario") for p in PLOTS]
     c.add("plot all", all_keys)
+    log.info(f"Add 'plot all' collecting {len(all_keys)} plots")

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -161,7 +161,10 @@ configure(
 
 def dims_of(info: dict) -> Dict[str, str]:
     """Return a mapping from the full index names to short dimension IDs of `info`."""
-    return {d: RENAME_DIMS.get(d, d) for d in info.get("idx_names") or info["idx_sets"]}
+    return {
+        d: RENAME_DIMS.get(d, d)
+        for d in (info.get("idx_names") or info.get("idx_sets") or [])
+    }
 
 
 def simulate_qty(
@@ -269,7 +272,6 @@ def add_simulated_solution(
 
         # Add a task to load data from a file in `path`, if it exists
         try:
-            # Candidate path
             assert path is not None
             p = path.joinpath(name).with_suffix(".csv.gz")
             assert p.exists()
@@ -277,7 +279,6 @@ def add_simulated_solution(
             pass  # No `path` or no such file
         else:
             # Add data from file
-
             rep.add(key, data_from_file, p, name=name, dims=key.dims, sums=True)
             continue
 

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -2,114 +2,287 @@ import logging
 from collections import ChainMap, defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Any, Dict, Optional, Tuple
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Union
 
 import pandas as pd
 from dask.core import quote
+from genno import configure
 from ixmp.reporting import RENAME_DIMS
-from message_ix.models import MESSAGE_ITEMS
+from message_ix.models import MESSAGE_ITEMS, item
 from message_ix.reporting import Key, KeyExistsError, Quantity, Reporter
 from pandas.api.types import is_scalar
 
 from message_ix_models import ScenarioInfo
-from message_ix_models.util._logging import silence_log
+from message_ix_models.util._logging import mark_time, silence_log
 
+log = logging.getLogger(__name__)
 
-# Shorthand for MESSAGE_VARS, below
-def item(ix_type, idx_names):
-    return dict(ix_type=ix_type, idx_names=tuple(idx_names.split()))
-
-
-# Copied from message_ix.models.MESSAGE_ITEMS, where these entries are commented because
-# of JDBCBackend limitations.
+# Copied and expanded from message_ix.models.MESSAGE_ITEMS, where these entries are
+# commented because of JDBCBackend limitations.
 # TODO read from that location once possible
 MESSAGE_VARS = {
     # Activity
     "ACT": item("var", "nl t yv ya m h"),
+    # "ACTIVITY_BOUND_ALL_MODES_LO": item("var", ""),
+    # "ACTIVITY_BOUND_ALL_MODES_UP": item("var", ""),
+    # "ACTIVITY_BOUND_LO": item("var", ""),
+    # "ACTIVITY_BOUND_UP": item("var", ""),
+    # "ACTIVITY_BY_RATING": item("var", ""),
+    # "ACTIVITY_CONSTRAINT_LO": item("var", ""),
+    # "ACTIVITY_CONSTRAINT_UP": item("var", ""),
+    # "ACTIVITY_RATING_TOTAL": item("var", ""),
+    # "ACTIVITY_SOFT_CONSTRAINT_LO": item("var", ""),
+    # "ACTIVITY_SOFT_CONSTRAINT_UP": item("var", ""),
+    # "ACT_LO": item("var", ""),
+    # "ACT_RATING": item("var", ""),
+    # "ACT_UP": item("var", ""),
+    # "ADDON_ACTIVITY_LO": item("var", ""),
+    # "ADDON_ACTIVITY_UP": item("var", ""),
     # Maintained capacity
     "CAP": item("var", "nl t yv ya"),
+    # "CAPACITY_CONSTRAINT": item("var", ""),
+    # "CAPACITY_MAINTENANCE": item("var", ""),
+    # "CAPACITY_MAINTENANCE_HIST": item("var", ""),
+    # "CAPACITY_MAINTENANCE_NEW": item("var", ""),
+    # "CAP_FIRM": item("var", ""),
     # New capacity
     "CAP_NEW": item("var", "nl t yv"),
+    # "CAP_NEW_LO": item("var", ""),
+    # "CAP_NEW_UP": item("var", ""),
+    # "COMMODITY_BALANCE_GT": item("var", ""),
+    # "COMMODITY_BALANCE_LT": item("var", ""),
+    # "COMMODITY_USE": item("var", ""),
+    # "COMMODITY_USE_LEVEL": item("var", ""),
+    # "COST_ACCOUNTING_NODAL": item("var", ""),
+    # "COST_NODAL": item("var", ""),
+    # "COST_NODAL_NET": item("var", ""),
+    # "DEMAND": item("var", ""),
+    # "DYNAMIC_LAND_SCEN_CONSTRAINT_LO": item("var", ""),
+    # "DYNAMIC_LAND_SCEN_CONSTRAINT_UP": item("var", ""),
+    # "DYNAMIC_LAND_TYPE_CONSTRAINT_LO": item("var", ""),
+    # "DYNAMIC_LAND_TYPE_CONSTRAINT_UP": item("var", ""),
     # Emissions
     "EMISS": item("var", "n e type_tec y"),
+    # "EMISSION_CONSTRAINT": item("var", ""),
+    # "EMISSION_EQUIVALENCE": item("var", ""),
     # Extraction
     "EXT": item("var", "n c g y"),
+    # "EXTRACTION_BOUND_UP": item("var", ""),
+    # "EXTRACTION_EQUIVALENCE": item("var", ""),
+    # "FIRM_CAPACITY_PROVISION": item("var", ""),
+    # "GDP": item("var", ""),
     # Land scenario share
     "LAND": item("var", "n land_scenario y"),
+    # "LAND_CONSTRAINT": item("var", ""),
+    # "MIN_UTILIZATION_CONSTRAINT": item("var", ""),
+    # "NEW_CAPACITY_BOUND_LO": item("var", ""),
+    # "NEW_CAPACITY_BOUND_UP": item("var", ""),
+    # "NEW_CAPACITY_CONSTRAINT_LO": item("var", ""),
+    # "NEW_CAPACITY_CONSTRAINT_UP": item("var", ""),
+    # "NEW_CAPACITY_SOFT_CONSTRAINT_LO": item("var", ""),
+    # "NEW_CAPACITY_SOFT_CONSTRAINT_UP": item("var", ""),
     # Objective (scalar)
-    "OBJ": dict(ix_type="var", idx_names=[]),
+    "OBJ": dict(ix_type="var", idx_sets=[]),
+    # "OBJECTIVE": item("var", ""),
+    # "OPERATION_CONSTRAINT": item("var", ""),
     # Price of emissions
     "PRICE_COMMODITY": item("var", "n c l y h"),
     # Price of emissions
     "PRICE_EMISSION": item("var", "n e t y"),
     # Relation (lhs)
     "REL": item("var", "relation nr yr"),
+    # "RELATION_CONSTRAINT_LO": item("var", ""),
+    # "RELATION_CONSTRAINT_UP": item("var", ""),
+    # "RELATION_EQUIVALENCE": item("var", ""),
+    # "REN": item("var", ""),
+    # "RENEWABLES_CAPACITY_REQUIREMENT": item("var", ""),
+    # "RENEWABLES_EQUIVALENCE": item("var", ""),
+    # "RENEWABLES_POTENTIAL_CONSTRAINT": item("var", ""),
+    # "RESOURCE_CONSTRAINT": item("var", ""),
+    # "RESOURCE_HORIZON": item("var", ""),
+    # "SHARE_CONSTRAINT_COMMODITY_LO": item("var", ""),
+    # "SHARE_CONSTRAINT_COMMODITY_UP": item("var", ""),
+    # "SHARE_CONSTRAINT_MODE_LO": item("var", ""),
+    # "SHARE_CONSTRAINT_MODE_UP": item("var", ""),
+    # "SLACK_ACT_BOUND_LO": item("var", ""),
+    # "SLACK_ACT_BOUND_UP": item("var", ""),
+    # "SLACK_ACT_DYNAMIC_LO": item("var", ""),
+    # "SLACK_ACT_DYNAMIC_UP": item("var", ""),
+    # "SLACK_CAP_NEW_BOUND_LO": item("var", ""),
+    # "SLACK_CAP_NEW_BOUND_UP": item("var", ""),
+    # "SLACK_CAP_NEW_DYNAMIC_LO": item("var", ""),
+    # "SLACK_CAP_NEW_DYNAMIC_UP": item("var", ""),
+    # "SLACK_CAP_TOTAL_BOUND_LO": item("var", ""),
+    # "SLACK_CAP_TOTAL_BOUND_UP": item("var", ""),
+    # "SLACK_COMMODITY_EQUIVALENCE_LO": item("var", ""),
+    # "SLACK_COMMODITY_EQUIVALENCE_UP": item("var", ""),
+    # "SLACK_LAND_SCEN_LO": item("var", ""),
+    # "SLACK_LAND_SCEN_UP": item("var", ""),
+    # "SLACK_LAND_TYPE_LO": item("var", ""),
+    # "SLACK_LAND_TYPE_UP": item("var", ""),
+    # "SLACK_RELATION_BOUND_LO": item("var", ""),
+    # "SLACK_RELATION_BOUND_UP": item("var", ""),
     # Stock
     "STOCK": item("var", "n c l y"),
+    # "STOCK_CHG": item("var", ""),
+    # "STOCKS_BALANCE": item("var", ""),
+    # "STORAGE": item("var", ""),
+    # "STORAGE_BALANCE": item("var", ""),
+    # "STORAGE_BALANCE_INIT": item("var", ""),
+    # "STORAGE_CHANGE": item("var", ""),
+    # "STORAGE_CHARGE": item("var", ""),
+    # "STORAGE_INPUT": item("var", ""),
+    # "SYSTEM_FLEXIBILITY_CONSTRAINT": item("var", ""),
+    # "SYSTEM_RELIABILITY_CONSTRAINT": item("var", ""),
+    # "TOTAL_CAPACITY_BOUND_LO": item("var", ""),
+    # "TOTAL_CAPACITY_BOUND_UP": item("var", ""),
 }
 
+# Items to included in a simulated solution: MESSAGE sets and parameters; some variables
+SIMULATE_ITEMS = deepcopy(MESSAGE_ITEMS)
+# Other MESSAGE variables
+SIMULATE_ITEMS.update(MESSAGE_VARS)
+# MACRO variables
+SIMULATE_ITEMS.update(
+    {
+        "GDP": item("var", "n y"),
+        "MERtoPPP": item("var", "n y"),
+    }
+)
 
-def simulate_qty(name: str, item_info: dict, **data_kw: Any) -> Tuple[Key, Quantity]:
+configure(
+    rename_dims=dict(
+        node_rel="nr",
+        year_rel="yr",
+    ),
+)
+
+
+def dims_of(info: dict) -> Dict[str, str]:
+    """Return a mapping from the full index names to short dimension IDs of `info`."""
+    return {d: RENAME_DIMS.get(d, d) for d in info.get("idx_names") or info["idx_sets"]}
+
+
+def simulate_qty(
+    name: str, info: dict, item_data: Union[dict, pd.DataFrame]
+) -> Quantity:
     """Return simulated data for item `name`."""
-    # NB this is code lightly modified from make_df
-
     # Dimensions of the resulting quantity
-    dims = list(
-        map(
-            lambda d: RENAME_DIMS.get(d, d),
-            item_info.get("idx_names", []) or item_info.get("idx_sets", []),
-        )
-    )
+    dims = list(dims_of(info).values())
 
-    # Default values for every column
-    data: Mapping = ChainMap(data_kw, defaultdict(lambda: None))
+    if isinstance(item_data, dict):
+        # NB this is code lightly modified from make_df
 
-    # Arguments for pd.DataFrame constructor
-    args: Dict[str, Any] = dict(data={})
+        # Default values for every column
+        data: Mapping = ChainMap(item_data, defaultdict(lambda: None))
 
-    # Flag if all values in `data` are scalars
-    all_scalar = True
+        # Arguments for pd.DataFrame constructor
+        args: Dict[str, Any] = dict(data={})
 
-    for column in dims + ["value"]:
-        # Update flag
-        all_scalar &= is_scalar(data[column])
-        # Store data
-        args["data"][column] = data[column]
+        # Flag if all values in `data` are scalars
+        all_scalar = True
 
-    if all_scalar:
-        # All values are scalars, so the constructor requires an index to be passed
-        # explicitly.
-        args["index"] = [0]
+        for column in dims + ["value"]:
+            # Update flag
+            all_scalar &= is_scalar(data[column])
+            # Store data
+            args["data"][column] = data[column]
 
-    df = pd.DataFrame(**args)
+        if all_scalar:
+            # All values are scalars, so the constructor requires an index to be passed
+            # explicitly.
+            args["index"] = [0]
+
+        df = pd.DataFrame(**args)
+    else:
+        # Provided complete data frame
+        df = item_data.rename(columns=RENAME_DIMS)
+
     # Data must be entirely empty, or complete
     assert not df.isna().any().any() or df.isna().all().all(), data
     assert not df.duplicated().any(), f"Duplicate data for simulated {repr(name)}"
 
-    return Key(name, dims), Quantity(df.set_index(dims) if len(dims) else df)
+    return Quantity(df.set_index(dims)["value"] if len(dims) else df, name=name)
+
+
+def data_from_file(path: Path, *, name: str, dims: Sequence[str]) -> Quantity:
+    """Read simulated solution data for item `name` from `path`.
+
+    For variables and equations (`name` in upper case), the file **must** have columns
+    corresponding to `dims` followed by "Val", "Marginal", "Upper", and "Scale". The
+    "Val" column is returned.
+
+    For parameters, the file **must** have columns corresponding to `dims` followed by
+    "value" and "unit". The "value" column is returned.
+    """
+    if name.isupper():
+        # Construct a list of the columns
+        # NB Must assign the dimensions directly; they cannot be read from the file, as
+        #    the column headers are the internal GAMS set names (e.g. "year_all")
+        #    instead of the index names from message_ix.
+        cols = list(dims) + ["Val", "Marginal", "Lower", "Upper", "Scale"]
+
+        return Quantity(
+            pd.read_csv(path, engine="pyarrow")
+            .set_axis(cols, axis=1)
+            .set_index(cols[:-5])["Val"],
+            name=name,
+        )
+    else:
+        cols = list(dims) + ["value", "unit"]
+        tmp = (
+            pd.read_csv(path, engine="pyarrow")
+            .set_axis(cols, axis=1)
+            .set_index(cols[:-2])
+        )
+        # TODO pass units if they are unique
+        return Quantity(tmp["value"], name=name)
 
 
 def add_simulated_solution(
-    rep: Reporter, info: ScenarioInfo, data: Optional[Dict] = None
+    rep: Reporter,
+    info: ScenarioInfo,
+    data: Optional[Dict] = None,
+    path: Optional[Path] = None,
 ):
-    """Add a simulated model solution to `rep`, given `info` and `data`."""
-    # Populate the sets (from `info`, maybe empty) and pars (empty)
-    to_add = deepcopy(MESSAGE_ITEMS)
-    # Populate variables
-    to_add.update(MESSAGE_VARS)
-    # Populate MACRO items
-    to_add.update(
-        {
-            "GDP": item("var", "n y"),
-            "MERtoPPP": item("var", "n y"),
-        }
-    )
+    """Add a simulated model solution to `rep`.
 
+    Parameters
+    ----------
+    data : dict or pandas.DataFrame, *optional*
+        If given, a mapping from MESSAGE item (set, parameter, or variable) names to
+        inputs that are passed to :func:`simulate_qty`.
+    path : Path, *optional*
+        If given, a path to a directory containing one or more files with names like
+        :file:`ACT.csv.gz`. These files are taken as containing "simulated" model
+        solution data for the MESSAGE variable with the same name. See
+        :func:`data_from_file`.
+    """
+    mark_time()
+    N = len(rep.graph)
+
+    # Add simulated data
     data = data or dict()
+    for name, item_info in SIMULATE_ITEMS.items():
+        key = Key(name, list(dims_of(item_info).values()))
 
-    for name, item_info in to_add.items():
+        # Add a task to load data from a file in `path`, if it exists
+        try:
+            # Candidate path
+            assert path is not None
+            p = path.joinpath(name).with_suffix(".csv.gz")
+            assert p.exists()
+        except AssertionError:
+            pass  # No `path` or no such file
+        else:
+            # Add data from file
+
+            rep.add(key, data_from_file, p, name=name, dims=key.dims, sums=True)
+            continue
+
         if item_info["ix_type"] == "set":
-            # Add the set elements
+            # Add the set elements from `info`
             rep.add(RENAME_DIMS.get(name, name), quote(info.set[name]))
         elif item_info["ix_type"] in ("par", "var"):
             # Retrieve an existing key for `name`
@@ -118,17 +291,26 @@ def add_simulated_solution(
             except KeyError:
                 full_key = None  # Not present in `rep`
 
-            # Simulated data for name
-            item_data = data.get(name, {})
+            # Simulate data for name
+            item_data = data.get(name)
 
             if full_key and not item_data:
                 # Don't overwrite existing task with empty data
                 continue
 
-            # Store simulated data for this quantity
-            key, qty = simulate_qty(name, item_info, **item_data)
-            rep.add(key, qty, sums=True)
-            # log.debug(f"{key}\n{qty}")
+            # Add a task to simulate data for this quantity
+            rep.add(
+                key,
+                simulate_qty,
+                name=name,
+                info=item_info,
+                item_data=item_data,
+                sums=True,
+            )
+
+    log.info(f"{len(rep.graph) - N} keys")
+    N = len(rep.graph)
+    mark_time()
 
     # Prepare the base MESSAGEix computations
     with silence_log("genno", logging.CRITICAL):
@@ -136,3 +318,6 @@ def add_simulated_solution(
             rep.add_tasks()
         except KeyExistsError:
             pass  # `rep` was produced with Reporter.from_scenario()
+
+    log.info(f"{len(rep.graph)} total keys")
+    mark_time()

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -262,6 +262,14 @@ def add_simulated_solution(
         solution data for the MESSAGE variable with the same name. See
         :func:`data_from_file`.
     """
+    from importlib.metadata import version
+
+    if version("message_ix") < "3.6":
+        raise NotImplementedError(
+            "Support for message_ix_models.report.sim.add_simulated_solution() with "
+            "message_ix <= 3.5.0. Please upgrade to message_ix 3.6 or later."
+        )
+
     mark_time()
     N = len(rep.graph)
 

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -1,3 +1,4 @@
+"""Simulated solution data for testing :mod:`~message_ix_models.report`."""
 import logging
 from collections import ChainMap, defaultdict
 from collections.abc import Mapping
@@ -15,6 +16,13 @@ from pandas.api.types import is_scalar
 
 from message_ix_models import ScenarioInfo
 from message_ix_models.util._logging import mark_time, silence_log
+
+__all__ = [
+    "SIMULATE_ITEMS",
+    "add_simulated_solution",
+    "data_from_file",
+    "simulate_qty",
+]
 
 log = logging.getLogger(__name__)
 

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -273,6 +273,9 @@ def add_simulated_solution(
     mark_time()
     N = len(rep.graph)
 
+    # Ensure "scenario" is present in the graph
+    rep.graph.setdefault("scenario", None)
+
     # Add simulated data
     data = data or dict()
     for name, item_info in SIMULATE_ITEMS.items():

--- a/message_ix_models/tests/model/test_snapshot.py
+++ b/message_ix_models/tests/model/test_snapshot.py
@@ -35,6 +35,7 @@ def unpacked_snapshot_data(test_context, request):
     shutil.copytree(snapshot_data_path, dest, dirs_exist_ok=True)
 
 
+@pytest.mark.xfail(reason="https://github.com/iiasa/message-ix-models/issues/131")
 @pytest.mark.xfail(
     condition=version("message_ix") < "3.5",
     raises=NotImplementedError,

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -224,7 +224,7 @@ def test_cli_techs(session_context, mix_models_cli):
     result = mix_models_cli.assert_exit_0(["techs"])
 
     # Result test
-    assert result.output.endswith("[5 rows x 8 columns]\n")
+    assert "\n[5 rows x 8 columns]\n" in result.output
 
     # Path to the temporary file written by the command
     path = Path(re.search("Write to (.*.csv)", result.output)[1])

--- a/message_ix_models/tests/project/test_ssp.py
+++ b/message_ix_models/tests/project/test_ssp.py
@@ -86,6 +86,44 @@ def test_cli(mix_models_cli):
     mix_models_cli.assert_exit_0(["ssp", "gen-structures", "--dry-run"])
 
 
+class TestSSPOriginal:
+    @pytest.mark.parametrize(
+        "source",
+        (
+            "ICONICS:SSP(2017).1",
+            "ICONICS:SSP(2017).2",
+            "ICONICS:SSP(2017).3",
+            "ICONICS:SSP(2017).4",
+            "ICONICS:SSP(2017).5",
+        ),
+    )
+    @pytest.mark.parametrize(
+        "source_kw",
+        (
+            dict(measure="POP", model="OECD Env-Growth"),
+            dict(measure="GDP", model="OECD Env-Growth"),
+        ),
+    )
+    def test_prepare_computer(self, test_context, source, source_kw):
+        # FIXME The following should be redundant, but appears mutable on GHA linux and
+        #       Windows runners.
+        test_context.model.regions = "R14"
+
+        c = Computer()
+
+        keys = prepare_computer(test_context, c, source, source_kw)
+
+        # Preparation of data runs successfully
+        result = c.get(keys[0])
+
+        # Data has the expected dimensions
+        assert ("n", "y") == result.dims
+
+        # Data is complete
+        assert 14 == len(result.coords["n"])
+        assert 14 == len(result.coords["y"])
+
+
 class TestSSPUpdate:
     @pytest.mark.parametrize(
         "source",

--- a/message_ix_models/tests/project/test_ssp.py
+++ b/message_ix_models/tests/project/test_ssp.py
@@ -102,6 +102,11 @@ class TestSSPOriginal:
         (
             dict(measure="POP", model="OECD Env-Growth"),
             dict(measure="GDP", model="OECD Env-Growth"),
+            # Excess keyword arguments
+            pytest.param(
+                dict(measure="GDP", model="OECD Env-Growth", foo="bar"),
+                marks=pytest.mark.xfail(raises=ValueError),
+            ),
         ),
     )
     def test_prepare_computer(self, test_context, source, source_kw):
@@ -141,6 +146,11 @@ class TestSSPUpdate:
             dict(measure="POP"),
             dict(measure="GDP", model="IIASA GDP 2023"),
             dict(measure="GDP", model="OECD ENV-Growth 2023"),
+            # Excess keyword arguments
+            pytest.param(
+                dict(measure="POP", foo="bar"),
+                marks=pytest.mark.xfail(raises=ValueError),
+            ),
         ),
     )
     def test_prepare_computer(self, test_context, source, source_kw):

--- a/message_ix_models/tests/project/test_ssp.py
+++ b/message_ix_models/tests/project/test_ssp.py
@@ -106,7 +106,12 @@ class TestSSPUpdate:
         ),
     )
     def test_prepare_computer(self, test_context, source, source_kw):
+        # FIXME The following should be redundant, but appears mutable on GHA linux and
+        #       Windows runners.
+        test_context.model.regions = "R14"
+
         c = Computer()
+
         keys = prepare_computer(test_context, c, source, source_kw)
 
         # Preparation of data runs successfully

--- a/message_ix_models/tests/report/test_computations.py
+++ b/message_ix_models/tests/report/test_computations.py
@@ -1,7 +1,10 @@
+import re
+
+import pandas as pd
 import xarray as xr
 from genno import Quantity
 
-from message_ix_models.report.computations import compound_growth
+from message_ix_models.report.computations import compound_growth, filter_ts
 
 
 def test_compound_growth():
@@ -28,3 +31,17 @@ def test_compound_growth():
     assert all(1.02**5 == r1.sel(t=2035) / r1.sel(t=2030))
 
     assert all(1.0 == result.sel(x="x2"))
+
+
+def test_filter_ts():
+    df = pd.DataFrame([["foo"], ["bar"]], columns=["variable"])
+    assert 2 == len(df)
+
+    # Operator runs
+    result = filter_ts(df, re.compile(".(ar)"))
+
+    # Only matching rows are returned
+    assert 1 == len(result)
+
+    # Only the first match group in `expr` is preserved
+    assert {"ar"} == set(result.variable.unique())

--- a/message_ix_models/tests/report/test_config.py
+++ b/message_ix_models/tests/report/test_config.py
@@ -1,0 +1,23 @@
+import pytest
+
+from message_ix_models.report.config import Config
+
+
+class TestConfig:
+    def test_use_file(self, tmp_path):
+        cfg = Config()
+
+        # No effect
+        cfg.use_file(None)
+
+        # Passing a missing path raises an exception
+        with pytest.raises(
+            FileNotFoundError, match="Reporting configuration in .*missing"
+        ):
+            cfg.use_file(tmp_path.joinpath("missing"))
+
+        # Passing a file name that does not exist raises an exception
+        with pytest.raises(
+            FileNotFoundError, match=r"Reporting configuration in 'unknown\(.yaml\)'"
+        ):
+            cfg.use_file("unknown")

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -253,6 +253,7 @@ def test_add_simulated_solution(test_context, test_data_path):
     assert np.isclose(79.76478, value.item())
 
 
+@MARK[0]
 def test_prepare_reporter(test_context):
     rep = ss_reporter()
     N = len(rep.graph)

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -203,6 +203,7 @@ def test_collapse(input, exp):
     pdt.assert_frame_equal(util.collapse(df_in), df_exp)
 
 
+@MARK[0]
 def test_add_simulated_solution(test_context, test_data_path):
     from message_ix import Reporter
 

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -30,7 +30,7 @@ def test_report_bare_res(request, test_context):
     scenario = testing.bare_res(request, test_context, solved=True)
 
     # Prepare the reporter
-    test_context.report.update(config="global.yaml", key="message::default")
+    test_context.report.update(from_file="global.yaml", key="message::default")
     reporter, key = prepare_reporter(test_context, scenario)
 
     # Get the default report
@@ -48,13 +48,13 @@ def test_report_legacy(caplog, request, tmp_path, test_context):
     # Set dry_run = True to not actually perform any calculations or modifications
     test_context.dry_run = True
     # Ensure the legacy reporting is used, with default settings
-    test_context.report = {"legacy": dict()}
+    test_context.report.legacy["use"] = True
 
     # Call succeeds
     report(test_context)
 
     # Dry-run message is logged
-    assert "DRY RUN" in caplog.messages
+    assert "DRY RUN" in caplog.messages[-1]
     caplog.clear()
 
     # Other deprecated usage
@@ -62,6 +62,7 @@ def test_report_legacy(caplog, request, tmp_path, test_context):
     # As called in .model.cli.new_baseline() and .model.create.solve(), with path as a
     # positional argument
     legacy_arg = dict(
+        use=True,
         ref_sol="True",  # Must be literal "True" or "False"
         merge_hist=True,
         xlsx=test_context.get_local_path("rep_template.xlsx"),
@@ -115,7 +116,7 @@ def test_apply_units(request, test_context, regions):
     config = MIN_CONFIG.copy()
 
     # Prepare the reporter
-    test_context.report.update(config=config, key=qty)
+    test_context.report.update(genno_config=config, key=qty)
     reporter, key = prepare_reporter(test_context, bare_res)
 
     # Add some data to the scenario
@@ -140,14 +141,14 @@ def test_apply_units(request, test_context, regions):
     assert "dimensionless" == str(reporter.get(key).units)
 
     # Update configuration, re-create the reporter
-    test_context.report["config"]["units"]["apply"] = {"inv_cost": "USD"}
+    test_context.report.genno_config["units"]["apply"] = {"inv_cost": "USD"}
     reporter, key = prepare_reporter(test_context, bare_res)
 
     # Units are applied
     assert USD_2005 == reporter.get(key).units
 
     # Update configuration, re-create the reporter
-    test_context.report["config"].update(INV_COST_CONFIG)
+    test_context.report.genno_config.update(INV_COST_CONFIG)
     reporter, key = prepare_reporter(test_context, bare_res)
 
     # Units are converted

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -44,7 +44,7 @@ def test_report_bare_res(request, test_context):
 
 @pytest.mark.xfail(raises=ModuleNotFoundError, reason="Requires message_data")
 def test_report_legacy(caplog, request, tmp_path, test_context):
-    """Legacy reporting can be invoked through :func:`.report()`."""
+    """Legacy reporting can be invoked via :func:`message_ix_models.report.report`."""
     # Create a target scenario
     scenario = testing.bare_res(request, test_context, solved=False)
     test_context.set_scenario(scenario)

--- a/message_ix_models/tests/tools/test_exo_data.py
+++ b/message_ix_models/tests/tools/test_exo_data.py
@@ -45,7 +45,7 @@ def test_prepare_computer(test_context, regions, N_n):
 def test_prepare_computer_exc(test_context):
     c = Computer()
 
-    with pytest.raises(ValueError, match="must be one of"):
+    with pytest.raises(ValueError, match="No source found that can handle"):
         prepare_computer(test_context, c, "test s1", dict(measure="FOO"))
 
     with pytest.raises(ValueError, match="No source found that can handle"):

--- a/message_ix_models/tests/util/test_click.py
+++ b/message_ix_models/tests/util/test_click.py
@@ -39,7 +39,7 @@ def test_default_path_cb(session_context, mix_models_cli):
         result = mix_models_cli.assert_exit_0(cmd)
 
     # The value was stored on, and retrieved from, `ctx`
-    assert f"{expected}\n" == result.output
+    assert result.output.startswith(f"{expected}\n")
 
 
 def test_store_context(mix_models_cli):

--- a/message_ix_models/tests/util/test_click.py
+++ b/message_ix_models/tests/util/test_click.py
@@ -58,3 +58,31 @@ def test_store_context(mix_models_cli):
 
     # The value was stored on, and retrieved from, `ctx`
     assert "SSP2\n" == result.output
+
+
+def test_urls_from_file(mix_models_cli, tmp_path):
+    """Test :func:`.urls_from_file` callback."""
+
+    # Create a hidden command and attach it to the CLI
+    @click.command(name="_test_store_context", hidden=True)
+    @common_params("urls_from_file")
+    @click.pass_obj
+    def func(ctx, **kwargs):
+        # Print the value stored on the Context object
+        print("\n".join([s.url for s in ctx.core.scenarios]))
+
+    # Create a temporary file with some scenario URLs
+    text = """m/s#3
+foo/bar#5
+baz/qux#123
+"""
+    p = tmp_path.joinpath("scenarios.txt")
+    p.write_text(text)
+
+    # Run the command, referring to the temporary file
+    with temporary_command(main, func):
+        result = mix_models_cli.assert_exit_0([func.name, f"--urls-from-file={p}"])
+
+    # Scenario URLs are parsed to ScenarioInfo objects, and then can be reconstructed →
+    # data is round-tripped
+    assert text == result.output

--- a/message_ix_models/tests/util/test_config.py
+++ b/message_ix_models/tests/util/test_config.py
@@ -131,3 +131,8 @@ subconfig-b:  # No name manipulation for subkeys here
         result = c.replace(foo_2="baz")
         assert result is not c
         assert "baz" == result.foo_2
+
+    def test_update(self, c):
+        """:meth:`.update` raises AttributeError."""
+        with pytest.raises(AttributeError):
+            c.update(foo_4="")

--- a/message_ix_models/tests/util/test_config.py
+++ b/message_ix_models/tests/util/test_config.py
@@ -133,6 +133,6 @@ subconfig-b:  # No name manipulation for subkeys here
         assert "baz" == result.foo_2
 
     def test_update(self, c):
-        """:meth:`.update` raises AttributeError."""
+        """:meth:`.ConfigHelper.update` raises AttributeError."""
         with pytest.raises(AttributeError):
             c.update(foo_4="")

--- a/message_ix_models/tests/util/test_context.py
+++ b/message_ix_models/tests/util/test_context.py
@@ -237,9 +237,9 @@ class TestContext:
 
         ctx.delete()
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         c = Context()
-        assert re.fullmatch("<Context object at [^ ]+ with 2 keys>", repr(c))
+        assert re.fullmatch("<Context object at [^ ]+ with 3 keys>", repr(c))
 
     def test_use_defaults(self, caplog):
         caplog.set_level(logging.INFO)

--- a/message_ix_models/tests/util/test_scenarioinfo.py
+++ b/message_ix_models/tests/util/test_scenarioinfo.py
@@ -137,6 +137,12 @@ class TestScenarioInfo:
         assert 1963 == info.y0
         assert [1963, 1964, 1965] == info.Y
 
+    def test_from_url(self):
+        si = ScenarioInfo.from_url("m/s#123")
+        assert "m" == si.model
+        assert "s" == si.scenario
+        assert 123 == si.version
+
     @pytest.mark.parametrize(
         "input, expected",
         (

--- a/message_ix_models/tests/util/test_scenarioinfo.py
+++ b/message_ix_models/tests/util/test_scenarioinfo.py
@@ -77,13 +77,36 @@ class TestScenarioInfo:
         # level= keyword argument → logged warning
         assert "level = 'useful' ignored" == caplog.messages[-1]
 
-    def test_from_scenario(self, test_context):
+    def test_iter(self) -> None:
+        info = ScenarioInfo(model="m", scenario="s")
+
+        # dict() operates on the instance via __iter__
+        assert dict(model="m", scenario="s", version=None) == dict(info)
+
+        # Individual attributes are accessible
+        assert "m" == info.model
+        assert "s" == info.scenario
+        assert None is info.version
+
+    def test_url(self) -> None:
+        info = ScenarioInfo(model="m", scenario="s", version=42)
+        assert "m/s#42" == info.url
+
+        info.url = "a/b"
+        assert dict(model="a", scenario="b", version=None) == dict(info)
+
+    def test_from_scenario(self, test_context) -> None:
         """ScenarioInfo initialized from an existing Scenario."""
         mp = test_context.get_platform()
         scenario = make_dantzig(mp, multi_year=True)
 
         # ScenarioInfo can be initialized from the scenario
         info = ScenarioInfo(scenario)
+
+        # model, scenario, and version attributes are retrieved from `scenario`
+        assert dict(
+            model="Canning problem (MESSAGE scheme)", scenario="multi-year", version=1
+        ) == dict(info)
 
         # Shorthand properties
         assert_frame_equal(
@@ -113,6 +136,21 @@ class TestScenarioInfo:
         ] == info.N
         assert 1963 == info.y0
         assert [1963, 1964, 1965] == info.Y
+
+    @pytest.mark.parametrize(
+        "input, expected",
+        (
+            (
+                "Mix-G 1.1-BM-R12 (NAV)/NPi-ref EN_20C_step-3+B#3",
+                "Mix-G 1.1-BM-R12 (NAV)_NPi-ref EN_20C_step-3+B_v3",
+            ),
+            ("foo<>bar/baz|qux*#42", "foo_bar_baz_qux_v42"),
+        ),
+    )
+    def test_path(self, input, expected) -> None:
+        si = ScenarioInfo()
+        si.url = input
+        assert expected == si.path
 
     def test_repr(self):
         si = ScenarioInfo()

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -256,6 +256,9 @@ def iamc_like_data_for_query(path: Path, query: str) -> Quantity:
     unique = dict()
 
     def drop_unique(df, names) -> pd.DataFrame:
+        if len(df) == 0:
+            raise RuntimeError(f"0 rows matching {query!r}")
+
         names_list = names.split()
         for name in names_list:
             values = df[name].unique()

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -230,7 +230,9 @@ class DemoSource(ExoDataSource):
 
 
 @cached
-def iamc_like_data_for_query(path: Path, query: str) -> Quantity:
+def iamc_like_data_for_query(
+    path: Path, query: str, *, replace: Optional[dict] = None
+) -> Quantity:
     """Load data from `path` in IAMC-like format and transform to :class:`.Quantity`.
 
     The steps involved are:
@@ -270,6 +272,7 @@ def iamc_like_data_for_query(path: Path, query: str) -> Quantity:
     tmp = (
         pd.read_csv(path, engine="pyarrow")
         .query(query)
+        .replace(replace or {})
         .rename(columns=lambda c: c.upper())
         .pipe(drop_unique, "MODEL SCENARIO VARIABLE UNIT")
         .assign(n=lambda df: df["REGION"].apply(iso_3166_alpha_3))
@@ -281,5 +284,4 @@ def iamc_like_data_for_query(path: Path, query: str) -> Quantity:
         .stack()
         .dropna()
     )
-
     return Quantity(tmp, units=unique["UNIT"])

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -2,7 +2,7 @@
 from abc import ABC, abstractmethod
 from operator import itemgetter
 from pathlib import Path
-from typing import Dict, Mapping, Optional, Type
+from typing import Dict, Mapping, Optional, Tuple, Type
 
 from genno import Computer, Key, Quantity, quote
 from genno.core.key import single_key
@@ -69,8 +69,13 @@ class ExoDataSource(ABC):
 
 
 def prepare_computer(
-    context, c: "Computer", source="test", source_kw: Optional[Mapping] = None
-):
+    context,
+    c: "Computer",
+    source="test",
+    source_kw: Optional[Mapping] = None,
+    *,
+    strict: bool = True,
+) -> Tuple[Key, ...]:
     """Prepare `c` to compute GDP, population, or other exogenous data.
 
     Returns a tuple of keys. The first, like ``{m}:n-y``, triggers the following
@@ -125,10 +130,10 @@ def prepare_computer(
     c.require_compat("message_ix_models.report.computations")
 
     # Retrieve the node codelist
-    c.add("n::codes", quote(get_codes(f"node/{context.model.regions}")), strict=True)
+    c.add("n::codes", quote(get_codes(f"node/{context.model.regions}")), strict=strict)
 
     # Convert the codelist into a nested dict for aggregate()
-    c.add("n::groups", "codelist_to_groups", "n::codes", strict=True)
+    c.add("n::groups", "codelist_to_groups", "n::codes", strict=strict)
 
     # Add information about the list of periods
     if "y" not in c:

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -16,6 +16,7 @@ __all__ = [
     "SOURCES",
     "DemoSource",
     "ExoDataSource",
+    "iamc_like_data_for_query",
     "prepare_computer",
     "register_source",
 ]
@@ -78,19 +79,10 @@ def prepare_computer(
 ) -> Tuple[Key, ...]:
     """Prepare `c` to compute GDP, population, or other exogenous data.
 
-    Returns a tuple of keys. The first, like ``{m}:n-y``, triggers the following
-    computations:
-
-    1. Load data by invoking a :class:`ExoDataSource`.
-    2. Aggregate on the ``n`` (``node``) dimension according to :attr:`Config.regions`.
-    3. Interpolate on the ``y`` (``year``) dimension according to :attr:`Config.years`.
-
-    Additional key(s) include:
-
-    - ``{m}:n-y:y0 indexed``: same as ``{m}:n-y``, indexed to values as of ``y0``, that
-      is, the first model year.
-
-    .. todo:: Extend to also prepare to compute values indexed to a particular ``n``.
+    Check each :class:`ExoDataSource` in :data:`SOURCES` to determine whether it
+    recognizes and can handle `source` and `source_kw`. If a source is identified, add
+    tasks to `c` that retrieve and process data into a :class:`.Quantity` with, at
+    least, dimensions :math:`(n, y)`.
 
     Parameters
     ----------
@@ -103,6 +95,12 @@ def prepare_computer(
         returned.
 
         If the key "measure" is present, it **must** be one of :data:`MEASURES`.
+    strict : bool, *optional*
+        Raise an exception if any of the keys to be added already exist.
+
+    Returns
+    -------
+    tuple of .Key
     """
     # Handle arguments
     source_kw = source_kw or dict()
@@ -172,7 +170,7 @@ def prepare_computer(
 
 
 def register_source(cls: Type[ExoDataSource]) -> Type[ExoDataSource]:
-    """Register `cls` as a source of exogenous data."""
+    """Register :class:`.ExoDataSource` `cls` as a source of exogenous data."""
     if cls.id in SOURCES:
         raise ValueError(f"{SOURCES[cls.id]} already registered for id {cls.id!r}")
     SOURCES[cls.id] = cls

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -267,10 +267,11 @@ def iamc_like_data_for_query(path: Path, query: str) -> Quantity:
     tmp = (
         pd.read_csv(path, engine="pyarrow")
         .query(query)
-        .pipe(drop_unique, "Model Scenario Variable Unit")
-        .assign(n=lambda df: df["Region"].apply(iso_3166_alpha_3))
+        .rename(columns=lambda c: c.upper())
+        .pipe(drop_unique, "MODEL SCENARIO VARIABLE UNIT")
+        .assign(n=lambda df: df["REGION"].apply(iso_3166_alpha_3))
         .dropna(subset=["n"])
-        .drop("Region", axis=1)
+        .drop("REGION", axis=1)
         .set_index("n")
         .rename(columns=lambda y: int(y))
         .rename_axis(columns="y")
@@ -278,4 +279,4 @@ def iamc_like_data_for_query(path: Path, query: str) -> Quantity:
         .dropna()
     )
 
-    return Quantity(tmp, units=unique["Unit"])
+    return Quantity(tmp, units=unique["UNIT"])

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -10,6 +10,7 @@ from message_ix.models import MESSAGE_ITEMS
 from ._convert_units import convert_units, series_of_pint_quantity
 from .cache import cached
 from .common import (
+    HAS_MESSAGE_DATA,
     MESSAGE_DATA_PATH,
     MESSAGE_MODELS_PATH,
     Adapter,
@@ -25,6 +26,7 @@ from .scenarioinfo import ScenarioInfo, Spec
 from .sdmx import CodeLike, as_codes, eval_anno
 
 __all__ = [
+    "HAS_MESSAGE_DATA",
     "MESSAGE_DATA_PATH",
     "MESSAGE_MODELS_PATH",
     "Adapter",

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -5,7 +5,7 @@ These are used for building CLIs using :mod:`click`.
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import click
 from click import Argument, Choice, Option
@@ -86,9 +86,15 @@ def store_context(context: Union[click.Context, Context], param, value):
     return value
 
 
-def urls_from_file(context: Union[click.Context, Context], param, value):
+def urls_from_file(
+    context: Union[click.Context, Context], param, value
+) -> List[ScenarioInfo]:
     """Callback to parse scenario URLs from `value`."""
-    si = []
+    si: List[ScenarioInfo] = []
+
+    if value is None:
+        return si
+
     with click.open_file(value) as f:
         for line in f:
             si.append(ScenarioInfo.from_url(url=line))

--- a/message_ix_models/util/common.py
+++ b/message_ix_models/util/common.py
@@ -14,9 +14,11 @@ try:
 except ImportError:
     log.warning("message_data is not installed or cannot be imported")
     MESSAGE_DATA_PATH: Optional[Path] = None
+    HAS_MESSAGE_DATA = False
 else:  # pragma: no cover  (needs message_data)
     # Root directory of the message_data repository.
     MESSAGE_DATA_PATH = Path(message_data.__file__).parents[1]
+    HAS_MESSAGE_DATA = True
 
 # Directory containing message_ix_models.__init__
 MESSAGE_MODELS_PATH = Path(__file__).parents[1]
@@ -29,6 +31,7 @@ PRIVATE_DATA: Dict[str, Any] = dict()
 
 
 __all__ = [
+    "HAS_MESSAGE_DATA",
     "Adapter",
     "MappingAdapter",
 ]

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -99,7 +99,9 @@ class ConfigHelper:
                     # Use name manipulation on the attribute value also
                     value = existing.replace(**value)
                 elif not isinstance(existing, type):
-                    value = replace(existing, **value)
+                    # https://github.com/python/mypy/issues/15843
+                    # TODO Check that fix is available in mypy 1.7.x; remove
+                    value = replace(existing, **value)  # type: ignore [misc]
             setattr(self, key, value)
 
     def replace(self, **kwargs):

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -110,6 +110,13 @@ class ConfigHelper:
         )
 
     def update(self, **kwargs):
+        """Update attributes in-place.
+
+        Raises
+        ------
+        AttributeError
+            Any of the `kwargs` are not fields in the data class.
+        """
         # TODO use _munge_dict(); allow a positional argument
         for k, v in kwargs.items():
             if not hasattr(self, k):

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -2,9 +2,11 @@ import logging
 import os
 from dataclasses import dataclass, field, fields, is_dataclass, replace
 from pathlib import Path
-from typing import Any, Hashable, Mapping, MutableMapping, Optional, Sequence, Set
+from typing import Any, Hashable, List, Mapping, MutableMapping, Optional, Sequence, Set
 
 import ixmp
+
+from .scenarioinfo import ScenarioInfo
 
 log = logging.getLogger(__name__)
 
@@ -137,6 +139,9 @@ class Config:
     #: :class:`ixmp.Scenario` constructor, as given by the :program:`--model`/
     #: :program:`--scenario` or :program:`--url` CLI options.
     scenario_info: MutableMapping[str, str] = field(default_factory=dict)
+
+    #: Like `scenario_info`, but a list for operations affecting multiple scenarios.
+    scenarios: List[ScenarioInfo] = field(default_factory=list)
 
     #: Like :attr:`platform_info`, used by e.g. :meth:`.clone_to_dest`.
     dest_platform: MutableMapping[str, str] = field(default_factory=dict)

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -107,6 +107,13 @@ class ConfigHelper:
             **{k: v for k, v in self._munge_dict(kwargs, "raise", "keyword argument")},
         )
 
+    def update(self, **kwargs):
+        # TODO use _munge_dict(); allow a positional argument
+        for k, v in kwargs.items():
+            if not hasattr(self, k):
+                raise AttributeError(k)
+            setattr(self, k, v)
+
     @classmethod
     def from_dict(cls, data: Mapping):
         """Construct an instance from `data` with name manipulation."""

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -349,8 +349,8 @@ class Context(dict):
     ):
         """Handle command-line arguments.
 
-        May update the :attr:`.Config.local_data`, :attr:`.Config.platform_info`,
-        :attr:`.Config.scenario_info`, and/or :attr:`.url` settings.
+        May update the :attr:`.Config.local_data`, :attr:`~.Config.platform_info`,
+        :attr:`~.Config.scenario_info`, and/or :attr:`~.Config.url` settings.
         """
         self.core.verbose = verbose
 

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -72,7 +72,7 @@ class Context(dict):
 
     def __init__(self, *args, **kwargs):
         from message_ix_models.model import Config as ModelConfig
-        from message_ix_models.report.config import Config as ReportConfig
+        from message_ix_models.report import Config as ReportConfig
 
         if len(_CONTEXTS) == 0:
             log.info("Create root Context")

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -72,6 +72,7 @@ class Context(dict):
 
     def __init__(self, *args, **kwargs):
         from message_ix_models.model import Config as ModelConfig
+        from message_ix_models.report.config import Config as ReportConfig
 
         if len(_CONTEXTS) == 0:
             log.info("Create root Context")
@@ -79,6 +80,7 @@ class Context(dict):
         # Handle keyword arguments going to known config dataclasses
         kwargs["core"] = Config(**_dealiased("core", kwargs))
         kwargs["model"] = ModelConfig(**_dealiased("model", kwargs))
+        kwargs["report"] = ReportConfig()
 
         # Store any keyword arguments
         super().__init__(*args, **kwargs)

--- a/message_ix_models/util/pycountry.py
+++ b/message_ix_models/util/pycountry.py
@@ -1,0 +1,42 @@
+from functools import lru_cache
+from typing import Optional
+
+from pycountry import countries, historic_countries
+
+#: Mapping from common, non-standard country names to ISO 3166-1 names.
+COUNTRY_NAME = {
+    "Korea": "Korea, Republic of",
+    "Republic of Korea": "Korea, Republic of",
+    "South Korea": "Korea, Republic of",
+    "Russia": "Russian Federation",
+}
+
+
+@lru_cache(maxsize=2**9)
+def iso_3166_alpha_3(name: str) -> Optional[str]:
+    """Return an ISO 3166 alpha-3 code for a country `name`.
+
+    Parameters
+    ----------
+    name : str
+        Country name. This is looked up in the `pycountry
+        <https://pypi.org/project/pycountry/#countries-iso-3166>`_ 'name',
+        'official_name', or 'common_name' field. Values in :data:`COUNTRY_NAME` are
+        supported.
+
+    Returns
+    -------
+    str or None
+    """
+    # Maybe map a known, non-standard value to a standard value
+    name = COUNTRY_NAME.get(name, name)
+
+    # Use pycountry's built-in, case-insensitive lookup on all fields including name,
+    # official_name, and common_name
+    for db in (countries, historic_countries):
+        try:
+            return db.lookup(name).alpha_3
+        except LookupError:
+            continue  # Not found in `db`, e.g. countries; try again
+
+    return None

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -158,7 +158,7 @@ class ScenarioInfo:
     @url.setter
     def url(self, value):
         p, s = ixmp.utils.parse_url(value)
-        self.platform_name = p["name"]
+        self.platform_name = p.get("name")
         for k in "model", "scenario", "version":
             setattr(self, k, s.get(k))
 

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -100,6 +100,13 @@ class ScenarioInfo:
 
         self._yv_ya = scenario_obj.vintage_and_active_years()
 
+    @classmethod
+    def from_url(cls, url: str) -> "ScenarioInfo":
+        """Create an instance using only an :attr:`url`."""
+        result = cls()
+        result.url = url
+        return result
+
     @property
     def yv_ya(self):
         """:class:`pandas.DataFrame` with valid ``year_vtg``, ``year_act`` pairs."""

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -52,6 +52,7 @@ class ScenarioInfo:
     """
 
     scenario_obj: InitVar[Optional["Scenario"]] = field(default=None, kw_only=False)
+    empty: InitVar[bool] = False
 
     platform_name: Optional[str] = None
     model: Optional[str] = None
@@ -72,7 +73,7 @@ class ScenarioInfo:
 
     _yv_ya: pd.DataFrame = None
 
-    def __post_init__(self, scenario_obj: Optional["Scenario"]):
+    def __post_init__(self, scenario_obj: Optional["Scenario"], empty: bool):
         if not scenario_obj:
             return
 
@@ -81,6 +82,9 @@ class ScenarioInfo:
         self.version = (
             None if scenario_obj.version is None else int(scenario_obj.version)
         )
+
+        if empty:
+            return
 
         # Copy structure (set contents)
         for name in scenario_obj.set_list():

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -53,6 +53,7 @@ class ScenarioInfo:
 
     scenario_obj: InitVar[Optional["Scenario"]] = field(default=None, kw_only=False)
 
+    platform_name: Optional[str] = None
     model: Optional[str] = None
     scenario: Optional[str] = None
     version: Optional[int] = None
@@ -152,9 +153,10 @@ class ScenarioInfo:
 
     @url.setter
     def url(self, value):
-        _, values = ixmp.utils.parse_url(value)
+        p, s = ixmp.utils.parse_url(value)
+        self.platform_name = p["name"]
         for k in "model", "scenario", "version":
-            setattr(self, k, values.get(k))
+            setattr(self, k, s.get(k))
 
     _path_re = [
         (re.compile(r"[/<>:\"\\\|\?\*]+"), "_"),

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -21,18 +21,19 @@ log = logging.getLogger(__name__)
 
 @dataclass(kw_only=True)
 class ScenarioInfo:
-    """Information about a :class:`~message_ix.Scenario` object.
+    """Information about a |Scenario| object.
 
     Code that prepares data for a target Scenario can accept a ScenarioInfo instance.
-    This avoids the need to load a Scenario, which can be slow under some conditions.
+    This avoids the need to create or load an actual Scenario, which can be slow under
+    some conditions.
 
-    ScenarioInfo objects can also be used (e.g. by :func:`.apply_spec`) to describe the
-    contents of a Scenario *before* it is created.
+    ScenarioInfo objects can also be used (for instance, by :func:`.apply_spec`) to
+    describe the contents of a Scenario *before* it is created.
 
     ScenarioInfo objects have the following convenience attributes:
 
     .. autosummary::
-       set
+       ~ScenarioInfo.set
        io_units
        is_message_macro
        N
@@ -46,17 +47,32 @@ class ScenarioInfo:
     scenario_obj : message_ix.Scenario
         If given, :attr:`.set` is initialized from this existing scenario.
 
+    Examples
+    --------
+    Iterating over an instance gives "model", "scenario", "version" and the values of
+    the respective attributes:
+    >>> si = ScenarioInfo.from_url("model name/scenario name#123")
+    >>> dict(si)
+    {'model': 'model name', 'scenario': 'scenario name', 'version': 123}
+
     See also
     --------
     .Spec
     """
 
+    # Parameters for initialization only
     scenario_obj: InitVar[Optional["Scenario"]] = field(default=None, kw_only=False)
     empty: InitVar[bool] = False
 
     platform_name: Optional[str] = None
+
+    #: Model name; equivalent to :attr:`.TimeSeries.model`.
     model: Optional[str] = None
+
+    #: Scenario name; equivalent to :attr:`.TimeSeries.scenario`.
     scenario: Optional[str] = None
+
+    #: Scenario version; equivalent to :attr:`.TimeSeries.version`.
     version: Optional[int] = None
 
     #: Elements of :mod:`ixmp`/:mod:`message_ix` sets.
@@ -170,7 +186,10 @@ class ScenarioInfo:
 
     @property
     def path(self) -> str:
-        """A valid path name similar to :attr:`url`."""
+        """A valid file system path name similar to :attr:`url`.
+
+        Characters invalid in Windows paths are replaced with "_".
+        """
         from functools import reduce
 
         return reduce(lambda s, e: e[0].sub(e[1], s), self._path_re, self.url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ exclude_also = [
   "@(abc\\.)?abstractmethod",
   # Imports only used by type checkers
   "if TYPE_CHECKING:",
+  # Requires message_data
+  "if HAS_MESSAGE_DATA:",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "message_ix >= 3.4.0",
   "pooch",
   "pyam-iamc >= 0.6",
+  "pyarrow",
   "pycountry",
   "PyYAML",
   "sdmx1 >= 2.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ exclude = ["doc/"]
 module = [
   "colorama",
   "message_data.*",
+  "plotnine",
   "pooch",
   "pycountry",
   # Indirectly via message_ix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,11 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
+report = ["plotnine"]
 tests = [
   # For nbclient, thus nbformat
   "ixmp[tests]",
+  "message_ix_models[report]",
   "pytest",
   "pytest-cov",
   "pytest-xdist",


### PR DESCRIPTION
- Build on the ExoDataSource class introduced in #122 to create providers for data from the SSP (original) and SSP Update databases.
  - In order to provide public/non-embargoed data for testing this code, add a CLI command `mix-models ssp make-test-data` that preserves the structure of the original, but replaces the values with random floats.
- Add a `.report.plot` submodule with a Plot class and five initial (sets of) plots including:
  - Emissions|CO2
  - Final Energy
  - Primary Energy
- Update and test `.report.sim`.
  - Add solution data from snapshot 0 for use with `add_simulated_solution()`. These are excluded from packaging.

## How to review

- Read the diff; skip over the .csv.gz files using the GitHub file filter.
- Note the checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.