### PR TITLE
Ensure --regions CLI option can be used twice

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
     - mypy
+    - plotnine
     - pytest
     - sdmx1
     - types-PyYAML

--- a/message_ix_models/report/plot.py
+++ b/message_ix_models/report/plot.py
@@ -14,6 +14,7 @@ import plotnine as p9
 from genno import Computer, Key
 
 if TYPE_CHECKING:
+    import plotnine.typing
     from genno.core.key import KeyLike
     from message_ix import Scenario
 
@@ -50,7 +51,7 @@ class Plot(genno.compat.plotnine.Plot):
     """
 
     #: 'Static' geoms: list of plotnine objects that are not dynamic.
-    static = [
+    static: List["plotnine.typing.PlotAddable"] = [
         p9.theme(figure_size=(23.4, 16.5)),  # A3 paper in landscape [inches]
         # p9.theme(figure_size=(11.7, 8.3)),  # A4 paper in landscape
     ]
@@ -122,12 +123,15 @@ class Plot(genno.compat.plotnine.Plot):
         per group, with :attr:`static` geoms and :func:`ggtitle` appended to each.
         """
         for group_key, group_df in data.groupby(*args):
-            yield group_key, (
-                p9.ggplot(group_df)
-                + self.static
-                + self.ggtitle(
-                    group_key if isinstance(group_key, str) else repr(group_key)
-                )
+            yield (
+                group_key,
+                (
+                    p9.ggplot(group_df)
+                    + self.static
+                    + self.ggtitle(
+                        group_key if isinstance(group_key, str) else repr(group_key)
+                    )
+                ),
             )
 
 
@@ -141,7 +145,7 @@ class EmissionsCO2(Plot):
         p9.aes(x="year", y="value", color="region"),
         p9.geom_line(),
         p9.geom_point(),
-        p9.labs(x="Period", y=None, color="Region"),
+        p9.labs(x="Period", y="", color="Region"),
     ]
 
     def generate(self, data: pd.DataFrame, scenario: "Scenario"):
@@ -181,7 +185,7 @@ class FinalEnergy1(Plot):
     static = Plot.static + [
         p9.aes(x="year", y="value", fill="variable"),
         p9.geom_bar(stat="identity", size=5.0),  # 5.0 is the minimum spacing of "year"
-        p9.labs(x="Period", y=None, fill="Commodity"),
+        p9.labs(x="Period", y="", fill="Commodity"),
     ]
 
     def generate(self, data: pd.DataFrame, scenario: "Scenario"):

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from base64 import b32hexencode
+from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from random import randbytes
@@ -205,6 +206,16 @@ class CliRunner(click.testing.CliRunner):
     @property
     def add_command(self):
         return cli_test_group.add_command
+
+    @contextmanager
+    def temporary_command(self, func: "click.Command", set_target: bool = True):
+        """Temporarily attach command `func` to :func:`cli_test_group`."""
+        assert func.name is not None
+        try:
+            cli_test_group.add_command(func)
+            yield
+        finally:
+            cli_test_group.commands.pop(func.name)
 
 
 @pytest.fixture(scope="session")

--- a/message_ix_models/tests/util/test_click.py
+++ b/message_ix_models/tests/util/test_click.py
@@ -29,6 +29,34 @@ def test_default_path_cb(session_context, mix_models_cli):
     assert result.output.startswith(f"{expected}\n")
 
 
+def test_regions(mix_models_cli):
+    """--regions=… used on both group and a command within the group.
+
+    If the option is not provided to the inner command, the value given to the outer
+    group should persist.
+    """
+
+    @click.group()
+    @common_params("regions")
+    def outer(regions):
+        pass
+
+    @outer.command()
+    @common_params("regions")
+    @click.pass_obj
+    def inner(context, regions):
+        print(context.model.regions)
+
+    # Give the option for the outer group, but not for the inner command
+    with mix_models_cli.temporary_command(outer):
+        result = mix_models_cli.assert_exit_0(
+            ["_test", "outer", "--regions=ZMB", "inner"]
+        )
+
+    # Value given to the outer group is stored and available to the inner command
+    assert "ZMB" == result.output.strip()
+
+
 def test_store_context(mix_models_cli):
     """Test :func:`.store_context`."""
 

