### PR TITLE
Annotate "transport" commodity with iea-eweb-flow

### DIFF
--- a/doc/pkg-data/codelists.rst
+++ b/doc/pkg-data/codelists.rst
@@ -11,12 +11,14 @@ These codelists correspond to :doc:`sets in the generic MESSAGE IAM formulation 
 Commodities (``commodity.yaml``)
 ================================
 
-These codes hav the following annotations:
+These codes have the following annotations:
 
 ``level`` (mandatory)
    Level where this commodity typically (not exclusively) occurs.
 ``units`` (mandatory)
    Units typically associated with this commodity.
+``iea-eweb-flow`` (optional)
+   List of ``FLOW`` codes from the IEA :ref:`tools-iea-web` associated with this MESSAGEix-GLOBIOM commodity.
 ``iea-eweb-product`` (optional)
    List of ``PRODUCT`` codes from the IEA :ref:`tools-iea-web` associated with this MESSAGEix-GLOBIOM commodity.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Annotate :py:`c="transport"` in :ref:`the commodity code list <commodity-yaml>` with associated :ref:`IEA (E)WEB <tools-iea-web>` flows (:pull:`153`).
 
 v2024.1.29
 ==========

--- a/message_ix_models/data/commodity.yaml
+++ b/message_ix_models/data/commodity.yaml
@@ -141,6 +141,7 @@ transport:
     duty vehicles, civil aviation, freight transport, etc.)
   level: useful
   units: GWa
+  iea-eweb-flow: [DOMESAIR, DOMESNAV, RAIL, ROAD, TRNONSPE]
 
 # The following codes also appear in a recent (2020-02-28) SSP2 scenario, but
 # are not currently used by model.bare.create_res.


### PR DESCRIPTION
This is needed for MESSAGEix-Transport (see message_data#535) to understand which IEA EWEB flows are aggregated to the MESSAGEix-GLOBIOM "transport" commodity.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.