### PR TITLE
Derive income categories for MESSAGE node lists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - mypy
+    - mypy >= 1.8.0
     - plotnine
     - pytest
     - sdmx1
@@ -19,11 +19,9 @@ repos:
     - "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
     - "message-ix @ git+https://github.com/iiasa/message_ix.git@main"
     args: ["."]
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.7.0
-  hooks:
-  - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.287
+  rev: v0.1.13
   hooks:
   - id: ruff
+  - id: ruff-format
+    args: [ --check ]

--- a/doc/api/tools.rst
+++ b/doc/api/tools.rst
@@ -98,6 +98,9 @@ IAMC data structures (:mod:`.tools.iamc`)
 .. automodule:: message_ix_models.tools.iamc
    :members:
 
+
+.. _tools-wb:
+
 World Bank structures (:mod:`.tools.wb`)
 ========================================
 

--- a/doc/api/tools.rst
+++ b/doc/api/tools.rst
@@ -97,3 +97,9 @@ IAMC data structures (:mod:`.tools.iamc`)
 
 .. automodule:: message_ix_models.tools.iamc
    :members:
+
+World Bank structures (:mod:`.tools.wb`)
+========================================
+
+.. automodule:: message_ix_models.tools.wb
+   :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,6 +60,7 @@ rst_prolog = """
    :language: python
 
 .. |Code| replace:: :class:`~sdmx.model.common.Code`
+.. |Codelist| replace:: :class:`~sdmx.model.common.Codelist`
 .. |Platform| replace:: :class:`~ixmp.Platform`
 .. |Scenario| replace:: :class:`~message_ix.Scenario`
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,6 +59,7 @@ rst_prolog = """
 .. role:: py(code)
    :language: python
 
+.. |Annotation| replace:: :class:`~sdmx.model.common.Annotation`
 .. |Code| replace:: :class:`~sdmx.model.common.Code`
 .. |Codelist| replace:: :class:`~sdmx.model.common.Codelist`
 .. |Platform| replace:: :class:`~ixmp.Platform`

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Add :ref:`tools-wb` and :func:`.assign_income_groups` to assign MESSAGE regions to World Bank income groups (:pull:`144`).
 - Adjust :mod:`.report.compat` for genno version 1.22 (:issue:`141`, :pull:`142`).
 
 v2023.11.24

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pycountry
 import xarray as xr
 from iam_units import registry
-from sdmx.model.v21 import Annotation, Code
+from sdmx.model.v21 import Annotation, Code, Codelist
 
 from message_ix_models.util import eval_anno, load_package_data, package_data_path
 from message_ix_models.util.sdmx import as_codes
@@ -90,6 +90,14 @@ def get_codes(name: str) -> List[Code]:
         process_technology_codes(data)
 
     return data
+
+
+@lru_cache()
+def get_codelist(name: str) -> Codelist:
+    """Return a |Codelist| for the dimension/set `name` in MESSAGE-GLOBIOM scenarios."""
+    cl = Codelist(id=name.replace("/", "_").upper())
+    cl.extend(get_codes(name))
+    return cl
 
 
 @lru_cache()

--- a/message_ix_models/tests/tools/test_wb.py
+++ b/message_ix_models/tests/tools/test_wb.py
@@ -1,14 +1,26 @@
+from typing import TYPE_CHECKING, Optional
+
 import pytest
 
 from message_ix_models.model.structure import get_codelist
-from message_ix_models.tools.wb import assign_income_groups, get_income_group_codelist
+from message_ix_models.tools.wb import (
+    assign_income_groups,
+    get_income_group_codelist,
+    make_map,
+)
+
+if TYPE_CHECKING:
+    import sdmx.model.common
 
 
-def test_get_income_group_codelist() -> None:
-    cl = get_income_group_codelist()
+@pytest.fixture(scope="module")
+def cl_ig() -> "sdmx.model.common.Codelist":
+    return get_income_group_codelist()
 
