### PR TITLE
Correct DOI URL in doc/api/model-snapshot

### DIFF
--- a/doc/api/model-snapshot.rst
+++ b/doc/api/model-snapshot.rst
@@ -25,7 +25,7 @@ In code, use :func:`.snapshot.load`:
 
     snapshot.load(scenario, 0)
 
-.. note:: For snapshot 0, contrary to the `description of the Zenodo item <https://10.5281/zenodo.5793870>`__, the file cannot be loaded using :meth:`.Scenario.read_excel`.
+.. note:: For snapshot 0, contrary to the `description of the Zenodo item <https://doi.org/10.5281/zenodo.5793870>`__, the file cannot be loaded using :meth:`.Scenario.read_excel`.
    This limitation will be fixed in subsequent snapshots.
 
 Code reference


### PR DESCRIPTION
The domain (doi.org) was missing, making this a broken link.

## How to review

Look at the RTD auto build and ensure the link is no longer broken.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update doc/whatsnew.~ N/A
