### PR TITLE
Adjust .wb.assign_income_groups() for sdmx 2.14.0

### DIFF
--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -67,7 +67,7 @@ def assign_income_groups(
     elif method == "population":
         # Retrieve WB_WDI data for SERIES=SP_POP_TOTAL (Population, total)
         dm = sdmx.Client("WB_WDI").data(
-            "WDI", key="A.SP_POP_TOTL.", params=dict(startperiod=2020, endperiod=2020)
+            "WDI", key="A.SP_POP_TOTL.", params=dict(start_period=2020, end_period=2020)
         )
 
         # Convert to pd.Series with multi-index with levels: REF_AREA, SERIES, FREQ,


### PR DESCRIPTION
sdmx1 v2.14.0 was released [2024-02-20](https://sdmx1.readthedocs.io/en/latest/whatsnew.html#v2-14-0-2024-02-20) with improved but stricter handling of query parameters.

This prompted failures like [this](https://github.com/iiasa/message-ix-models/actions/runs/7984254881/job/21800794183#step:9:777) in the "pytest" CI workflow, because `.wb.assign_income_groups()` used a parameter name "startperiod" that was neither snake_case ("start_period") nor lowerCamelCase ("startPeriod").

The PR corrects.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, bugfix only
- ~Update doc/whatsnew.~
