### PR TITLE
Pin pytest version to fix CI

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -66,6 +66,11 @@ jobs:
       with:
         macos-skip-brew-update: true
 
+    - name: Install specific version of pytest
+      # All versions prior to v3.9.0 use a hook argument that pytest removed in v8.1.0
+      if: ${{ matrix.version != 'main' }}
+      run: pip install pytest==8.0.0
+
     - name: Install packages and dependencies
       # By default, install:
       # - ixmp, message_ix: from GitHub branches/tags per matrix.upstream-version (above)


### PR DESCRIPTION
Pytest renamed the hook argument `startdir` to `start_path` in v8.1.0, see https://github.com/iiasa/ixmp/pull/519 for more information. While this has been fixed on the latest version of ixmp upstream, our CI test suite doesn't always install that version. This PR adds a step that installs a pinned pytest version (v8.0.0) if necessary.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just a CI change
- ~[ ] Add, expand, or update documentation.~ Just a CI change
- ~[ ] Update doc/whatsnew.~ Just a CI change
