### PR TITLE
Report CO₂ emissions from transportation

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -110,6 +110,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with: { python-version: "3.11" }
 
     - name: Force recreation of pre-commit virtual environment for mypy
       if: github.event_name == 'schedule'  # Comment this line to run on a PR

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,8 @@ dmypy.json
 # Generated and temporary data files
 debug/
 cache/
+# LibreOffice lock files
+.~lock*#
 
 # VSCode settings
 .vscode

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,9 +12,12 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+clean-autosummary:
+	find . -name "$(BUILDDIR)" -prune -o -iname _autosummary -print0 | xargs -0 rmdir
+
+.PHONY: help clean-autosummary Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+.DEFAULT: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/api/report/index.rst
+++ b/doc/api/report/index.rst
@@ -177,7 +177,7 @@ Compatibility with :mod:`.message_data`
    :members:
 
    :mod:`.message_data` contains :doc:`m-data:reference/tools/post_processing`.
-   This code predates :mod:`genno` and the stack of tools built on upon it (:ref:`described above <report-intro>`); these were designed to avoid issues with performance and extensibility in the older code. [1]_
+   This code predates :mod:`genno` and the stack of tools built on it (:ref:`described above <report-intro>`); these were designed to avoid issues with performance and extensibility in the older code. [1]_
    :mod:`.report.compat` prepares a Reporter to perform the same calculations as :mod:`message_data.tools.post_processing`, except using :mod:`genno`.
 
    .. warning:: This code is **under development** and **incomplete**.

--- a/doc/api/testing.rst
+++ b/doc/api/testing.rst
@@ -1,7 +1,7 @@
+.. currentmodule:: message_ix_models.testing
+
 Test utilities and fixtures (:mod:`.testing`)
 *********************************************
-
-.. currentmodule:: message_ix_models.testing
 
 :doc:`Fixtures <pytest:explanation/fixtures>`:
 

--- a/doc/repro.rst
+++ b/doc/repro.rst
@@ -20,6 +20,8 @@ This is a Scenario that has the same *structure* (ixmp 'sets') as actual instanc
 Code that operates on the global model can be tested on the bare RES; if it works on that scenario, this is one indication (necessary, but not always sufficient) that it should work on fully-populated scenarios.
 Such tests are faster and lighter than testing on fully-populated scenarios, and make it easier to isolate errors in the code that is being tested.
 
+.. _test-suite:
+
 Test suite (:mod:`message_ix_models.tests`)
 ===========================================
 
@@ -58,13 +60,16 @@ In either case:
 - Running the test suite with ``--local-cache`` causes the local cache to be populated, and this will affect subsequent runs.
 - The continuous integration (below) services don't preserve caches, so code always runs.
 
+.. _ci:
+
 Continuous testing
 ==================
 
-The test suite (:mod:`message_ix_models.tests`) is run using GitHub Actions for new commits on the ``main`` branch, or on any branch associated with a pull request.
+The test suite (:mod:`message_ix_models.tests`) is run using GitHub Actions for new commits on the ``main`` branch; new commits on any branch associated with a pull request; and on a daily schedule.
+These ensure that the code is functional and produces expected outputs, even as upstream dependencies evolve.
+Workflow runs and their outputs can be viewed `here <https://github.com/iiasa/message-ix-models/actions/workflows/pytest.yaml>`__.
 
-Because it is closed-source and requires access to internal IIASA resources, including databases, continuous integration for :mod:`message_data` is handled by an internal server running `TeamCity <https://www.jetbrains.com/teamcity/>`_: https://ene-builds.iiasa.ac.at/project/message (requires authorization)
-
+Because it is closed-source and requires access to internal IIASA resources, including databases, continuous integration for :mod:`.message_data` is handled by GitHub Actions `self-hosted runners <https://docs.github.com/en/actions/hosting-your-own-runners>`__ running on IIASA systems.
 
 .. _export-test-data:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add :mod:`message_ix_models.report.compat` :ref:`for emulating legacy reporting <report-legacy>` (:pull:`134`).
 
 v2023.10.16
 ===========

--- a/message_ix_models/data/technology.yaml
+++ b/message_ix_models/data/technology.yaml
@@ -1228,8 +1228,8 @@ gas_rc:
   input: [gas, secondary]
   output: [gas, final]
 
-gas_t/d:
-  name: gas_t/d
+gas_t_d:
+  name: gas_t_d
   description: Transmission/Distribution of gas
   type: final
   vintaged: TRUE
@@ -1237,8 +1237,8 @@ gas_t/d:
   input: [gas, secondary]
   output: [gas, final]
 
-gas_t/d_ch4:
-  name: gas_t/d_ch4
+gas_t_d_ch4:
+  name: gas_t_d_ch4
   description: Transmission/Distribution of gas with CH4 mitigation
   type: final
   vintaged: TRUE

--- a/message_ix_models/data/technology.yaml
+++ b/message_ix_models/data/technology.yaml
@@ -1224,7 +1224,7 @@ gas_rc:
   name: gas_rc
   description: Gas heating in residential/commercial sector
   type: final
-  sector: gas
+  sector: residential/commercial
   input: [gas, secondary]
   output: [gas, final]
 

--- a/message_ix_models/model/config.py
+++ b/message_ix_models/model/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 
 from message_ix_models.model.structure import codelists
 from message_ix_models.util.context import _ALIAS
@@ -38,6 +38,11 @@ class Config:
     #: Create the reference energy system with dummy commodities and technologies. See
     #: :func:`.bare.get_spec`.
     res_with_dummies: bool = False