+
+def test_get_income_group_codelist(cl_ig: "sdmx.model.common.Codelist") -> None:
     def n(id) -> int:
-        return len(cl[id].child)
+        return len(cl_ig[id].child)
 
     # Groups counts are as expected and have the expected relationships
     assert 25 == n("LIC")
@@ -20,13 +32,36 @@ def test_get_income_group_codelist() -> None:
     # Annotations exist and have expected values
     assert (
         "urn:sdmx:org.sdmx.infomodel.codelist.Code=WB:CL_REF_AREA_WDI(1.0).HIC"
-        == str(cl["ABW"].get_annotation(id="wb-income-group").text)
+        == str(cl_ig["ABW"].get_annotation(id="wb-income-group").text)
     )
-    assert "IDA" == str(cl["AFG"].get_annotation(id="wb-lending-category").text)
+    assert "IDA" == str(cl_ig["AFG"].get_annotation(id="wb-lending-category").text)
 
+
+REPLACE = (
+    {  # index 0
+        "HIC": "HIC",
+        "UMC": "LMIC",
+        "LMC": "LMIC",
+        "LIC": "LMIC",
+    },
+)
 
 EXP = {
-    ("R12", "count"): {
+    ("R12", "count", None): {
+        "R12_AFR": "LIC",
+        "R12_RCPA": "LMC",
+        "R12_CHN": "HIC",
+        "R12_EEU": "HIC",
+        "R12_FSU": "UMC",
+        "R12_LAM": "UMC",
+        "R12_MEA": "HIC",
+        "R12_NAM": "HIC",
+        "R12_PAO": "HIC",
+        "R12_PAS": "LMC",
+        "R12_SAS": "LMC",
+        "R12_WEU": "HIC",
+    },
+    ("R12", "population", None): {
         "R12_AFR": "LMC",
         "R12_RCPA": "LMC",
         "R12_CHN": "UMC",
@@ -40,39 +75,58 @@ EXP = {
         "R12_SAS": "LMC",
         "R12_WEU": "HIC",
     },
-    ("R12", "population"): {
-        "R12_AFR": "LMC",
-        "R12_RCPA": "LMC",
-        "R12_CHN": "UMC",
+    ("R12", "population", 0): {
+        "R12_AFR": "LMIC",
+        "R12_RCPA": "LMIC",
+        "R12_CHN": "LMIC",
         "R12_EEU": "HIC",
-        "R12_FSU": "UMC",
-        "R12_LAM": "UMC",
-        "R12_MEA": "LMC",
+        "R12_FSU": "LMIC",
+        "R12_LAM": "LMIC",
+        "R12_MEA": "LMIC",
         "R12_NAM": "HIC",
         "R12_PAO": "HIC",
-        "R12_PAS": "UMC",
-        "R12_SAS": "LMC",
+        "R12_PAS": "LMIC",
+        "R12_SAS": "LMIC",
         "R12_WEU": "HIC",
     },
 }
 
 
 @pytest.mark.parametrize(
-    "nodes, method",
+    "nodes, method, replace",
     (
-        ("R12", "population"),
-        ("R12", "count"),
+        ("R12", "population", None),
+        ("R12", "count", None),
+        ("R12", "population", 0),
     ),
 )
-def test_assign_income_groups(nodes: str, method: str) -> None:
+def test_assign_income_groups(
+    cl_ig: "sdmx.model.common.Codelist", nodes: str, method: str, replace: Optional[int]
+) -> None:
     cl_node = get_codelist(f"node/{nodes}")
-    cl_ig = get_income_group_codelist()
 
     # Function runs without error
-    assign_income_groups(cl_node, cl_ig, method)
+    replace_arg = make_map(REPLACE[replace]) if replace is not None else None
+
+    assign_income_groups(cl_node, cl_ig, method, replace=replace_arg)
 
     # Each node belongs to the expected income group
-    for node, ig in EXP[nodes, method].items():
-        assert str(cl_node[node].get_annotation(id="wb-income-group").text).endswith(
-            ig
-        ), node
+    for node, ig in EXP[nodes, method, replace].items():
+        c_node = cl_node[node]
+        assert str(c_node.get_annotation(id="wb-income-group").text).endswith(ig), (
+            c_node,
+            c_node.annotations,
+        )
+
+
+def test_make_map() -> None:
+    # Function runs
+    result = make_map(REPLACE[0])
+
+    # Expected result
+    assert {
+        "urn:sdmx:org.sdmx.infomodel.codelist.Code=WB:CL_REF_AREA_WDI(1.0).HIC": "HIC",
+        "urn:sdmx:org.sdmx.infomodel.codelist.Code=WB:CL_REF_AREA_WDI(1.0).LMC": "LMIC",
+        "urn:sdmx:org.sdmx.infomodel.codelist.Code=WB:CL_REF_AREA_WDI(1.0).UMC": "LMIC",
+        "urn:sdmx:org.sdmx.infomodel.codelist.Code=WB:CL_REF_AREA_WDI(1.0).LIC": "LMIC",
+    } == result

--- a/message_ix_models/tests/tools/test_wb.py
+++ b/message_ix_models/tests/tools/test_wb.py
@@ -17,35 +17,42 @@ def test_get_income_group_codelist() -> None:
     # NB +1 is for VEN, which is not categorized
     assert n("WLD") == n("LIC") + n("MIC") + n("HIC") + 1
 
+    # Annotations exist and have expected values
+    assert (
+        "urn:sdmx:org.sdmx.infomodel.codelist.Code=WB:CL_REF_AREA_WDI(1.0).HIC"
+        == str(cl["ABW"].get_annotation(id="wb-income-group").text)
+    )
+    assert "IDA" == str(cl["AFG"].get_annotation(id="wb-lending-category").text)
+
 
 EXP = {
     ("R12", "count"): {
-        "R12_AFR": "Lower middle income",
-        "R12_RCPA": "Lower middle income",
-        "R12_CHN": "Upper middle income",
-        "R12_EEU": "High income",
-        "R12_FSU": "Upper middle income",
-        "R12_LAM": "Upper middle income",
-        "R12_MEA": "Lower middle income",
-        "R12_NAM": "High income",
-        "R12_PAO": "High income",
-        "R12_PAS": "Upper middle income",
-        "R12_SAS": "Lower middle income",
-        "R12_WEU": "High income",
+        "R12_AFR": "LMC",
+        "R12_RCPA": "LMC",
+        "R12_CHN": "UMC",
+        "R12_EEU": "HIC",
+        "R12_FSU": "UMC",
+        "R12_LAM": "UMC",
+        "R12_MEA": "LMC",
+        "R12_NAM": "HIC",
+        "R12_PAO": "HIC",
+        "R12_PAS": "UMC",
+        "R12_SAS": "LMC",
+        "R12_WEU": "HIC",
     },
     ("R12", "population"): {
-        "R12_AFR": "Lower middle income",
-        "R12_RCPA": "Lower middle income",
-        "R12_CHN": "Upper middle income",
-        "R12_EEU": "High income",
-        "R12_FSU": "Upper middle income",
-        "R12_LAM": "Upper middle income",
-        "R12_MEA": "Lower middle income",
-        "R12_NAM": "High income",
-        "R12_PAO": "High income",
-        "R12_PAS": "Upper middle income",
-        "R12_SAS": "Lower middle income",
-        "R12_WEU": "High income",
+        "R12_AFR": "LMC",
+        "R12_RCPA": "LMC",
+        "R12_CHN": "UMC",
+        "R12_EEU": "HIC",
+        "R12_FSU": "UMC",
+        "R12_LAM": "UMC",
+        "R12_MEA": "LMC",
+        "R12_NAM": "HIC",
+        "R12_PAO": "HIC",
+        "R12_PAS": "UMC",
+        "R12_SAS": "LMC",
+        "R12_WEU": "HIC",
     },
 }
 
@@ -66,4 +73,6 @@ def test_assign_income_groups(nodes: str, method: str) -> None:
 
     # Each node belongs to the expected income group
     for node, ig in EXP[nodes, method].items():
-        assert ig == str(cl_node[node].get_annotation(id="wb-income-group").text), node
+        assert str(cl_node[node].get_annotation(id="wb-income-group").text).endswith(
+            ig
+        ), node

--- a/message_ix_models/tests/tools/test_wb.py
+++ b/message_ix_models/tests/tools/test_wb.py
@@ -1,3 +1,5 @@
+import pytest
+
 from message_ix_models.model.structure import get_codelist
 from message_ix_models.tools.wb import assign_income_groups, get_income_group_codelist
 
@@ -16,12 +18,8 @@ def test_get_income_group_codelist() -> None:
     assert n("WLD") == n("LIC") + n("MIC") + n("HIC") + 1
 
 
-def test_assign_income_groups(nodes="R12") -> None:
-    cl_node = get_codelist(f"node/{nodes}")
-    cl_ig = get_income_group_codelist()
-    assign_income_groups(cl_node, cl_ig)
-
-    expected = {
+EXP = {
+    ("R12", "count"): {
         "R12_AFR": "Lower middle income",
         "R12_RCPA": "Lower middle income",
         "R12_CHN": "Upper middle income",
@@ -31,11 +29,41 @@ def test_assign_income_groups(nodes="R12") -> None:
         "R12_MEA": "Lower middle income",
         "R12_NAM": "High income",
         "R12_PAO": "High income",
-        "R12_PAS": "Lower middle income",
+        "R12_PAS": "Upper middle income",
         "R12_SAS": "Lower middle income",
         "R12_WEU": "High income",
-    }
+    },
+    ("R12", "population"): {
+        "R12_AFR": "Lower middle income",
+        "R12_RCPA": "Lower middle income",
+        "R12_CHN": "Upper middle income",
+        "R12_EEU": "High income",
+        "R12_FSU": "Upper middle income",
+        "R12_LAM": "Upper middle income",
+        "R12_MEA": "Lower middle income",
+        "R12_NAM": "High income",
+        "R12_PAO": "High income",
+        "R12_PAS": "Upper middle income",
+        "R12_SAS": "Lower middle income",
+        "R12_WEU": "High income",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "nodes, method",
+    (
+        ("R12", "population"),
+        ("R12", "count"),
+    ),
+)
+def test_assign_income_groups(nodes: str, method: str) -> None:
+    cl_node = get_codelist(f"node/{nodes}")
+    cl_ig = get_income_group_codelist()
+
+    # Function runs without error
+    assign_income_groups(cl_node, cl_ig, method)
 
     # Each node belongs to the expected income group
-    for node, ig in expected.items():
-        assert ig == str(cl_node[node].get_annotation(id="wb-income-group").text)
+    for node, ig in EXP[nodes, method].items():
+        assert ig == str(cl_node[node].get_annotation(id="wb-income-group").text), node

--- a/message_ix_models/tests/tools/test_wb.py
+++ b/message_ix_models/tests/tools/test_wb.py
@@ -1,0 +1,15 @@
+from message_ix_models.tools.wb import get_income_group_codelist
+
+
+def test_get_income_group_codelist() -> None:
+    cl = get_income_group_codelist()
+
+    def n(id) -> int:
+        return len(cl[id].child)
+
+    # Groups counts are as expected and have the expected relationships
+    assert 25 == n("LIC")
+    assert 108 == n("MIC") == n("LMC") + n("UMC")
+    assert 77 == n("HIC")
+    # NB +1 is for VEN, which is not categorized
+    assert n("WLD") == n("LIC") + n("MIC") + n("HIC") + 1

--- a/message_ix_models/tests/tools/test_wb.py
+++ b/message_ix_models/tests/tools/test_wb.py
@@ -1,4 +1,5 @@
-from message_ix_models.tools.wb import get_income_group_codelist
+from message_ix_models.model.structure import get_codelist
+from message_ix_models.tools.wb import assign_income_groups, get_income_group_codelist
 
 
 def test_get_income_group_codelist() -> None:
@@ -13,3 +14,28 @@ def test_get_income_group_codelist() -> None:
     assert 77 == n("HIC")
     # NB +1 is for VEN, which is not categorized
     assert n("WLD") == n("LIC") + n("MIC") + n("HIC") + 1
+
+
+def test_assign_income_groups(nodes="R12") -> None:
+    cl_node = get_codelist(f"node/{nodes}")
+    cl_ig = get_income_group_codelist()
+    assign_income_groups(cl_node, cl_ig)
+
+    expected = {
+        "R12_AFR": "Lower middle income",
+        "R12_RCPA": "Lower middle income",
+        "R12_CHN": "Upper middle income",
+        "R12_EEU": "High income",
+        "R12_FSU": "Upper middle income",
+        "R12_LAM": "Upper middle income",
+        "R12_MEA": "Lower middle income",
+        "R12_NAM": "High income",
+        "R12_PAO": "High income",
+        "R12_PAS": "Lower middle income",
+        "R12_SAS": "Lower middle income",
+        "R12_WEU": "High income",
+    }
+
+    # Each node belongs to the expected income group
+    for node, ig in expected.items():
+        assert ig == str(cl_node[node].get_annotation(id="wb-income-group").text)

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -18,7 +18,7 @@ def assign_income_groups(
     method: str = "population",
     replace: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Annotate `cl_node` with income groups. .
+    """Annotate `cl_node` with income groups.
 
     Each node is assigned an |Annotation| with :py:`id="wb-income-group"`, according to
     the income groups of its children (countries), as reflected in `cl_income_group`
@@ -35,9 +35,9 @@ def assign_income_groups(
         - :py:`"count"`: each country is weighted equally, so that the node's income
           group is the mode (most frequently occurring value) of its childrens'.
     replace : dict
-        Mapping from wb-income-group text appearing in `cl_income_group` to texts to be
-        attached to `cl_node`. Mapping two keys to the same value effectively combines
-        or aggregates those group.
+        Mapping from wb-income-group annotation text appearing in `cl_income_group` to
+        texts to be attached to `cl_node`. Mapping two keys to the same value
+        effectively combines or aggregates those groups. See :func:`.make_map`.
 
     Example
     -------
@@ -82,7 +82,7 @@ def assign_income_groups(
             except KeyError:
                 # log.debug(f"No population data for {code!r}; omitted")
                 return 0
-    else:
+    else:  # pragma: no cover
         raise ValueError(f"method={method!r}")
 
     weight_info = {}  # For debugging
@@ -199,7 +199,7 @@ def get_income_group_codelist() -> "sdmx.model.common.Codelist":
         for code in cl:
             if str(code.name) == name:
                 return code.urn
-        raise ValueError(name)
+        raise ValueError(name)  # pragma: no cover
 
     # Fetch the file containing the classification
     file = pooch.retrieve(
@@ -279,7 +279,7 @@ def get_income_group_codelist() -> "sdmx.model.common.Codelist":
 def make_map(
     source: Dict[str, str], expand_key_urn: bool = True, expand_value_urn: bool = False
 ) -> Dict[str, str]:
-    """Prepare the :py:`map` parameter of :func:`assign_income_groups`.
+    """Prepare the :py:`replace` parameter of :func:`assign_income_groups`.
 
     The result has one (`key`, `value`) for each in `source`.
 

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -1,0 +1,120 @@
+"""Tools for World Bank data."""
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sdmx.model.common
+
+log = logging.getLogger(__name__)
+
+
+def get_income_group_codelist() -> "sdmx.model.common.Codelist":
+    """Return a :class:`.Codelist` with World Bank income group information.
+
+    The returned code list is a modified version of the one with URN
+    ``…Codelist=WB:CL_REF_AREA_WDI(1.0)``, available from
+    http://api.worldbank.org/v2/sdmx/rest/codelist/WB/ as described at
+    https://datahelpdesk.worldbank.org/knowledgebase/articles/1886701-sdmx-api-queries.
+
+    This is augmented with information about the income group and lending category
+    concepts: https://datahelpdesk.worldbank.org/knowledgebase/articles/906519
+
+    The information is stored two ways:
+
+    - Existing codes in the list like "HIC: High income" that designate groups of
+      countries are associated with child codes that are designated as members of that
+      country.
+    - Existing codes in the list like "ABW: Aruba" are annotated with:
+
+      - :py:`id="wb-income-group"`: the name of the income group, for instance
+        "High income".
+      - :py:`id="wb-lending-category"`: the name of the lending category, if any.
+    """
+    import pandas as pd
+    import pooch
+    import sdmx
+    import sdmx.model.v21 as m
+
+    # Retrieve the WB WDI related code lists
+    # NB Would prefer to use sdmx.Client("WB_WDI").codelist("CL_REF_AREA_WDI"), but the
+    #    World Bank SDMX REST API does not support queries for a specific code list.
+    file = pooch.retrieve(
+        url="http://api.worldbank.org/v2/sdmx/rest/codelist/WB/",
+        known_hash=None,
+    )
+    # Read the retrieved SDMX StructureMessage and extract the code list
+    sm = sdmx.read_sdmx(file)
+    cl = sm.codelist["CL_REF_AREA_WDI"]
+
+    # Retrieve the file containing the classification
+    file = pooch.retrieve(
+        url="https://datacatalogfiles.worldbank.org/ddh-published/0037712/DR0090755/"
+        "CLASS.xlsx",
+        known_hash="sha256:"
+        "9b8452db52e391602c9e9e4d4ef4d254f505ce210ce6464497cf3e40002a3545",
+    )
+
+    # Open the retrieved file
+    ef = pd.ExcelFile(file)
+
+    # Read the "List of economies" sheet
+    tmp = (
+        pd.read_excel(ef, sheet_name="List of economies")
+        .drop(["Economy", "Region"], axis=1)
+        .dropna(subset=["Income group"], axis=0)
+        .set_index("Code")
+    )
+    for code in cl:
+        try:
+            row = tmp.loc[code.id, :]
+        except KeyError:
+            log.debug(f"Not in 'List of economies' sheet: {code!r}")
+            continue
+
+        code.annotations.append(
+            m.Annotation(id="wb-income-group", text=row["Income group"])
+        )
+
+        try:
+            code.annotations.append(
+                m.Annotation(id="wb-lending-category", text=row["Lending category"])
+            )
+        except ValueError:
+            pass
+
+    # Read the "Groups" sheet → assign hierarchy
+    for group_id, group_df in (
+        pd.read_excel(ef, sheet_name="Groups")
+        .drop(["GroupName", "CountryName", "Unnamed: 4"], axis=1)
+        .groupby("GroupCode")
+    ):
+        try:
+            # Identify the Code for this group ID
+            group = cl[group_id]
+        except KeyError:
+            log.info(f"No code for group {group_id!r}")
+            continue
+
+        for child_id in sorted(group_df["CountryCode"]):
+            try:
+                group.append_child(cl[child_id])
+            except KeyError:
+                log.debug(f"No code for child {child_id!r}")
+                continue
+
+        log.info(f"{cl[group_id]}: {len(cl[group_id].child)} children")
+
+    # Read "Notes" sheet → append to description of `cl`
+    tmp = "\n\n".join(pd.read_excel(ef, sheet_name="Notes").dropna()["Notes"])
+
+    # Ensure the "en" localization exists
+    cl.description.localizations.setdefault("en", "")
+    cl.description.localizations["en"] += (
+        "\n\nThis code list has been modified from the official version by the "
+        "'message-ix-models' Python package to add annotations and hierarchy parsed "
+        "from the World Bank income groups and lending categories as described at "
+        "https://datahelpdesk.worldbank.org/knowledgebase/articles/906519. The original"
+        f" Excel file parsed includes the following descriptive text:\n\n{tmp}"
+    )
+
+    return cl

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -9,26 +9,32 @@ log = logging.getLogger(__name__)
 
 
 def get_income_group_codelist() -> "sdmx.model.common.Codelist":
-    """Return a :class:`.Codelist` with World Bank income group information.
+    """Return a |Codelist| with World Bank income group information.
 
     The returned code list is a modified version of the one with URN
-    ``…Codelist=WB:CL_REF_AREA_WDI(1.0)``, available from
-    http://api.worldbank.org/v2/sdmx/rest/codelist/WB/ as described at
-    https://datahelpdesk.worldbank.org/knowledgebase/articles/1886701-sdmx-api-queries.
+    ``…Codelist=WB:CL_REF_AREA_WDI(1.0)`` as described at
+    https://datahelpdesk.worldbank.org/knowledgebase/articles/1886701-sdmx-api-queries
+    and available from http://api.worldbank.org/v2/sdmx/rest/codelist/WB/.
 
     This is augmented with information about the income group and lending category
-    concepts: https://datahelpdesk.worldbank.org/knowledgebase/articles/906519
+    concepts as described at
+    https://datahelpdesk.worldbank.org/knowledgebase/articles/906519
 
     The information is stored two ways:
 
     - Existing codes in the list like "HIC: High income" that designate groups of
       countries are associated with child codes that are designated as members of that
-      country.
+      country. These can be accessed at :attr:`Code.child
+      <sdmx.model.common.Item.child>`.
     - Existing codes in the list like "ABW: Aruba" are annotated with:
 
       - :py:`id="wb-income-group"`: the name of the income group, for instance
         "High income".
       - :py:`id="wb-lending-category"`: the name of the lending category, if any.
+
+      These can be accessed using :attr:`Code.annotations
+      <sdmx.model.common.AnnotableArtefact.annotations>`, :attr:`Code.get_annotation
+      <sdmx.model.common.AnnotableArtefact.get_annotation>`, and other methods.
     """
     import pandas as pd
     import pooch


### PR DESCRIPTION
This PR adds code to:

1. Retrieve the World Bank (WB) World Development Indicators (WDI) country categorization to income groups, as described at https://datahelpdesk.worldbank.org/knowledgebase/articles/906519; then use these to annotate the CL_REF_AREA_WDI code list.
2. Use the result of (1) to determine income group categorization for arbitrary MESSAGE node lists—that is, the R12 list and others—by counting membership or population of the countries in each region.
3. As part of (2), replace, combine, or relabel groups.

This provides a transparent and repeatable way of determining this categorization by reference to established sources. It will be useful in applying assumptions in, for instance, the transport realizations of the 2024 SSPs, since these can be distinguished by income group, and the applicable value for each node determined automatically.

Housekeeping:
- iiasa/message_ix#772

## How to review

- View the expanded docs and ensure the added functions are adequately documented: [1](https://iiasa-energy-program-message-ix--144.com.readthedocs.build/projects/models/en/144/whatsnew.html#next-release), [2](https://iiasa-energy-program-message-ix--144.com.readthedocs.build/projects/models/en/144/api/tools.html#message_ix_models.tools.wb.assign_income_groups)
- Note that the CI checks all pass.
- Skim the diff.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.