### PR TITLE
Remove Python 3.10-exclusive kw_only dataclass argument temporarily

### DIFF
--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -61,8 +61,9 @@ class ScenarioInfo:
     .Spec
     """
 
+    # TODO: give this field kw_only=False once python 3.10 is the minimum version
     # Parameters for initialization only
-    scenario_obj: InitVar[Optional["Scenario"]] = field(default=None, kw_only=False)
+    scenario_obj: InitVar[Optional["Scenario"]] = field(default=None)
     empty: InitVar[bool] = False
 
     platform_name: Optional[str] = None

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -89,7 +89,7 @@ class ScenarioInfo:
     #: :obj:`True` if a MESSAGE-MACRO scenario.
     is_message_macro: bool = False
 
-    _yv_ya: pd.DataFrame | None = None
+    _yv_ya: Optional[pd.DataFrame] = None
 
     def __post_init__(self, scenario_obj: Optional["Scenario"], empty: bool):
         if not scenario_obj:

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True)
+# TODO: use kw_only=True once python 3.10 is oldest supported version
+@dataclass()
 class ScenarioInfo:
     """Information about a |Scenario| object.
 
@@ -87,7 +88,7 @@ class ScenarioInfo:
     #: :obj:`True` if a MESSAGE-MACRO scenario.
     is_message_macro: bool = False
 
-    _yv_ya: pd.DataFrame = None
+    _yv_ya: pd.DataFrame | None = None
 
     def __post_init__(self, scenario_obj: Optional["Scenario"], empty: bool):
         if not scenario_obj:
@@ -192,10 +193,12 @@ class ScenarioInfo:
 
     def update(self, other: "ScenarioInfo"):
         """Update with the set elements of `other`."""
-        for name, data in other.set.items():
-            self.set[name].extend(filter(lambda id: id not in self.set[name], data))
+        for name, data_list in other.set.items():
+            self.set[name].extend(
+                filter(lambda id: id not in self.set[name], data_list)
+            )
 
-        for name, data in other.par.items():
+        for name, data_frame in other.par.items():
             raise NotImplementedError("Merging parameter data")
 
     def __iter__(self):


### PR DESCRIPTION
As discovered by @behnam-zakeri, our current code should either require python >= 3.10, or remove the `dataclass()` argument `kw_only` until this is the case.
Should we leave a note somewhere that we strongly encourage users to still use the syntax you were trying to enforce, @khaeru?

Please note: this PR leaves a TODO comment to come back to it. The other changes are small notes that mypy complained about. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~
- [x] Update doc/whatsnew.

