### PR TITLE
Delete unused DEMAND data file

### DIFF
--- a/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DEMAND.csv.gz
+++ b/message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DEMAND.csv.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3334223695badec19f0a01d9063e77cbb88fcad70090b97be3a34b90e239790d
-size 7351

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -371,7 +371,7 @@ class Context(dict):
                 )
 
             self.core.url = url
-            urlinfo = ixmp.utils.parse_url(url)
+            urlinfo = ixmp.util.parse_url(url)
             platform_info.update(urlinfo[0])
             scenario_info.update(urlinfo[1])
         elif platform:

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -371,7 +371,7 @@ class Context(dict):
                 )
 
             self.core.url = url
-            urlinfo = ixmp.util.parse_url(url)
+            urlinfo = ixmp.utils.parse_url(url)
             platform_info.update(urlinfo[0])
             scenario_info.update(urlinfo[1])
         elif platform:


### PR DESCRIPTION
As suggested by @khaeru in #147, this PR removes `message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline/DEMAND.csv.gz` since it's not mentioned anywhere in the current code base.

Trying to run the tests locally, I got stuck on `test_snapshot`, which might be most crucial here. `test_cli` also complained that `ixmp.utils` has no attribute `parse_url`, so I updated this to `ixmp.util`.


## How to review

- Read the diff and note that the CI checks all pass.
- Do you think we need to leave a note for when we are adding code/data again that need to reference both `demand` and `DEMAND`?


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ All tests still working
- ~[ ] Add, expand, or update documentation.~ Do we mention this file somewhere? A [quick search](https://docs.messageix.org/projects/models/en/latest/search.html?q=DEMAND&check_keywords=yes&area=default) yields nothing.
- ~[ ] Update doc/whatsnew.~ This file was not used, so no need.