--- a/message_ix_models/tests/util/test_click.py
+++ b/message_ix_models/tests/util/test_click.py
@@ -1,27 +1,14 @@
 """Basic tests of the command line."""
-from contextlib import contextmanager
-
 import click
 
-from message_ix_models.cli import main
 from message_ix_models.util.click import common_params
-
-
-@contextmanager
-def temporary_command(group, func):
-    """Context manager that temporarily attaches command `func` to `group`."""
-    try:
-        group.add_command(func)
-        yield
-    finally:
-        group.commands.pop(func.name)
 
 
 def test_default_path_cb(session_context, mix_models_cli):
     """Test :func:`.default_path_cb`."""
 
     # Create a hidden command and attach it to the CLI
-    @click.command(name="_test_default_path_cb", hidden=True)
+    @click.command("default_path_cb")
     @common_params("rep_out_path")
     @click.pass_obj
     def func(ctx, rep_out_path):
@@ -29,13 +16,13 @@ def test_default_path_cb(session_context, mix_models_cli):
 
     # Command parameters: --local-data gives the local data path, but the --rep-out-path
     # option is *not* given
-    cmd = [f"--local-data={session_context.local_data}", func.name]
+    cmd = [f"--local-data={session_context.local_data}", "_test", func.name]
 
     # …so default_path_cb() should supply "{local_data}/reporting_output".
     expected = session_context.local_data / "reporting_output"
 
     # Run the command
-    with temporary_command(main, func):
+    with mix_models_cli.temporary_command(func):
         result = mix_models_cli.assert_exit_0(cmd)
 
     # The value was stored on, and retrieved from, `ctx`
@@ -46,15 +33,15 @@ def test_store_context(mix_models_cli):
     """Test :func:`.store_context`."""
 
     # Create a hidden command and attach it to the CLI
-    @click.command(name="_test_store_context", hidden=True)
+    @click.command("store_context")
     @common_params("ssp")
     @click.pass_obj
     def func(ctx, ssp):
         print(ctx["ssp"])  # Print the value stored on the Context object
 
     # Run the command with a valid value
-    with temporary_command(main, func):
-        result = mix_models_cli.assert_exit_0([func.name, "SSP2"])
+    with mix_models_cli.temporary_command(func):
+        result = mix_models_cli.assert_exit_0(["_test", func.name, "SSP2"])
 
     # The value was stored on, and retrieved from, `ctx`
     assert "SSP2\n" == result.output
@@ -64,7 +51,7 @@ def test_urls_from_file(mix_models_cli, tmp_path):
     """Test :func:`.urls_from_file` callback."""
 
     # Create a hidden command and attach it to the CLI
-    @click.command(name="_test_store_context", hidden=True)
+    @click.command("urls_from_file")
     @common_params("urls_from_file")
     @click.pass_obj
     def func(ctx, **kwargs):
@@ -80,8 +67,10 @@ baz/qux#123
     p.write_text(text)
 
     # Run the command, referring to the temporary file
-    with temporary_command(main, func):
-        result = mix_models_cli.assert_exit_0([func.name, f"--urls-from-file={p}"])
+    with mix_models_cli.temporary_command(func):
+        result = mix_models_cli.assert_exit_0(
+            ["_test", func.name, f"--urls-from-file={p}"]
+        )
 
     # Scenario URLs are parsed to ScenarioInfo objects, and then can be reconstructed →
     # data is round-tripped

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -210,7 +210,7 @@ PARAMS = {
     "regions": Option(
         ["--regions"],
         help="Code list to use for 'node' dimension.",
-        callback=exec_cb("context.model.regions = value"),
+        callback=exec_cb("context.model.regions = value or context.model.regions"),
         type=Choice(codelists("node")),
     ),
     "rep_out_path": Option(


### PR DESCRIPTION
As raised by @adrivinca. This was previously-untested behaviour that the "water-ix" CLI command relied on; changes in #137 caused it to no longer work.

The PR restores the original behaviour by refining the code passed to `exec_cb()`, and adds a test to confirm.

## How to review

- Read message_ix_models/util/click.py in the diff.
- Note the CI checks all pass, especially the newly-added `.tests.util.test_click.test_regions()`.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update doc/whatsnew.~