+
+    #: Default or preferred units for model quantities and reporting.
+    units: dict = field(
+        default_factory=lambda: {"energy": "GWa", "CO2 emissions": "Mt / a"}
+    )
 
     def check(self):
         """Check the validity of :attr:`regions`, :attr:`relations`, :attr:`years`."""

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -364,6 +364,7 @@ def prepare_reporter(
         **deepcopy(context.report.genno_config),
         fail="raise" if has_solution else logging.NOTSET,
     )
+    rep.configure(model=deepcopy(context.model))
 
     # Apply callbacks for other modules which define additional reporting computations
     for callback in CALLBACKS:

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -146,20 +146,24 @@ def register(name_or_callback: Union[Callable, str]) -> Optional[str]:
     """
     if isinstance(name_or_callback, str):
         # Resolve a string
-        for name in [
+        candidates = [
             # As a fully-resolved package/module name
             name_or_callback,
             # As a submodule of message_ix_models
             f"message_ix_models.{name_or_callback}.report",
             # As a submodule of message_data
             f"message_data.{name_or_callback}.report",
-        ]:
+        ]
+        mod = None
+        for name in candidates:
             try:
                 mod = import_module(name)
             except ModuleNotFoundError:
                 continue
             else:
                 break
+        if mod is None:
+            raise ModuleNotFoundError(" or ".join(candidates))
         callback = mod.callback
     else:
         callback = name_or_callback
@@ -338,11 +342,13 @@ def prepare_reporter(
         rep = Reporter.from_scenario(scenario)
         has_solution = scenario.has_solution()
 
-    # Append the message_data computations
+    # Append the message_data operators
     rep.require_compat("message_ix_models.report.computations")
     try:
+        # TODO Replace usage of operators from this module in favour of .exo_data; then
+        #      remove this line.
         rep.require_compat("message_data.tools.gdp_pop")
-    except ModuleNotFoundError:
+    except ModuleNotFoundError:  # pragma: no cover
         pass  # Currently in message_data
 
     # Force re-installation of the function iamc() in this file as the handler for

--- a/message_ix_models/report/compat.py
+++ b/message_ix_models/report/compat.py
@@ -1,0 +1,273 @@
+"""Compatibility code that emulates :mod:`message_data` reporting."""
+import logging
+from itertools import chain, count
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, cast
+
+from genno import Computer, Key, quote
+from genno.core.key import single_key
+
+if TYPE_CHECKING:
+    from ixmp.reporting import Reporter
+
+    from message_ix_models import Context
+
+log = logging.getLogger(__name__)
+
+#: Lists of technologies.
+#:
+#: Duplicated and reduced
+#: from :data:`message_data.tools.post_processing.default_tables.TECHS`.
+#:
+#: Modify these lists in order to control the lists of technologies handled by various`
+#: reporting calculations.
+#:
+#: .. todo:: store these on :class:`.Context`; read them from technology codelists.
+TECHS: Mapping[str, List[str]] = {
+    "gas extra": [],
+    # Residential and commercial
+    "rc gas": ["gas_rc", "hp_gas_rc"],
+    # Transport
+    "trp coal": ["coal_trp"],
+    "trp foil": ["foil_trp"],
+    "trp gas": ["gas_trp"],
+    "trp loil": ["loil_trp"],
+    "trp meth": ["meth_fc_trp", "meth_ic_trp"],
+}
+
+
+_ANON = map(lambda n: Key(f"_{n}"), count())
+
+
+def anon(name: Optional[str] = None, dims: Optional[Key] = None) -> Key:
+    """Create an ‘anonymous’ :class:`.Key` with `dims` optionally from another Key."""
+    result = next(_ANON) if name is None else Key(name)
+
+    return result.append(*getattr(dims, "dims", []))
+
+
+def get_techs(prefix: str, kinds: str) -> List[str]:
+    """Return a list of technologies.
+
+    The list is assembled from entries in :data:`TECHS` with the keys
+    "{prefix} {value}", with one `value` for each space-separated item in `kinds`.
+    """
+    return list(
+        chain(
+            *[
+                cast(Sequence[str], TECHS.get(f"{prefix} {kind}", []))
+                for kind in kinds.split()
+            ]
+        )
+    )
+
+
+def make_shorthand_function(base_name, to_drop):
+    """Create a shorthand function for adding tasks to a :class:`.Reporter`."""
+    _to_drop = to_drop.split()
+
+    def func(
+        c: Computer,
+        technologies: List[str],
+        *,
+        name: Optional[str] = None,
+        filters: Optional[dict] = None,
+    ) -> Key:
+        base = single_key(c.full_key(base_name))
+        key = anon(name, dims=base)
+
+        indexers = dict(t=technologies)
+        indexers.update(filters or {})
+
+        c.add(key, "select", base, indexers=indexers, sums=True)
+
+        # Return the partial sum over some dimensions
+        return key.drop(*_to_drop)
+
+    return func
+
+
+inp = make_shorthand_function("in", "c h ho l no t")
+emi = make_shorthand_function("rel", "nr r t yr")
+out = make_shorthand_function("out", "c h hd l nd t")
+
+
+def eff(
+    c: Computer,
+    technologies: List[str],
+    filters_in: Optional[dict] = None,
+    filters_out: Optional[dict] = None,
+) -> Key:
+    num = c.graph.unsorted_key(inp(c, technologies, filters=filters_in).append("t"))
+    denom = c.graph.unsorted_key(out(c, technologies, filters=filters_out).append("t"))
+    assert isinstance(num, Key)
+    assert isinstance(denom, Key)
+
+    key = anon(dims=num)
+
+    c.add(key, "div", num, denom, sums=True)
+
+    return key.drop("t")
+
+
+def pe_wCSSretro(
+    c: Computer,
+    t: str,
+    t_scrub: str,
+    k_share: Optional[Key],
+    filters: Optional[dict] = None,
+) -> Key:
+    """Equivalent to the function of the same name.
+
+    :func:`message_data.tools.post_processing.default_tables._pe_wCCS_retro` at L129.
+    """
+    ACT: Key = single_key(c.full_key("ACT"))
+
+    k0 = out(c, [t_scrub])
+    k1 = c.add(anon(), "mul", k0, k_share) if k_share else k0
+
+    k2 = anon(dims=ACT).drop("t")
+    c.add(k2, "select", ACT, indexers=dict(t=t), drop=True, sums=True)
+
+    # TODO determine the dimensions to drop for the numerator
+    k3 = anon(dims=k2)
+    c.add(k3, "div", k2.drop("yv"), k2, sums=True)
+
+    filters_out = dict(c=["electr"], l=["secondary"])
+    k4 = eff(c, [t], filters_in=filters, filters_out=filters_out)
+    k5 = single_key(c.add(anon(), "mul", k3, k4))
+    k6 = single_key(c.add(anon(dims=k5), "div", k1, k5))
+
+    return k6
+
+
+def callback(rep: "Reporter", context: "Context") -> None:
+    """Partially duplicate the behaviour of :func:`_retr_CO2emi`."""
+    # TODO Handle `units_ene_mdl`
+    # TODO Handle emissions_units=units_emi
+    from . import iamc
+
+    N = len(rep.graph)
+
+    # Structure information
+    # Keys like "t::trp gas" corresponding to TECHS["trp gas"]
+    for k, v in TECHS.items():
+        rep.add(f"t::{k}", quote(v))
+
+    # Constants from report/default_units.yaml
+    rep.add("conv_c2co2:", 44.0 / 12.0)
+    rep.add("crbcnt_gas:", 0.482)  # “Carbon content of natural gas”
+
+    # L3059 from message_data/tools/post_processing/default_tables.py
+    k0 = out(rep, ["gas_cc", "gas_ppl"])
+    k1 = out(rep, ["gas_cc"])
+    k2 = out(rep, ["gas_ppl"])
+    gas_cc_share = Key("gas_cc_share", k0.dims)
+    rep.add(gas_cc_share, "div", k0, k1)
+    gas_ppl_share = Key("gas_ppl_share", k0.dims)
+    rep.add(gas_ppl_share, "div", k0, k2)
+
+    # L3026
+    c_gas = dict(c=["gas"])
+    k1 = inp(
+        rep,
+        [
+            "gas_i",
+            "hp_gas_i",
+            "gas_fs",
+            "gas_ppl",
+            "gas_ct",
+            "gas_cc",
+            "gas_htfc",
+            "gas_hpl",
+            "gas_t_d",
+            "gas_t_d_ch4",
+        ]
+        + TECHS["rc gas"]
+        + TECHS["trp gas"]
+        + TECHS["gas extra"],
+        filters=c_gas,
+    )
+    k2 = out(rep, ["gas_t_d", "gas_t_d_ch4"], filters=c_gas)
+
+    inp_nonccs_gas_tecs = Key("inp_nonccs_gas_tecs", k2.dims)
+    rep.add(inp_nonccs_gas_tecs, "sub", k1, k2)
+
+    # L3091
+    Biogas_tot_abs = out(rep, ["gas_bio"])
+    Biogas_tot = rep.add(
+        "Biogas_tot", "mul", Biogas_tot_abs, "crbcnt_gas", "conv_c2co2"
+    )
+
+    # L3052
+    key = inp(
+        rep,
+        ["gas_cc_ccs", "meth_ng", "meth_ng_ccs", "h2_smr", "h2_smr_ccs"],
+        filters=c_gas,
+    )
+    inp_all_gas_tecs = Key("inp_all_gas_tecs", key.dims)
+    rep.add(inp_all_gas_tecs, "add", inp_nonccs_gas_tecs, key)
+
+    # L3165
+    Hydrogen_tot = emi(rep, ["h2_mix"], filters=dict(r="CO2_cc"))
+
+    # L3063
+    filters = dict(c=["gas"], l=["secondary"])
+
+    keys = [
+        pe_wCSSretro(rep, *args, filters=filters)
+        for args in (
+            ("gas_cc", "g_ppl_co2scr", gas_cc_share),
+            ("gas_ppl", "g_ppl_co2_scr", gas_ppl_share),
+            # FIXME Raises KeyError
+            # ("gas_htfc", "gfc_co2scr", None),
+        )
+    ]
+
+    key = Key.product(anon().name, *keys)
+    rep.add(key, "add", *keys)
+
+    inp_nonccs_gas_tecs_wo_CCSRETRO = Key("inp_nonccs_gas_tecs_wo_CCSRETRO", key.dims)
+    rep.add(inp_nonccs_gas_tecs_wo_CCSRETRO, "sub", inp_nonccs_gas_tecs, key)
+
+    # L3144
+    key = inp(rep, TECHS["trp gas"], filters=c_gas)
+    key = rep.add(anon(), "mul", Biogas_tot, key)
+
+    Biogas_trp = Key.product("Biogas_trp", key, inp_all_gas_tecs)
+    rep.add(Biogas_trp, "div", key, inp_all_gas_tecs)
+
+    # L3234
+    key = inp(rep, TECHS["trp gas"], filters=c_gas)
+    key = rep.add(anon(), "mul", Hydrogen_tot, key)
+
+    Hydrogen_trp = Key.product("Hydrogen_trp", key, inp_nonccs_gas_tecs_wo_CCSRETRO)
+    rep.add(Hydrogen_trp, "div", key, inp_nonccs_gas_tecs_wo_CCSRETRO)
+
+    # L3346
+    FE_Transport = emi(
+        rep,
+        get_techs("trp", "coal foil gas loil meth"),
+        name="FE_Transport",
+        filters=dict(r=["CO2_trp"]),
+    )
+
+    # L3886
+    k0 = Key.product(anon().name, FE_Transport, Biogas_trp)
+    rep.add(k0, "sub", FE_Transport, Biogas_trp)
+
+    k1 = Key.product("Transport", k0, Hydrogen_trp)
+    rep.add(k1, "add", k0, Hydrogen_trp, sums=True)
+
+    # FIXME Set units properly upstream so these units emerge from the calculation
+    k2 = rep.add(k1 + "units", "assign_units", k1, units="Mt/a")
+
+    # TODO Identify where to sum on "h", "m", "yv" dimensions
+
+    # Convert to IAMC format
+    var = "Emissions|CO2|Energy|Demand|Transportation|Road Rail and Domestic Shipping"
+    info = dict(variable="transport emissions", base=k1.drop("h", "m", "yv"), var=[var])
+    iamc(rep, info)
+
+    # TODO use store_ts()
+
+    log.info(f"Added {len(rep.graph) - N} keys")

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -172,18 +172,22 @@ def model_periods(y: List[int], cat_year: pd.DataFrame) -> List[int]:
 
 def remove_ts(
     scenario: ixmp.Scenario,
-    config: dict,
+    config: Optional[dict] = None,
     after: Optional[int] = None,
     dump: bool = False,
 ) -> None:
     """Remove all time series data from `scenario`.
 
