### PR TITLE
Raise informative exception from ScenarioInfo.io_units()

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,7 @@ Next release
 - Add :ref:`tools-iea-web` for handling data from the International Energy Agency (IEA) Extended World Energy Balances (:issue:`25`, :pull:`75`).
 - Add :ref:`tools-wb` and :func:`.assign_income_groups` to assign MESSAGE regions to World Bank income groups (:pull:`144`).
 - Adjust :mod:`.report.compat` for genno version 1.22 (:issue:`141`, :pull:`142`).
+- Raise informative exception from :meth:`.ScenarioInfo.io_units` (:pull:`151`).
 
 v2023.11.24
 ===========

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -218,10 +218,12 @@ class CliRunner(click.testing.CliRunner):
             cli_test_group.commands.pop(func.name)
 
 
-@pytest.fixture(scope="session")
-def mix_models_cli(request, session_context, tmp_env):
+@pytest.fixture
+def mix_models_cli(request, test_context, tmp_env):
     """A :class:`.CliRunner` object that invokes the :program:`mix-models` CLI."""
-    # Require the `session_context` fixture in order to set Context.local_data
+    # Require the `test_context` fixture in order to (a) set Context.local_data and (b)
+    # ensure changes to the Context from tested CLI commands are isolated from other
+    # tests
     yield CliRunner(env=tmp_env)
 
 

--- a/message_ix_models/tests/util/test_scenarioinfo.py
+++ b/message_ix_models/tests/util/test_scenarioinfo.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import pandas as pd
 import pytest
@@ -53,7 +54,7 @@ class TestScenarioInfo:
         info.set["commodity"] = get_codes("commodity")
         # NB create a technology with units annotation, since technology.yaml lacks
         #    units as of 2022-07-20
-        t = as_codes({"example tech": {"units": "coulomb"}})
+        t = as_codes({"example tech": {"units": "coulomb"}, "example tech 2": {}})
         process_technology_codes(t)
         info.set["technology"].extend(t)
 
@@ -76,6 +77,12 @@ class TestScenarioInfo:
             )
         # level= keyword argument → logged warning
         assert "level = 'useful' ignored" == caplog.messages[-1]
+
+        # io_units
+        with pytest.raises(
+            ValueError, match=re.escape("technology='example tech 2' [None]")
+        ):
+            info.io_units("example tech 2", "electr")
 
     def test_iter(self) -> None:
         info = ScenarioInfo(model="m", scenario="s")

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -259,12 +259,22 @@ class ScenarioInfo:
         level : str
             Placeholder for future functionality, i.e. to use different units per
             (commodity, level). Currently ignored. If given, a debug message is logged.
+
+        Raises
+        ------
+        ValueError
+            if either `technology` or `commodity` lack defined units.
         """
         if level is not None:
             log.debug(f"{level = } ignored")
-        return self.units_for("commodity", commodity) / self.units_for(
-            "technology", technology
-        )
+        c = self.units_for("commodity", commodity)
+        t = self.units_for("technology", technology)
+        if None in (c, t):
+            raise ValueError(
+                "Cannot compute input/output units for: "
+                f"commodity={commodity!r} [{c}] / technology={technology!r} [{t}]"
+            )
+        return c / t
 
     def year_from_codes(self, codes: List[sdmx_model.Code]):
         """Update using a list of `codes`.


### PR DESCRIPTION
Currently, if either the commodity or technology lacks units, the exception is internal to pint and could be hard to interpret:
```
File "/home/khaeru/vc/iiasa/models/message_ix_models/util/scenarioinfo.py", line 265, in io_units                                                                                                                                  
  return self.units_for("commodity", commodity) / self.units_for(                                                                                                                                                                  
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                
File "/home/khaeru/.venv/3.11/lib/python3.11/site-packages/pint/facets/plain/unit.py", line 159, in __truediv__
  return self._REGISTRY.Quantity(1 / other, self._units)
                                 ~~^~~~~~~
TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
```

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.