-    .. todo:: Improve to provide the option to remove only those periods in the model
-       horizon.
+    Note that data stored with :meth:`.add_timeseries` using :py:`meta=True` as a
+    keyword argument cannot be removed using :meth:`.TimeSeries.remove_timeseries`, and
+    thus also not with this operator.
 
-    .. todo:: Move upstream, e.g. to :mod:`ixmp` alongside :func:`.store_ts`.
+    .. todo:: Move upstream, to :mod:`ixmp` alongside :func:`.store_ts`.
     """
-    data = scenario.timeseries()
+    if dump:
+        raise NotImplementedError
+
+    data = scenario.timeseries().drop("value", axis=1)
     N = len(data)
     count = f"{N}"
 
@@ -202,9 +206,6 @@ def remove_ts(
         scenario.discard_changes()
     else:
         scenario.commit(f"Remove time series data ({__name__}.remove_all_ts)")
-
-    if dump:
-        raise NotImplementedError
 
 
 # Non-weak references to objects to keep them alive

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -68,7 +68,7 @@ def compound_growth(qty: Quantity, dim: str) -> Quantity:
     return pow(qty, Quantity(dur)).cumprod(dim).shift({dim: 1}).fillna(1.0)
 
 
-@Operator.define
+@Operator.define()
 def exogenous_data():
     """No action.
 

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -166,13 +166,8 @@ def model_periods(y: List[int], cat_year: pd.DataFrame) -> List[int]:
 
     .. todo:: Move upstream, to :mod:`message_ix`.
     """
-    return list(
-        filter(
-            lambda year: cat_year.query("type_year == 'firstmodelyear'")["year"].item()
-            <= year,
-            y,
-        )
-    )
+    y0 = cat_year.query("type_year == 'firstmodelyear'")["year"].item()
+    return list(filter(lambda year: y0 <= year, y))
 
 
 def remove_ts(

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -15,6 +15,8 @@ from ixmp.reporting import Quantity
 from message_ix_models import Context
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from genno import Computer, Key
     from sdmx.model.v21 import Code
 
@@ -120,7 +122,7 @@ def get_ts(
     return scenario.timeseries(iamc=iamc, subannual=subannual, **filters)
 
 
-def gwp_factors():
+def gwp_factors() -> Quantity:
     """Use :mod:`iam_units` to generate a Quantity of GWP factors.
 
     The quantity is dimensionless, e.g. for converting [mass] to [mass], andhas
@@ -154,7 +156,7 @@ def gwp_factors():
     )
 
 
-def make_output_path(config, name):
+def make_output_path(config: Mapping, name: str) -> "Path":
     """Return a path under the "output_dir" Path from the reporter configuration."""
     return config["output_dir"].joinpath(name)
 

--- a/message_ix_models/report/computations.py
+++ b/message_ix_models/report/computations.py
@@ -210,23 +210,18 @@ def remove_ts(
 # Non-weak references to objects to keep them alive
 _FROM_URL_REF: Set[Any] = set()
 
-# def from_url(url: str) -> message_ix.Scenario:
-#     """Return a :class:`message_ix.Scenario` given its `url`.
-#
-#     .. todo:: Move upstream to :mod:`message_ix.reporting`.
-#     .. todo:: Create a similar method in :mod:`ixmp.reporting` to load and return
-#        :class:`ixmp.TimeSeries` (or :class:`ixmp.Scenario`) given its `url`.
-#     """
-#     s, mp = message_ix.Scenario.from_url(url)
-#     assert s is not None
-#     _FROM_URL_REF.add(s)
-#     _FROM_URL_REF.add(mp)
-#     return s
 
+def from_url(url: str, cls=ixmp.TimeSeries) -> ixmp.TimeSeries:
+    """Return a :class:`ixmp.TimeSeries` or subclass instance, given its `url`.
 
-def from_url(url: str) -> ixmp.TimeSeries:
-    """Return a :class:`ixmp.TimeSeries` given its `url`."""
-    ts, mp = ixmp.TimeSeries.from_url(url)
+    .. todo:: Move upstream, to :mod:`ixmp.reporting`.
+
+    Parameters
+    ----------
+    cls : type, *optional*
+        Subclass to instantiate and return; for instance, |Scenario|.
+    """
+    ts, mp = cls.from_url(url)
     assert ts is not None
     _FROM_URL_REF.add(ts)
     _FROM_URL_REF.add(mp)

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -244,6 +244,10 @@ def data_from_file(path: Path, *, name: str, dims: Sequence[str]) -> Quantity:
         cols = list(dims) + ["value", "unit"]
         tmp = (
             pd.read_csv(path, engine="pyarrow")
+            # Drop a leading index column that appears in some files
+            # TODO Adjust .snapshot.unpack() to avoid generating this column; update
+            # data; then remove this call
+            .drop(columns="", errors="ignore")
             .set_axis(cols, axis=1)
             .set_index(cols[:-2])
         )

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -1,6 +1,6 @@
 from message_ix_models import ScenarioInfo
 from message_ix_models.report import prepare_reporter
-from message_ix_models.report.compat import callback
+from message_ix_models.report.compat import callback, prepare_techs
 
 from ..test_report import MARK, ss_reporter
 
@@ -29,3 +29,25 @@ def test_compat(test_context):
     # print(result.to_string())
     # print(result.as_pandas().to_string())
     del result
+
+
+def test_prepare_techs(test_context):
+    from message_ix_models.model.bare import get_spec
+    from message_ix_models.report.compat import TECHS
+
+    spec = get_spec(test_context)
+
+    prepare_techs(spec.add.set["technology"])
+
+    # Expected sets of technologies based on the default technology.yaml
+    assert {
+        "gas extra": [],
+        # Residential and commercial
+        "rc gas": ["gas_rc", "hp_gas_rc"],
+        # Transport
+        "trp coal": ["coal_trp"],
+        "trp foil": ["foil_trp"],
+        "trp gas": ["gas_trp"],
+        "trp loil": ["loil_trp"],
+        "trp meth": ["meth_fc_trp", "meth_ic_trp"],
+    } == TECHS

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -9,6 +9,8 @@ from ..test_report import MARK, ss_reporter
 
 @MARK[0]
 def test_compat(test_context):
+    import numpy.testing as npt
+
     rep = ss_reporter()
     prepare_reporter(test_context, reporter=rep)
 
@@ -24,13 +26,22 @@ def test_compat(test_context):
     # key = "_26"  # Fourth level
 
     # print(rep.describe(key))
+    # rep.visualize("transport-emissions-full-iamc.svg", key)
 
     # Calculation runs
     result = rep.get(key)
 
     # print(result.to_string())
     # print(result.as_pandas().to_string())
-    del result
+
+    # Check a specific value
+    # TODO Expand set of expected values
+    npt.assert_allclose(
+        result.as_pandas()
+        .query("region == 'R11_AFR' and year == 2020")["value"]
+        .item(),
+        54.0532,
+    )
 
 
 def test_prepare_techs(test_context):

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -1,0 +1,30 @@
+from message_ix_models import ScenarioInfo
+from message_ix_models.report import prepare_reporter
+from message_ix_models.report.compat import callback
+
+from ..test_report import ss_reporter
+
+
+def test_compat(test_context):
+    rep = ss_reporter()
+    prepare_reporter(test_context, reporter=rep)
+
+    rep.add("scenario", ScenarioInfo(model="Model name", scenario="Scenario name"))
+
+    # Tasks can be added to the reporter
+    callback(rep, test_context)
+
+    key = "transport emissions full::iamc"  # IAMC structure
+    # key = "Transport"  # Top level
+    # key = "Hydrogen_trp"  # Second level
+    # key = "inp_nonccs_gas_tecs_wo_CCSRETRO"  # Third level
+    # key = "_26"  # Fourth level
+
+    # print(rep.describe(key))
+
+    # Calculation runs
+    result = rep.get(key)
+
+    # print(result.to_string())
+    # print(result.as_pandas().to_string())
+    del result

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -1,6 +1,8 @@
+from genno import Computer
+
 from message_ix_models import ScenarioInfo
 from message_ix_models.report import prepare_reporter
-from message_ix_models.report.compat import callback, prepare_techs
+from message_ix_models.report.compat import callback, get_techs, prepare_techs
 
 from ..test_report import MARK, ss_reporter
 
@@ -33,11 +35,12 @@ def test_compat(test_context):
 
 def test_prepare_techs(test_context):
     from message_ix_models.model.bare import get_spec
-    from message_ix_models.report.compat import TECHS
+    from message_ix_models.report.compat import TECH_FILTERS
 
     spec = get_spec(test_context)
 
-    prepare_techs(spec.add.set["technology"])
+    c = Computer()
+    prepare_techs(c, spec.add.set["technology"])
 
     # Expected sets of technologies based on the default technology.yaml
     assert {
@@ -50,4 +53,4 @@ def test_prepare_techs(test_context):
         "trp gas": ["gas_trp"],
         "trp loil": ["loil_trp"],
         "trp meth": ["meth_fc_trp", "meth_ic_trp"],
-    } == TECHS
+    } == {k: get_techs(c, k) for k in TECH_FILTERS}

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -1,8 +1,17 @@
+import logging
+
 from genno import Computer
+from ixmp.testing import assert_logs
 
 from message_ix_models import ScenarioInfo
+from message_ix_models.model.structure import get_codes
 from message_ix_models.report import prepare_reporter
-from message_ix_models.report.compat import callback, get_techs, prepare_techs
+from message_ix_models.report.compat import (
+    TECH_FILTERS,
+    callback,
+    get_techs,
+    prepare_techs,
+)
 
 from ..test_report import MARK, ss_reporter
 
@@ -52,7 +61,6 @@ def test_compat(tmp_path, test_context):
 
 def test_prepare_techs(test_context):
     from message_ix_models.model.bare import get_spec
-    from message_ix_models.report.compat import TECH_FILTERS
 
     # Retrieve a spec with the default set of technologies
     spec = get_spec(test_context)
@@ -88,3 +96,11 @@ def test_prepare_techs(test_context):
         "trp loil": ["loil_trp"],
         "trp meth": ["meth_fc_trp", "meth_ic_trp"],
     } == {k: get_techs(c, k) for k in TECH_FILTERS}
+
+
+def test_prepare_techs_filter_error(caplog, monkeypatch):
+    """:func:`.prepare_techs` logs warnings for invalid filters."""
+    monkeypatch.setitem(TECH_FILTERS, "foo", "not a filter")
+
+    with assert_logs(caplog, "SyntaxError('invalid syntax", at_level=logging.WARNING):
+        prepare_techs(Computer(), get_codes("technology"))

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -2,9 +2,10 @@ from message_ix_models import ScenarioInfo
 from message_ix_models.report import prepare_reporter
 from message_ix_models.report.compat import callback
 
-from ..test_report import ss_reporter
+from ..test_report import MARK, ss_reporter
 
 
+@MARK[0]
 def test_compat(test_context):
     rep = ss_reporter()
     prepare_reporter(test_context, reporter=rep)

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -16,7 +16,7 @@ from message_ix_models.report.compat import (
 from ..test_report import MARK, ss_reporter
 
 
-@MARK[0]
+@MARK[1]
 def test_compat(tmp_path, test_context):
     import numpy.testing as npt
 

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -37,13 +37,30 @@ def test_prepare_techs(test_context):
     from message_ix_models.model.bare import get_spec
     from message_ix_models.report.compat import TECH_FILTERS
 
+    # Retrieve a spec with the default set of technologies
     spec = get_spec(test_context)
+    technologies = spec.add.set["technology"]
 
     c = Computer()
-    prepare_techs(c, spec.add.set["technology"])
+    prepare_techs(c, technologies)
 
     # Expected sets of technologies based on the default technology.yaml
     assert {
+        "gas all": [
+            "gas_cc",
+            "gas_ct",
+            "gas_fs",
+            "gas_hpl",
+            "gas_htfc",
+            "gas_i",
+            "gas_ppl",
+            "gas_rc",
+            "gas_t_d",
+            "gas_t_d_ch4",
+            "gas_trp",
+            "hp_gas_i",
+            "hp_gas_rc",
+        ],
         "gas extra": [],
         # Residential and commercial
         "rc gas": ["gas_rc", "hp_gas_rc"],

--- a/message_ix_models/tests/report/test_compat.py
+++ b/message_ix_models/tests/report/test_compat.py
@@ -8,7 +8,7 @@ from ..test_report import MARK, ss_reporter
 
 
 @MARK[0]
-def test_compat(test_context):
+def test_compat(tmp_path, test_context):
     import numpy.testing as npt
 
     rep = ss_reporter()
@@ -19,28 +19,34 @@ def test_compat(test_context):
     # Tasks can be added to the reporter
     callback(rep, test_context)
 
-    key = "transport emissions full::iamc"  # IAMC structure
-    # key = "Transport"  # Top level
-    # key = "Hydrogen_trp"  # Second level
-    # key = "inp_nonccs_gas_tecs_wo_CCSRETRO"  # Third level
-    # key = "_26"  # Fourth level
+    # Select a key
+    key = (
+        "transport emissions full::iamc"  # IAMC structure
+        # "Transport"  # Top level
+        # "Hydrogen_trp"  # Second level
+        # "inp_nonccs_gas_tecs_wo_CCSRETRO"  # Third level
+        # "_26"  # Fourth level
+    )
 
+    # commented: Show what would be done
     # print(rep.describe(key))
-    # rep.visualize("transport-emissions-full-iamc.svg", key)
+    # rep.visualize(tmp_path.joinpath("visualize.svg"), key)
 
     # Calculation runs
     result = rep.get(key)
 
-    # print(result.to_string())
-    # print(result.as_pandas().to_string())
+    # print(result.to_string())  # For intermediate results
+
+    df = result.as_pandas()  # For pyam.IamDataFrame, which doesn't have .to_string()
+
+    # commented: Display or save output
+    # print(df.to_string())
+    # df.to_csv(tmp_path.joinpath("transport-emissions-full.csv"), index=False)
 
     # Check a specific value
     # TODO Expand set of expected values
     npt.assert_allclose(
-        result.as_pandas()
-        .query("region == 'R11_AFR' and year == 2020")["value"]
-        .item(),
-        54.0532,
+        df.query("region == 'R11_AFR' and year == 2020")["value"].item(), 54.0532
     )
 
 

--- a/message_ix_models/tests/report/test_computations.py
+++ b/message_ix_models/tests/report/test_computations.py
@@ -1,10 +1,26 @@
 import re
 
 import pandas as pd
+import pytest
 import xarray as xr
-from genno import Quantity
+from genno import Computer, Quantity
 
-from message_ix_models.report.computations import compound_growth, filter_ts
+from message_ix_models.report.computations import (
+    compound_growth,
+    filter_ts,
+    from_url,
+    get_ts,
+    gwp_factors,
+    make_output_path,
+    model_periods,
+    remove_ts,
+    share_curtailment,
+)
+
+
+@pytest.fixture
+def c() -> Computer:
+    return Computer()
 
 
 def test_compound_growth():
@@ -45,3 +61,45 @@ def test_filter_ts():
 
     # Only the first match group in `expr` is preserved
     assert {"ar"} == set(result.variable.unique())
+
+
+@pytest.mark.xfail(reason="Incomplete")
+def test_from_url():
+    from_url()
+
+
+@pytest.mark.xfail(reason="Incomplete")
+def test_get_ts():
+    get_ts()
+
+
+def test_gwp_factors():
+    result = gwp_factors()
+
+    assert ("gwp metric", "e", "e equivalent") == result.dims
+
+
+def test_make_output_path(tmp_path, c):
+    # Configure a Computer, ensuring the output_dir configuration attribute is set
+    c.configure(output_dir=tmp_path)
+
+    # Add a computation that invokes make_output_path
+    c.add("test", make_output_path, "config", "foo.csv")
+
+    # Returns the correct path
+    assert tmp_path.joinpath("foo.csv") == c.get("test")
+
+
+@pytest.mark.xfail(reason="Incomplete")
+def test_model_periods():
+    model_periods()
+
+
+@pytest.mark.xfail(reason="Incomplete")
+def test_remove_ts():
+    remove_ts()
+
+
+@pytest.mark.xfail(reason="Incomplete")
+def test_share_curtailment():
+    share_curtailment()

--- a/message_ix_models/tests/report/test_computations.py
+++ b/message_ix_models/tests/report/test_computations.py
@@ -5,6 +5,8 @@ import pytest
 import xarray as xr
 from genno import Computer, Quantity
 
+from message_ix_models import ScenarioInfo
+from message_ix_models.model.structure import get_codes
 from message_ix_models.report.computations import (
     compound_growth,
     filter_ts,
@@ -90,9 +92,18 @@ def test_make_output_path(tmp_path, c):
     assert tmp_path.joinpath("foo.csv") == c.get("test")
 
 
-@pytest.mark.xfail(reason="Incomplete")
 def test_model_periods():
-    model_periods()
+    # Prepare input data
+    si = ScenarioInfo()
+    si.year_from_codes(get_codes("year/B"))
+    cat_year = pd.DataFrame(si.set["cat_year"], columns=["type_year", "year"])
+
+    # Operator runs
+    result = model_periods(si.set["year"], cat_year)
+
+    assert isinstance(result, list)
+    assert all(isinstance(y, int) for y in result)
+    assert 2020 == min(result)
 
 
 @pytest.mark.xfail(reason="Incomplete")

--- a/message_ix_models/tests/report/test_computations.py
+++ b/message_ix_models/tests/report/test_computations.py
@@ -3,9 +3,11 @@ import re
 import ixmp
 import message_ix
 import pandas as pd
+import pandas.testing as pdt
 import pytest
 import xarray as xr
 from genno import Computer, Quantity
+from ixmp.testing import assert_logs
 from message_ix.testing import make_dantzig
 
 from message_ix_models import ScenarioInfo
@@ -90,8 +92,38 @@ def test_from_url(scenario):
     assert scenario.url == result.url
 
 
-def test_get_ts():
-    get_ts()
+def test_get_remove_ts(caplog, scenario):
+    # get_ts() runs
+    result0 = get_ts(scenario)
+    pdt.assert_frame_equal(scenario.timeseries(), result0)
+
+    # Can be used through a Computer
+
+    c = Computer()
+    c.require_compat("message_ix_models.report.computations")
+    c.add("scenario", scenario)
+
+    key = c.add("test1", "get_ts", "scenario", filters=dict(variable="GDP"))
+    result1 = c.get(key)
+    assert 3 == len(result1)
+
+    # remove_ts() can be used through Computer
+    key = c.add("test2", "remove_ts", "scenario", "config", after=1964)
+
+    # Task runs, logs
+    # NB this log message is incorrect, because ixmp's JDBCBackend is unable to delete
+    #    data stored with "meta=True". Only 1 row is removed
+    with assert_logs(caplog, "Remove 2 of 6 (1964 <= year) rows of time series data"):
+        c.get(key)
+
+    # See comment above; only one row is removed
+    assert 6 - 1 == len(scenario.timeseries())
+
+    # remove_ts() can be used directly
+    remove_ts(scenario)
+
+    # All non-'meta' data were removed
+    assert 3 == len(scenario.timeseries())
 
 
 def test_gwp_factors():
@@ -123,11 +155,6 @@ def test_model_periods():
     assert isinstance(result, list)
     assert all(isinstance(y, int) for y in result)
     assert 2020 == min(result)
-
-
-@pytest.mark.xfail(reason="Incomplete")
-def test_remove_ts():
-    remove_ts()
 
 
 @pytest.mark.xfail(reason="Incomplete")

--- a/message_ix_models/tests/report/test_computations.py
+++ b/message_ix_models/tests/report/test_computations.py
@@ -24,6 +24,8 @@ from message_ix_models.report.computations import (
     share_curtailment,
 )
 
+from ..test_report import MARK
+
 
 @pytest.fixture
 def c() -> Computer:
@@ -76,6 +78,7 @@ def test_filter_ts():
     assert {"ar"} == set(result.variable.unique())
 
 
+@MARK[0]
 def test_from_url(scenario):
     full_url = f"ixmp://{scenario.platform.name}/{scenario.url}"
 
@@ -92,6 +95,7 @@ def test_from_url(scenario):
     assert scenario.url == result.url
 
 
+@MARK[0]
 def test_get_remove_ts(caplog, scenario):
     # get_ts() runs
     result0 = get_ts(scenario)

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -5,9 +5,10 @@ import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
+from ixmp.testing import assert_logs
 
 from message_ix_models import ScenarioInfo, testing
-from message_ix_models.report import prepare_reporter, report, util
+from message_ix_models.report import prepare_reporter, register, report, util
 from message_ix_models.report.sim import add_simulated_solution
 from message_ix_models.util import package_data_path
 
@@ -25,6 +26,22 @@ MARK = (
         reason="Not supported with message_ix < 3.6",
     ),
 )
+
+
+def test_register(caplog):
+    # Exception raised for unfindable module
+    with pytest.raises(ModuleNotFoundError):
+        register("foo.bar")
+
+    # Adding a callback of the same name twice triggers a log message
+    def _cb(*args):
+        pass
+
+    register(_cb)
+    with assert_logs(
+        caplog, "Already registered: <function test_register.<locals>._cb"
+    ):
+        register(_cb)
 
 
 @MARK[0]

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -21,6 +21,10 @@ MIN_CONFIG = {
 
 MARK = (
     pytest.mark.xfail(
+        condition=version("message_ix") < "3.5",
+        reason="Not supported with message_ix < 3.5",
+    ),
+    pytest.mark.xfail(
         condition=version("message_ix") < "3.6",
         raises=NotImplementedError,
         reason="Not supported with message_ix < 3.6",
@@ -44,7 +48,7 @@ def test_register(caplog):
         register(_cb)
 
 
-@MARK[0]
+@MARK[1]
 def test_report_bare_res(request, test_context):
     """Prepare and run the standard MESSAGE-GLOBIOM reporting on a bare RES."""
     scenario = testing.bare_res(request, test_context, solved=True)
@@ -124,7 +128,7 @@ INV_COST_CONFIG = dict(
 )
 
 
-@MARK[0]
+@MARK[1]
 @pytest.mark.parametrize("regions", ["R11"])
 def test_apply_units(request, test_context, regions):
     test_context.regions = regions
@@ -242,7 +246,7 @@ def ss_reporter():
     return rep
 
 
-@MARK[0]
+@MARK[1]
 def test_add_simulated_solution(test_context, test_data_path):
     # Simulated solution can be added to an empty Reporter
     rep = ss_reporter()
@@ -270,7 +274,7 @@ def test_add_simulated_solution(test_context, test_data_path):
     assert np.isclose(79.76478, value.item())
 
 
-@MARK[0]
+@MARK[1]
 def test_prepare_reporter(test_context):
     rep = ss_reporter()
     N = len(rep.graph)

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -132,21 +132,16 @@ class ScenarioInfo:
     def yv_ya(self):
         """:class:`pandas.DataFrame` with valid ``year_vtg``, ``year_act`` pairs."""
         if self._yv_ya is None:
-            first = self.y0
-
-            # Product of all years
-            yv = ya = self.set["year"]
-
-            # Predicate for filtering years
-            def _valid(elem):
-                yv, ya = elem
-                return first <= yv <= ya
-
             # - Cartesian product of all yv and ya.
-            # - Filter only valid years.
             # - Convert to data frame.
-            self._yv_ya = pd.DataFrame(
-                filter(_valid, product(yv, ya)), columns=["year_vtg", "year_act"]
+            # - Filter only valid years.
+            self._yv_ya = (
+                pd.DataFrame(
+                    product(self.set["year"], self.set["year"]),
+                    columns=["year_vtg", "year_act"],
+                )
+                .query("@self.y0 <= year_vtg <= year_act")
+                .reset_index(drop=True)
             )
 
         return self._yv_ya

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "colorama",
   # When the minimum is greater than the minimum via message_ix; e.g.
   # message_ix >= 3.4.0 → ixmp >= 3.4.0 → genno >= 1.6.0",
-  "genno >= 1.18.1",
+  "genno >= 1.20.0",
   "iam_units >= 2023.9.11",
   "message_ix >= 3.4.0",
   "pooch",


### PR DESCRIPTION
This PR adds code that mirrors the behaviour of `message_data` (‘legacy’) reporting, as an exploration of how to exactly replicate these calculations using `genno`. For this purpose, the code only replaces the portions of `message_data.tools.post_processing.default_tables.retr_CO2emi` that calculate CO₂ emissions from transportation.

The goals are:
- The magnitudes and labels on the data are the same (to within a small tolerance) as those produced by `message_data`. (However, per [this Slack thread](https://iiasa-ece.slack.com/archives/CD0GBHHA4/p1698062587533069), there does not exist a legacy reporting output for the snapshot, and it would be difficult to produce one due to changes to the units.)
- The code is legible, and it is clear how the genno-based code mirrors the logic of the older code.

Some things specifically omitted, that could be tackled in follow-up PRs:
- Apply units to e.g. `out:*` earlier, in a single operation for all technologies that share the same units of `ACT` and `output`.

Housekeeping
- Adjust usage of `genno.Operator.define` to avoid mypy complaints in "Code quality" CI job (FYI @glatterf42)

## How to review

See:
- The added docs.
- [transport-emissions-full-iamc.svg](https://github.com/iiasa/message-ix-models/assets/1634164/1109eee7-48b7-4497-9c6f-46f36cd56428) —genno visualization of the calculation of "transport emissions full::iamc".
- [transport-emissions-full.csv](https://github.com/iiasa/message-ix-models/files/13054269/transport-emissions-full.csv) —output.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.