### PR TITLE
Miscellaneous improvements for 2024-W10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Only update major versions
+    ignore:
+    - dependency-name: "*"
+      update-types:
+      - "version-update:semver-minor"
+      - "version-update:semver-patch"
+    # Below config mirrors the example at
+    # https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    groups:
+      all-actions:
+        patterns: [ "*" ]
+    assignees:
+    - "glatterf42"
+    - "khaeru"
+    labels:
+    - "dependencies"
+    reviewers:
+    - "glatterf42"
+    - "khaeru"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,31 +16,55 @@ jobs:
   pytest:
     strategy:
       matrix:
-        # One job per OS.
-        version:
-        - { os: macos-latest }
-        - { os: ubuntu-latest }
-        - { os: windows-latest }
-        # Versions of both ixmp and message_ix to use plus latest supported python version
+        os:
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
         upstream:
-        - { python-version: "3.11", version: v3.4.0, extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0"' }  # Minimum version given in pyproject.toml
-        - { python-version: "3.11", version: v3.5.0, extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0"' }
-        - { python-version: "3.11", version: v3.6.0, extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0"' }
-        - { python-version: "3.11", version: v3.7.0, extra-deps: 'dask[dataframe] "genno < 1.25" ' }
-        - { python-version: "3.12", version: v3.8.0, extra-deps: 'dask[dataframe]' } # Latest released version
-        - { python-version: "3.12", version: main,   extra-deps: 'dask[dataframe]' }  # Development version
+        # In each group:
+        # - Versions of ixmp and message_ix to test.
+        # - Latest supported Python version for those or other dependencies.
+        # - Extra dependencies, in particular fixed/maximum versions to resolve conficts.
+        #   - dask[dataframe] >= 2024.3.0 requires dask-expr and in turn pandas >= 2.0.
+        #     https://github.com/iiasa/message-ix-models/pull/156#issuecomment-2020152360
+        #   - genno: upstream versions < 3.8.0 import genno.computations, removed in 1.25.0.
+        #     https://github.com/iiasa/message-ix-models/pull/156
+        #   - pytest: upstream versions < 3.9.0 use a hook argument removed in pytest 8.1.0.
+        #     https://github.com/iiasa/message-ix-models/pull/155
+        #
+        # Minimum version given in pyproject.toml
+        - version: v3.4.0
+          python-version: "3.11"
+          extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"' #
+        - version: v3.5.0
+          python-version: "3.11"
+          extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"' #
+        - version: v3.6.0
+          python-version: "3.11"
+          extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"' #
+        - version: v3.7.0
+          python-version: "3.11"
+          extra-deps: 'dask[dataframe]   "genno < 1.25"                "pytest == 8.0.0"' #
+        # Latest released version
+        - version: v3.8.0
+          python-version: "3.12"
+          extra-deps: 'dask[dataframe]                                 "pytest == 8.0.0"' #
+        # Development version
+        - version: main
+          python-version: "3.12"
+          extra-deps: 'dask[dataframe]' #
 
       fail-fast: false
 
-    runs-on: ${{ matrix.version.os }}
-    name: ${{ matrix.version.os }}-py${{ matrix.upstream.python-version }}-upstream-${{ matrix.upstream.version }}
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}-py${{ matrix.upstream.python-version }}-upstream-${{ matrix.upstream.version }}
 
     steps:
     - name: Cache test data
       uses: actions/cache@v4
       with:
         path: message-local-data
-        key: ${{ matrix.version.os }}
+        key: ${{ matrix.os }}
 
     - name: Check out message-ix-models
       uses: actions/checkout@v4
@@ -62,11 +86,6 @@ jobs:
     - uses: ts-graphviz/setup-graphviz@v2
       with:
         macos-skip-brew-update: true
-
-    - name: Install specific version of pytest
-      # All versions prior to v3.9.0 use a hook argument that pytest removed in v8.1.0
-      if: ${{ matrix.version != 'main' }}
-      run: pip install pytest==8.0.0
 
     - name: Install packages and dependencies
       # By default, install:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,12 +23,12 @@ jobs:
         - { os: windows-latest }
         # Versions of both ixmp and message_ix to use plus latest supported python version
         upstream:
-        - { version: v3.4.0, extra-deps: '"pandas<2.0"', python-version: "3.11" }  # Minimum version given in pyproject.toml
-        - { version: v3.5.0, extra-deps: '"pandas<2.0"', python-version: "3.11" }
-        - { version: v3.6.0, extra-deps: '"pandas<2.0"', python-version: "3.11" }
-        - { version: v3.7.0, extra-deps: "", python-version: "3.11" }  
-        - { version: v3.8.0, extra-deps: "", python-version: "3.12" } # Latest released version
-        - { version: main, extra-deps: "", python-version: "3.12" }  # Development version
+        - { python-version: "3.11", version: v3.4.0, extra-deps: '"pandas<2.0"' }  # Minimum version given in pyproject.toml
+        - { python-version: "3.11", version: v3.5.0, extra-deps: '"pandas<2.0"' }
+        - { python-version: "3.11", version: v3.6.0, extra-deps: '"pandas<2.0"' }
+        - { python-version: "3.11", version: v3.7.0, extra-deps: "" }
+        - { python-version: "3.12", version: v3.8.0, extra-deps: "" } # Latest released version
+        - { python-version: "3.12", version: main,   extra-deps: "" }  # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,12 +23,12 @@ jobs:
         - { os: windows-latest }
         # Versions of both ixmp and message_ix to use plus latest supported python version
         upstream:
-        - { python-version: "3.11", version: v3.4.0, extra-deps: '"genno < 1.25" "pandas < 2.0"' }  # Minimum version given in pyproject.toml
-        - { python-version: "3.11", version: v3.5.0, extra-deps: '"genno < 1.25" "pandas < 2.0"' }
-        - { python-version: "3.11", version: v3.6.0, extra-deps: '"genno < 1.25" "pandas < 2.0"' }
-        - { python-version: "3.11", version: v3.7.0, extra-deps: '"genno < 1.25" ' }
-        - { python-version: "3.12", version: v3.8.0, extra-deps: '' } # Latest released version
-        - { python-version: "3.12", version: main,   extra-deps: '' }  # Development version
+        - { python-version: "3.11", version: v3.4.0, extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0"' }  # Minimum version given in pyproject.toml
+        - { python-version: "3.11", version: v3.5.0, extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0"' }
+        - { python-version: "3.11", version: v3.6.0, extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0"' }
+        - { python-version: "3.11", version: v3.7.0, extra-deps: 'dask[dataframe] "genno < 1.25" ' }
+        - { python-version: "3.12", version: v3.8.0, extra-deps: 'dask[dataframe]' } # Latest released version
+        - { python-version: "3.12", version: main,   extra-deps: 'dask[dataframe]' }  # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,12 +23,12 @@ jobs:
         - { os: windows-latest }
         # Versions of both ixmp and message_ix to use plus latest supported python version
         upstream:
-        - { python-version: "3.11", version: v3.4.0, extra-deps: '"pandas<2.0"' }  # Minimum version given in pyproject.toml
-        - { python-version: "3.11", version: v3.5.0, extra-deps: '"pandas<2.0"' }
-        - { python-version: "3.11", version: v3.6.0, extra-deps: '"pandas<2.0"' }
-        - { python-version: "3.11", version: v3.7.0, extra-deps: "" }
-        - { python-version: "3.12", version: v3.8.0, extra-deps: "" } # Latest released version
-        - { python-version: "3.12", version: main,   extra-deps: "" }  # Development version
+        - { python-version: "3.11", version: v3.4.0, extra-deps: '"genno < 1.25" "pandas < 2.0"' }  # Minimum version given in pyproject.toml
+        - { python-version: "3.11", version: v3.5.0, extra-deps: '"genno < 1.25" "pandas < 2.0"' }
+        - { python-version: "3.11", version: v3.6.0, extra-deps: '"genno < 1.25" "pandas < 2.0"' }
+        - { python-version: "3.11", version: v3.7.0, extra-deps: '"genno < 1.25" ' }
+        - { python-version: "3.12", version: v3.8.0, extra-deps: '' } # Latest released version
+        - { python-version: "3.12", version: main,   extra-deps: '' }  # Development version
 
       fail-fast: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     - "message-ix @ git+https://github.com/iiasa/message_ix.git@main"
     args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.13
+  rev: v0.3.0
   hooks:
   - id: ruff
   - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@; python -m pip list"
     additional_dependencies:
-    - mypy >= 1.8.0
+    - mypy >= 1.9.0
     - plotnine
     - pytest
     - sdmx1
@@ -20,7 +20,7 @@ repos:
     - "message-ix @ git+https://github.com/iiasa/message_ix.git@main"
     args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.0
+  rev: v0.3.2
   hooks:
   - id: ruff
   - id: ruff-format

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,8 @@ prune message_ix_models/data/test/iea
 prune message_ix_models/data/test/MESSAGEix-GLOBIOM_1.1_R11_no-policy_baseline
 prune message_ix_models/data/test/ssp
 prune message_ix_models/data/water/*
+# Larger package data
+# - Not distributed on PyPI.
+# - Should be fetched with Pooch from GitHub.
+exclude message_ix_models/data/ssp/*.gz
 exclude message_ix_models/data/water/*.tar.xz

--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -34,6 +34,7 @@ Commonly used:
    check_support
    convert_units
    copy_column
+   datetime_now_with_tz
    ffill
    identify_nodes
    iter_keys
@@ -52,6 +53,7 @@ Commonly used:
    same_node
    same_time
    series_of_pint_quantity
+   show_versions
 
 .. automodule:: message_ix_models.util
    :members:

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -8,7 +8,6 @@ Our goal is that the *semantics* of all commands are similar, so that interactin
 .. contents::
    :local:
 
-
 Controlling CLI behaviour
 =========================
 
@@ -16,8 +15,9 @@ To support a variety of complex use-cases, the MESSAGEix stack takes configurati
 
 :mod:`ixmp` configuration file: :file:`config.json`
 ---------------------------------------------------
+
 :mod:`ixmp` keeps track of named Platforms and their associated databases, and stores information in its :file:`config.json` file.
-See :mod:`ixmp.config`.
+See :ref:`ixmp:configuration` in the documentation.
 List existing platforms::
 
     $ ixmp platform list
@@ -27,15 +27,29 @@ To add a specific database, you can use the ixmp CLI [1]_::
     $ ixmp platform add [PLATFORMNAME] jdbc oracle [COMPUTER]:[PORT]/[SERVICENAME] [USERNAME] [PASSWORD]
 
 You may also want to make this the *default* platform.
-Unless told otherwise, :mod:`message_ix_models` creates :class:`~ixmp.Platform` objects without any arguments (``mp = ixmp.Platform()``); this loads the default platform.
+Unless told otherwise, :mod:`message_ix_models` creates :class:`~ixmp.Platform` objects without any arguments (:py:`mp = ixmp.Platform()`); this loads the default platform.
 Set the default::
 
     $ ixmp platform add default [PLATFORMNAME]
 
-:mod:`message_ix` stores only one configuration value in :file:`config.json`: ``'message model dir'``, the path to the GAMS model files.
-MESSAGEix-GLOBIOM uses the GAMS model files from the current :mod:`message_ix` ``master`` branch, so you should not set this, or unset it when using :mod:`message_ix_models`.
+:mod:`message_ix` recognizes the following :file:`config.json` value:
 
-:mod:`message_ix_models` will use the :file:`config.json` value ``"message_local_data"`` for local data, if it is set and not overridden.
+``message_model_dir``
+   Path to the GAMS model files.
+   Most code in MESSAGEix-GLOBIOM expects the GAMS model files from the current :mod:`message_ix` ``main`` branch, so you should not set this, or unset it when using :mod:`message_ix_models`.
+
+:mod:`message_ix_models` recognizes the following 2 :file:`config.json` values:
+
+``message_local_data``
+   Path to local data, if it is set and not overridden.
+``no_message_data``
+   If not set or :any:`False`, then the CLI displays a warning message if the private :mod:`message_data` package is not installed::
+
+      Warning: message_data is not installed or cannot be imported; see the documentation via --help
+
+   If set to :any:`True`, then the message is suppressed::
+
+      $ mix-models config set no_message_data true
 
 .. [1] ``[COMPUTER]`` is in this case either the hostname or the IP address.
 
@@ -45,7 +59,6 @@ Some code responds to environment variables.
 For example, ixmp responds to ``IXMP_DATA``, which tells it where to find the file :file:`config.json`.
 
 :mod:`message_ix_models` responds to ``MESSAGE_LOCAL_DATA``; see :ref:`the discussion of local data <local-data>`.
-
 
 CLI parameters (arguments and options)
 --------------------------------------
@@ -63,12 +76,12 @@ Consider the following examples::
 
 In these examples:
 
-- ``--opt0`` is an option that (potentially) affects **any** command, including the subcommands ``cmd2`` or ``cmd3``.
-- ``--opt1`` and ``arg1`` are an option and mandatory argument to the command ``cmd1``.
-  They might not have any relevance to other ``mix-data`` commands.
-- ``cmd2`` and ``cmd3`` are distinct subcommands of ``cmd1``.
+- :program:`--opt0` is an option that (potentially) affects **any** command, including the subcommands :program:`cmd2` or :program:`cmd3`.
+- :program:`--opt1` and :program:`arg1` are an option and mandatory argument to the command :program:`cmd1`.
+  They might not have any relevance to other :program:`mix-models` commands.
+- :program:`cmd2` and :program:`cmd3` are distinct subcommands of :program:`cmd1`.
 
-  - They *may* respond to ``--opt1`` and ``arg1``, and to ``--opt0``; at least, they *must* not contradict them.
+  - They *may* respond to :program:`--opt1` and :program:`arg1`, and to :program:`--opt0`; at least, they *must* not contradict them.
   - They each may have their own options and arguments, which can be distinct.
 
 .. tip:: Use ``--help`` for any (sub)command to read about its behaviour.
@@ -80,7 +93,7 @@ For some features of the code, the default behaviour is very elaborate and serve
 This default behaviour or optional behaviour is defined by reading an input file.
 These are stored in the :ref:`package data <package-data>` directory.
 
-For example, ``mix-models report`` loads reporting configuration from :file:`message_ix_models/data/report/global.yaml`, a YAML file with hundreds of lines.
+For example, :program:`mix-models report` loads reporting configuration from :file:`message_ix_models/data/report/global.yaml`, a YAML file with hundreds of lines.
 Optionally, a different file can be used::
 
     $ mix-models report --config other
@@ -99,77 +112,86 @@ Important CLI options and commands
 
 Top-level options and commands
 ------------------------------
-``mix-models --help`` describes these::
+:program:`mix-models --help` describes these::
 
-    $ mix-models --help
     Usage: mix-models [OPTIONS] COMMAND [ARGS]...
 
       Command-line interface for MESSAGEix-GLOBIOM model tools.
 
       Every tool and script in this repository is accessible through this CLI.
       Scripts are grouped into commands and sub-commands. For help on specific
-      (sub)commands, use --help, e.g.:
+      (sub)commands, use --help, for instance:
 
-              mix-models cd-links --help
-              mix-models cd-links run --help
+              mix-models report --help
+              mix-models ssp gen-structures --help
 
       The top-level options --platform, --model, and --scenario are used by
-      commands that access specific message_ix scenarios; these can also be
-      specified with --url.
+      commands that access specific MESSAGEix scenarios in a specific ixmp
+      platform/database; these can also be specified with --url.
 
-      For more information, see
-      https://docs.messageix.org/projects/models2/en/latest/cli.html
+      For complete documentation, see
+      https://docs.messageix.org/projects/models/en/latest/cli.html
 
     Options:
       --url ixmp://PLATFORM/MODEL/SCENARIO[#VERSION]
                                       Scenario URL.
-      --platform PLATFORM             Configured platform name.
+      --platform PLATFORM             ixmp platform name.
       --model MODEL                   Model name for some commands.
       --scenario SCENARIO             Scenario name for some commands.
-      --version INTEGER               Scenario version.
+      --version INTEGER               Scenario version for some commands.
       --local-data PATH               Base path for local data.
       -v, --verbose                   Print DEBUG-level log messages.
       --help                          Show this message and exit.
 
     Commands:
-      cd-links         CD-LINKS project.
-      dl               Retrieve data from primary sources.
-      engage           ENGAGE project.
-      iiasapp          Import power plant capacity.
-      material         Model with materials accounting.
-      prep-submission  Prepare scenarios for submission to database.
-      report           Postprocess results.
-      res              MESSAGE-GLOBIOM reference energy system (RES).
-      techs            Export data from data/technology.yaml to CSV.
-      transport        MESSAGEix-Transport variant.
+      buildings         MESSAGEix-Buildings model.
+      cd-links          CD-LINKS project.
+      config            Get and set configuration keys.
+      covid             COVID project.
+      engage            ENGAGE project.
+      export-test-data  Prepare data for testing.
+      fetch             Retrieve data from primary sources.
+      iiasapp           Import power plant capacity.
+      last-log          Show the location of the last log file, if any.
+      material          Model with materials accounting.
+      model             MESSAGEix-GLOBIOM reference energy system (RES).
+      navigate          NAVIGATE project.
+      prep-submission   Prepare scenarios for submission to an IIASA Scenario...
+      report            Postprocess results.
+      res               MESSAGEix-GLOBIOM reference energy system (RES).
+      ssp               Shared Socioeconomic Pathways (SSP) project.
+      techs             Export metadata to technology.csv.
+      testing           Manipulate test data.
+      transport         MESSAGEix-Transport variant.
+      water-ix          MESSAGEix-Water and Nexus variant.
 
-To explain further:
+Further information about the top-level options:
 
-``--platform PLATFORM`` or ``--url``
+:program:`--platform PLATFORM` or :program:`--url`
    By default, message_data connects to the default ixmp Platform.
    These options direct it to work with a different Platform.
 
-``--model MODEL --scenario SCENARIO`` or ``--url``
+:program:`--model MODEL --scenario SCENARIO` or :program:`--url`
     Many commands use an *existing* |Scenario| as a starting point, and begin by cloning that Scenario to a new (model name, scenario name).
     For any such command, these top-level options define the starting point/initial Scenario to clone/‘baseline’.
 
-    In contrast, see ``--output-model``, below.
-
+    In contrast, see :program:`--output-model`, below.
 
 Common options
 --------------
+
 Since :mod:`message_ix_models.model` and :mod:`message_ix_models.project` codes often perform similar tasks, their CLI options and arguments are provided in :mod:`.util.click` for easy re-use.
 These include:
 
-``ssp`` argument
+:program:`SSP` argument
    This takes one of the values 'SSP1', 'SSP2', or 'SSP3'.
 
    Commands that will not work for one or more of the SSPs should check the argument value given by the user and raise :class:`NotImplementedError`.
 
-``--output-model NAME`` option
-   This option is a counterpart to the top-level ``--url/--model/--scenario`` options.
+:program:`--output-model NAME` option
+   This option is a counterpart to the top-level :program:`--url`, :program:`--model`, or :program:`--scenario` options.
    A command that starts from one Scenario, and builds one or more Scenarios from it will clone *to* a new (model name, scenario name);
-   ``--output-model`` gives the model name.
+   :program:`--output-model` gives the model name.
 
    Current code generates a variety of fixed (non-configurable) scenario names; use ``--help`` for each command to see which.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,6 +143,7 @@ intersphinx_mapping = {
     ),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable/", None),
+    "platformdirs": ("https://platformdirs.readthedocs.io/en/latest", None),
     "pooch": ("https://www.fatiando.org/pooch/latest/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,24 @@ What's new
 Next release
 ============
 
+- The :class:`.SSPUpdate` data provider pulls data from the SSP 2024 "Release 3.0" data files, and handles both the earlier and current structures (:pull:`156`).
+- Improve :class:`.ExoDataSource` with :meth:`.raise_on_extra_kw` utility method, automatic copy of source keyword arguments (:pull:`156`).
+- Expose :func:`.node.nodes_ex_world` for use as a genno (reporting) operator.
+- Raise DeprecationWarning from :func:`.util.sdmx.eval_anno`; remove internal usage of this deprecated method (:pull:`156`).
+- Reduce verbosity when using the :program:`mix-models` CLI when :mod:`message_data` is not installed (:issue:`37`, :pull:`156`).
+- Improve logging (:pull:`156`).
+
+  - Use multi-threaded logging for better performance.
+    Logging to stdout and file is on a separate thread and does not block operations on the main thread.
+  - Add automatic file logging.
+    Log versions of packages to file when using :func:`.workflow.make_click_command`.
+  - New CLI command :program:`mix-models last-log` to retrieve the location of the latest log file.
+- Update :doc:`cli` (:pull:`156`).
+- Improve performance in :func:`.disutility.data_conversion` (:pull:`156`).
+- Use :func:`platformdirs.user_cache_path` in more places; remove cache-path handling code (:pull:`156`).
+- Add :func:`.util.datetime_now_with_tz` (:pull:`156`).
+- Add :func:`.util.show_versions`, wrapping :func:`ixmp.util.show_versions` and returning its output as :class:`str` (:pull:`156`).
+- :func:`.util.private_data_path` returns an alternate, local data path if :mod:`message_data` is not installed (:pull:`156`).
 - Annotate :py:`c="transport"` in :ref:`the commodity code list <commodity-yaml>` with associated :ref:`IEA (E)WEB <tools-iea-web>` flows (:pull:`153`).
 
 v2024.1.29

--- a/message_ix_models/__init__.py
+++ b/message_ix_models/__init__.py
@@ -20,8 +20,8 @@ except PackageNotFoundError:  # pragma: no cover
     # Package is not installed
     __version__ = "999"
 
-# No logging to stdout (console) by default
-setup_logging(console=False)
+# By default, no logging to console/stdout or to file
+setup_logging(console=False, file=False)
 
 # Use iam_units.registry as the default pint.UnitsRegistry
 pint.set_application_registry(registry)

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 from ixmp.cli import main as ixmp_cli
 
-from message_ix_models.util._logging import mark_time
+from message_ix_models.util._logging import flush, mark_time
 from message_ix_models.util._logging import setup as setup_logging
 from message_ix_models.util.click import common_params
 from message_ix_models.util.context import Context
@@ -79,6 +79,9 @@ def main(click_ctx, **kwargs):
 
     # Close any database connections when the CLI exits
     click_ctx.call_on_close(click_ctx.obj.close_db)
+
+    # Ensure all log messages are handled
+    click_ctx.call_on_close(flush)
 
 
 @main.command("export-test-data")

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -149,11 +149,23 @@ try:
     import message_data.cli
 except ImportError:
     # message_data is not installed or contains some ImportError of its own
-    from traceback import format_exception
+    import ixmp
 
-    # Display information for debugging
-    etype, value, tb = sys.exc_info()
-    print("", *format_exception(etype, value, tb, limit=-1, chain=False)[1:], sep="\n")
+    if ixmp.config.get("no message_data") is not True:
+        print(
+            "Warning: message_data is not installed or cannot be imported; see the "
+            "documentation via --help"
+        )
+
+    # commented: Display verbose information for debugging
+    # from traceback import format_exception
+    #
+    # etype, value, tb = sys.exc_info()
+    # print(
+    #     "",
+    #     *format_exception(etype, value, tb, limit=-1, chain=False)[1:],
+    #     sep="\n",
+    # )
 else:  # pragma: no cover  (needs message_data)
     # Also add message_data submodules
     submodules.extend(

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -130,6 +130,26 @@ def debug(ctx):
     log.debug(ctx.local_data)
 
 
+@main.group("_test", hidden=True)
+def cli_test_group():
+    """Hidden group of CLI commands.
+
+    Other code which needs to test CLI behaviour **may** attach temporary/throw-away
+    commands to this group and then invoke them using :func:`mix_models_cli`. This
+    avoids the need to expose additional commands for testing purposes only.
+    """
+
+
+@cli_test_group.command("log-threads")
+@click.argument("k", type=int)
+@click.argument("N", type=int)
+def _log_threads(k: int, n: int):
+    # Emit many log records
+    log = logging.getLogger("message_ix_models")
+    for i in range(n):
+        log.info(f"{k = } {i = }")
+
+
 # Attach the ixmp "config" CLI
 main.add_command(ixmp_cli.commands["config"])
 
@@ -185,3 +205,7 @@ for name in submodules:
         continue
 
     main.add_command(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -63,7 +63,8 @@ def main(click_ctx, **kwargs):
     # Don't start file logging for a non-trivial execution.
     setup_logging(level="DEBUG" if kwargs.pop("verbose") else "INFO", file=non_trivial)
 
-    log.debug("CLI invoked with:\n" + "\n  ".join(sys.argv))
+    if "pytest" not in sys.argv[0]:
+        log.debug("CLI invoked with:\n" + "\n  ".join(sys.argv))
 
     # Store the most recently created instance of message_ix_models.Context. click
     # carries this object to any subcommand decorated with @click.pass_obj.

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -104,6 +104,17 @@ def export_test_data_cmd(ctx, exclude, nodes, techs):
     mark_time()
 
 
+@main.command("last-log")
+@click.pass_obj
+def last_log(ctx):
+    """Show the location of the last log file, if any."""
+    from platformdirs import user_log_path
+
+    log_dir = user_log_path("message-ix-models")
+    if log_files := sorted(log_dir.glob("*T*")):
+        print(log_files[-1])
+
+
 @main.command(hidden=True)
 @click.pass_obj
 def debug(ctx):

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -13,6 +13,7 @@ access specific message_ix scenarios; these can also be specified with --url.
 
 For more information, see https://docs.messageix.org/projects/models2/en/latest/cli.html
 """
+
 import logging
 import sys
 from pathlib import Path
@@ -52,8 +53,17 @@ def main(click_ctx, **kwargs):
     # Start timer
     mark_time(quiet=True)
 
-    # Log to console
-    setup_logging(level="DEBUG" if kwargs.pop("verbose") else "INFO", console=True)
+    # Check for a non-trivial execution of the CLI
+    non_trivial = (
+        not any(s in sys.argv for s in {"last-log", "--help"})
+        and click_ctx.invoked_subcommand != "_test"
+    )
+
+    # Log to console: either DEBUG or INFO.
+    # Don't start file logging for a non-trivial execution.
+    setup_logging(level="DEBUG" if kwargs.pop("verbose") else "INFO", file=non_trivial)
+
+    log.debug("CLI invoked with:\n" + "\n  ".join(sys.argv))
 
     # Store the most recently created instance of message_ix_models.Context. click
     # carries this object to any subcommand decorated with @click.pass_obj.

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -11,7 +11,7 @@ e.g.:
 The top-level options --platform, --model, and --scenario are used by commands that
 access specific message_ix scenarios; these can also be specified with --url.
 
-For more information, see https://docs.messageix.org/projects/models2/en/latest/cli.html
+For more information, see https://docs.messageix.org/projects/models/en/latest/cli.html
 """
 
 import logging
@@ -57,6 +57,7 @@ def main(click_ctx, **kwargs):
     non_trivial = (
         not any(s in sys.argv for s in {"last-log", "--help"})
         and click_ctx.invoked_subcommand != "_test"
+        and "pytest" not in sys.argv[0]
     )
 
     # Log to console: either DEBUG or INFO.

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -2,16 +2,18 @@
 
 Every tool and script in this repository is accessible through this CLI. Scripts are
 grouped into commands and sub-commands. For help on specific (sub)commands, use --help,
-e.g.:
+for instance:
 
     \b
-    mix-models cd-links --help
-    mix-models cd-links run --help
+    mix-models report --help
+    mix-models ssp gen-structures --help
 
 The top-level options --platform, --model, and --scenario are used by commands that
-access specific message_ix scenarios; these can also be specified with --url.
+access specific MESSAGEix scenarios in a specific ixmp platform/database; these can also
+be specified with --url.
 
-For more information, see https://docs.messageix.org/projects/models/en/latest/cli.html
+For complete documentation, see
+https://docs.messageix.org/projects/models/en/latest/cli.html
 """
 
 import logging
@@ -35,7 +37,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--url", metavar="ixmp://PLATFORM/MODEL/SCENARIO[#VERSION]", help="Scenario URL."
 )
-@click.option("--platform", metavar="PLATFORM", help="Configured platform name.")
+@click.option("--platform", metavar="PLATFORM", help="ixmp platform name.")
 @click.option(
     "--model", "model_name", metavar="MODEL", help="Model name for some commands."
 )
@@ -45,7 +47,7 @@ log = logging.getLogger(__name__)
     metavar="SCENARIO",
     help="Scenario name for some commands.",
 )
-@click.option("--version", type=int, help="Scenario version.")
+@click.option("--version", type=int, help="Scenario version for some commands.")
 @click.option("--local-data", type=Path, help="Base path for local data.")
 @common_params("verbose")
 @click.pass_context

--- a/message_ix_models/data/ssp/1706548837040-ssp_basic_drivers_release_3.0_full.csv.gz
+++ b/message_ix_models/data/ssp/1706548837040-ssp_basic_drivers_release_3.0_full.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fffa5c7f87155d4476cd581771a496048e4e96cf4b59a7496cbb4f4fd79394f
+size 20847285

--- a/message_ix_models/model/__init__.py
+++ b/message_ix_models/model/__init__.py
@@ -1,4 +1,5 @@
 """Code for constructing models/scenarios in the MESSAGEix-GLOBIOM model family."""
+
 from .config import Config
 
 __all__ = ["Config"]

--- a/message_ix_models/model/bare.py
+++ b/message_ix_models/model/bare.py
@@ -8,7 +8,6 @@ from sdmx.model.v21 import Code
 
 import message_ix_models
 from message_ix_models import ScenarioInfo, Spec
-from message_ix_models.util import eval_anno
 
 from .build import apply_spec
 from .config import Config
@@ -134,7 +133,9 @@ def get_spec(context) -> Spec:
     add.set["commodity"] = get_codes("commodity")
 
     # Add units, associated with commodities
-    units = set(eval_anno(commodity, "unit") for commodity in add.set["commodity"])
+    units = set(
+        commodity.eval_annotation(id="unit") for commodity in add.set["commodity"]
+    )
     # Deduplicate by converting to a set and then back; not strictly necessary,
     # but reduces duplicate log entries
     add.set["unit"] = sorted(filter(None, units))

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -13,7 +13,6 @@ from message_ix_models import ScenarioInfo, Spec
 from message_ix_models.model.build import apply_spec
 from message_ix_models.util import (
     broadcast,
-    eval_anno,
     make_io,
     make_matched_dfs,
     make_source_tech,
@@ -81,9 +80,11 @@ def get_spec(
         fmt = dict(technology=t, group=g)
 
         # Format each field in the "input" and "output" annotations
-        input = {k: v.format(**fmt) for k, v in eval_anno(template, id="input").items()}
+        input = {
+            k: v.format(**fmt) for k, v in template.eval_annotation(id="input").items()
+        }
         output = {
-            k: v.format(**fmt) for k, v in eval_anno(template, id="output").items()
+            k: v.format(**fmt) for k, v in template.eval_annotation(id="output").items()
         }
 
         # - Format the ID string from the template
@@ -176,8 +177,8 @@ def data_conversion(info, spec) -> MutableMapping[str, pd.DataFrame]:
     for t in technology:
         # Use the annotations on the technology Code to get information about the
         # commodity, level, and unit
-        input = eval_anno(t, "input")
-        output = eval_anno(t, "output")
+        input = t.eval_annotation(id="input")
+        output = t.eval_annotation(id="output")
         if None in (input, output):
             if t.id == "disutility source":
                 continue  # Data for this tech is from data_source()
@@ -219,7 +220,7 @@ def data_source(info, spec) -> Mapping[str, pd.DataFrame]:
     # List of input levels where disutility commodity must exist
     levels = set()
     for t in spec["add"].set["technology"]:
-        input = eval_anno(t, "input")
+        input = t.eval_annotation(id="input")
         if input:
             levels.add(input["level"])
 

--- a/message_ix_models/model/macro.py
+++ b/message_ix_models/model/macro.py
@@ -3,6 +3,7 @@
 See :doc:`message-ix:macro` for *general* documentation on MACRO and MESSAGE-MACRO. This
 module contains tools specifically for using these models with MESSAGEix-GLOBIOM.
 """
+
 import logging
 from functools import lru_cache
 from itertools import product

--- a/message_ix_models/model/snapshot.py
+++ b/message_ix_models/model/snapshot.py
@@ -1,4 +1,5 @@
 """Prepare base models from snapshot data."""
+
 import logging
 from pathlib import Path
 

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -13,7 +13,7 @@ import xarray as xr
 from iam_units import registry
 from sdmx.model.v21 import Annotation, Code, Codelist
 
-from message_ix_models.util import eval_anno, load_package_data, package_data_path
+from message_ix_models.util import load_package_data, package_data_path
 from message_ix_models.util.sdmx import as_codes
 
 log = logging.getLogger(__name__)
@@ -126,7 +126,7 @@ def generate_product(
         attributes.
     """
     # eval() and remove the original annotation
-    dims = eval_anno(template, "_generate")
+    dims = template.eval_annotation(id="_generate")
     template.pop_annotation(id="_generate")
 
     def _base(dim, match):
@@ -191,7 +191,7 @@ def generate_set_elements(data: MutableMapping, name) -> None:
         if name in {"commodity", "technology"}:
             process_units_anno(name, code, quiet=True)
 
-        if eval_anno(code, "_generate"):
+        if code.eval_annotation(id="_generate"):
             # Requires a call to generate_product(); do these last
             deferred.append(code)
             continue

--- a/message_ix_models/model/water/data/infrastructure.py
+++ b/message_ix_models/model/water/data/infrastructure.py
@@ -1,5 +1,5 @@
 """Prepare data for adding techs related to water distribution,
- treatment in urban & rural"""
+treatment in urban & rural"""
 
 from collections import defaultdict
 

--- a/message_ix_models/model/water/data/pre_processing/hydro_agg_basin.py
+++ b/message_ix_models/model/water/data/pre_processing/hydro_agg_basin.py
@@ -156,9 +156,9 @@ def bias_correction(df):
                         final_temp = pd.concat((final_temp, temp), axis=1)
 
                 df_monthly = final_temp
-                df[
-                    pd.date_range(str(year) + "-01-01", periods=12, freq="M")
-                ] = final_temp.groupby(final_temp.columns.month, axis=1).mean()
+                df[pd.date_range(str(year) + "-01-01", periods=12, freq="M")] = (
+                    final_temp.groupby(final_temp.columns.month, axis=1).mean()
+                )
                 # 5 year monthly data
                 df_5y_m = df[df.columns[df.columns.year.isin(years)]]
                 # 5 year annual
@@ -319,9 +319,9 @@ for year in np.arange(2020, 2105, 5):
             ]
 
     df_monthly = final_temp
-    eflow[
-        pd.date_range(str(year) + "-01-01", periods=12, freq="M")
-    ] = final_temp.groupby(final_temp.columns.month, axis=1).mean()
+    eflow[pd.date_range(str(year) + "-01-01", periods=12, freq="M")] = (
+        final_temp.groupby(final_temp.columns.month, axis=1).mean()
+    )
 
     eflow_5y_m = eflow[eflow.columns[eflow.columns.year.isin(years)]]
     eflow_5y_m.to_csv(wd11 + f"e-flow_5y_m_7p0_{iso3}.csv")

--- a/message_ix_models/model/water/data/pre_processing/hydro_agg_raster.py
+++ b/message_ix_models/model/water/data/pre_processing/hydro_agg_raster.py
@@ -5,6 +5,7 @@ script specifically aggregates global gridded hydrological
 data onto the basin
  mapping used in the nexus module.
 """
+
 import glob
 
 #  Import packages

--- a/message_ix_models/project/ssp/__init__.py
+++ b/message_ix_models/project/ssp/__init__.py
@@ -59,7 +59,7 @@ class ssp_field:
 
 @click.group("ssp")
 def cli():
-    pass
+    """Shared Socioeconomic Pathways (SSP) project."""
 
 
 @cli.command("gen-structures")

--- a/message_ix_models/project/ssp/data.py
+++ b/message_ix_models/project/ssp/data.py
@@ -1,16 +1,11 @@
 import logging
-from copy import copy
 
 from message_ix_models.tools.exo_data import (
     ExoDataSource,
     iamc_like_data_for_query,
     register_source,
 )
-from message_ix_models.util import (
-    HAS_MESSAGE_DATA,
-    package_data_path,
-    private_data_path,
-)
+from message_ix_models.util import package_data_path, private_data_path
 
 __all__ = [
     "SSPOriginal",
@@ -56,6 +51,9 @@ class SSPOriginal(ExoDataSource):
 
     id = "SSP"
 
+    #: Name of file containing the data.
+    filename = "SspDb_country_data_2013-06-12.csv.zip"
+
     #: One-to-one correspondence between "model" codes and date fragments in scenario
     #: codes.
     model_date = {
@@ -74,44 +72,45 @@ class SSPOriginal(ExoDataSource):
         if not source.startswith(s):
             raise ValueError(source)
 
-        *parts, self.ssp_number = source.partition(s)
+        *parts, ssp_id = source.partition(s)
 
         # Map the `measure` keyword to a string appearing in the data
-        _kw = copy(source_kw)
-        self.measure = {
+        measure = {
             "GDP": "GDP|PPP",
             "POP": "Population",
-        }[_kw.pop("measure")]
+        }[source_kw.pop("measure")]
 
         # Store the model ID, if any
-        self.model = _kw.pop("model", None)
+        model = source_kw.pop("model", None)
 
         # Determine the date based on the model ID. There is a 1:1 correspondence.
-        self.date = self.model_date[self.model]
+        date = self.model_date[model]
 
-        if len(_kw):
-            raise ValueError(_kw)
+        self.raise_on_extra_kw(source_kw)
+
+        # Assemble a query string
+        extra = "d" if ssp_id == "4" and model == "IIASA-WiC POP" else ""
+        self.query = (
+            f"SCENARIO == 'SSP{ssp_id}{extra}_v9_{date}' and VARIABLE == '{measure}'"
+            + (f" and MODEL == '{model}'" if model else "")
+        )
+        # log.debug(query)
+
+        # Iterate over possible locations for the data file
+        dirs = [private_data_path("ssp"), package_data_path("test", "ssp")]
+        for path in [d.joinpath(self.filename) for d in dirs]:
+            if not path.exists():
+                log.info(f"Not found: {path}")
+                continue
+            if "test" in path.parts:
+                log.warning(f"Reading random data from {path}")
+            break
+
+        self.path = path
 
     def __call__(self):
-        # Assemble a query string
-        extra = "d" if self.ssp_number == "4" and self.model == "IIASA-WiC POP" else ""
-        query = " and ".join(
-            [
-                f"SCENARIO == 'SSP{self.ssp_number}{extra}_v9_{self.date}'",
-                f"VARIABLE == '{self.measure}'",
-                f"MODEL == '{self.model}'" if self.model else "True",
-            ]
-        )
-        log.debug(query)
-
-        parts = ("ssp", "SspDb_country_data_2013-06-12.csv.zip")
-        if HAS_MESSAGE_DATA:
-            path = private_data_path(*parts)
-        else:
-            path = package_data_path("test", *parts)
-            log.warning(f"Reading random data from {path}")
-
-        return iamc_like_data_for_query(path, query, replace=self.replace)
+        # Use prepared path, query, and replacements
+        return iamc_like_data_for_query(self.path, self.query, replace=self.replace)
 
 
 @register_source
@@ -123,6 +122,7 @@ class SSPUpdate(ExoDataSource):
 
     - `source`: Any value from :data:`.SSP_2024` or equivalent string, for instance
       "ICONICS:SSP(2024).2".
+    - `release`: One of "3.0" or "preview".
 
     Example
     -------
@@ -137,28 +137,32 @@ class SSPUpdate(ExoDataSource):
 
     id = "SSP update"
 
+    #: File names containing the data, according to the release.
+    filename = {
+        "3.0": "1706548837040-ssp_basic_drivers_release_3.0_full.csv.gz",
+        "preview": "SSP-Review-Phase-1.csv.gz",
+    }
+
     def __init__(self, source, source_kw):
         s = "ICONICS:SSP(2024)."
         if not source.startswith(s):
             raise ValueError(source)
 
-        *parts, self.ssp_number = source.partition(s)
+        *parts, ssp_id = source.partition(s)
 
-        # Map the `measure` keyword to a string appearing in the data
-        _kw = copy(source_kw)
+        # Map the `measure` keyword to a 'Variable' dimension code
         measure = {
             "GDP": "GDP|PPP",
             "POP": "Population",
-        }[_kw.pop("measure")]
+        }[source_kw.pop("measure")]
 
-        # Store the model ID, if any
-        self.model = _kw.pop("model", None)
+        # Store the model code, if any
+        model = source_kw.pop("model", None)
 
         # Identify the data release date/version/label
-        self.release = _kw.pop("release", "3.0")
+        release = source_kw.pop("release", "3.0")
 
-        # Directories in which to locate `self.filename`
-        self.dirs = []
+        self.raise_on_extra_kw(source_kw)
 
         # Replacements to apply, if any
         self.replace = {}
@@ -167,29 +171,33 @@ class SSPUpdate(ExoDataSource):
         models = []
         scenarios = []
 
-        if self.release == "3.0":
-            self.filename = "1706548837040-ssp_basic_drivers_release_3.0_full.csv.gz"
-            # Stored directly in message_ix_models
-            self.dirs.append(package_data_path("ssp"))
-            scenarios.append(f"SSP{self.ssp_number}")
+        if release == "3.0":
+            # Directories in which to locate `self.filename`; stored directly within
+            # message_ix_models
+            dirs = [package_data_path("ssp")]
 
-            if measure == "GDP|PPP" and self.model != "OECD ENV-Growth 2023":
-                # Configure to prepend s="Historical Reference" observations to series
-                models.extend([self.model, "OECD ENV-Growth 2023"])
+            scenarios.append(f"SSP{ssp_id}")
+
+            if measure == "GDP|PPP":
+                # Configure to prepend (m="OECD…", s="Historical Reference")
+                # observations to series
+                models.extend({model, "OECD ENV-Growth 2023"})
                 scenarios.append("Historical Reference")
                 self.replace.update(
-                    Model={"OECD ENV-Growth 2023": models[0]},
+                    Model={"OECD ENV-Growth 2023": model},
                     Scenario={"Historical Reference": scenarios[0]},
                 )
-        elif self.release == "preview":
-            self.filename = "SSP-Review-Phase-1.csv.gz"
+        elif release == "preview":
             # Look first in message_data, then in message_ix_models test data
-            self.dirs.extend(
-                [private_data_path("ssp"), package_data_path("test", "ssp")]
-            )
-            scenarios.append(f"SSP{self.ssp_number} - Review Phase 1")
+            dirs = [private_data_path("ssp"), package_data_path("test", "ssp")]
+
+            scenarios.append(f"SSP{ssp_id} - Review Phase 1")
         else:
-            raise ValueError(f"{self.release = }")
+            log.error(
+                f"{release = } invalid for {type(self)}; expected one of: "
+                f"{set(self.filename)}"
+            )
+            raise ValueError(release)
 
         # Assemble and store a query string
         self.query = f"Scenario in {scenarios!r} and Variable == '{measure}'" + (
@@ -197,19 +205,17 @@ class SSPUpdate(ExoDataSource):
         )
         # log.info(f"{self.query = }")
 
-        if len(_kw):
-            raise ValueError(_kw)
-
-    def __call__(self):
-        # Iterate over possible locations for self.filename
-        for dir in self.dirs:
-            path = dir.joinpath(self.filename)
+        # Iterate over possible locations for the data file
+        for path in [d.joinpath(self.filename[release]) for d in dirs]:
             if not path.exists():
                 log.info(f"Not found: {path}")
-            elif "test" in path.parts:
+                continue
+            if "test" in path.parts:
                 log.warning(f"Reading random data from {path}")
-            else:
-                break
+            break
 
-        # Use prepared query and replacements
-        return iamc_like_data_for_query(path, self.query, replace=self.replace)
+        self.path = path
+
+    def __call__(self):
+        # Use prepared path, query, and replacements
+        return iamc_like_data_for_query(self.path, self.query, replace=self.replace)

--- a/message_ix_models/project/ssp/structure.py
+++ b/message_ix_models/project/ssp/structure.py
@@ -1,4 +1,5 @@
 """Manipulate data structures for working with the SSPs."""
+
 import logging
 from textwrap import wrap
 from typing import TYPE_CHECKING, Optional

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -246,7 +246,7 @@ def report(context: Context, *args, **kwargs):
     with (
         nullcontext()
         if context.core.verbose
-        else silence_log(["genno", "message_ix_models"])
+        else silence_log("genno message_ix_models")
     ):
         rep, key = prepare_reporter(context)
 

--- a/message_ix_models/report/compat.py
+++ b/message_ix_models/report/compat.py
@@ -1,4 +1,5 @@
 """Compatibility code that emulates :mod:`.message_data` reporting."""
+
 import logging
 from functools import partial
 from itertools import chain, count

--- a/message_ix_models/report/operator.py
+++ b/message_ix_models/report/operator.py
@@ -1,4 +1,5 @@
 """Atomic reporting operations for MESSAGEix-GLOBIOM."""
+
 import itertools
 import logging
 import re

--- a/message_ix_models/report/operator.py
+++ b/message_ix_models/report/operator.py
@@ -13,7 +13,7 @@ from iam_units import convert_gwp
 from iam_units.emissions import SPECIES
 
 from message_ix_models import Context
-from message_ix_models.util import add_par_data
+from message_ix_models.util import add_par_data, nodes_ex_world
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -34,6 +34,7 @@ __all__ = [
     "gwp_factors",
     "make_output_path",
     "model_periods",
+    "nodes_ex_world",
     "remove_ts",
     "share_curtailment",
 ]

--- a/message_ix_models/report/plot.py
+++ b/message_ix_models/report/plot.py
@@ -3,6 +3,7 @@
 The current set functions on time series data stored on the scenario by
 :mod:`message_ix_models.report` or :mod:`message_data` legacy reporting.
 """
+
 import logging
 import re
 from datetime import datetime

--- a/message_ix_models/report/plot.py
+++ b/message_ix_models/report/plot.py
@@ -101,9 +101,7 @@ class Plot(genno.compat.plotnine.Plot):
                 c.add(k, "get_ts", scenario_key, dict(variable=k.name))
 
         # Add the plot itself
-        # TODO once the genno class returns the added key, change to "return super().…"
-        super().add_tasks(c, key, *inputs[1:], strict=strict)
-        return key
+        return super().add_tasks(c, key, *inputs[1:], strict=strict)
 
     def ggtitle(self, value=None) -> p9.ggtitle:
         """Return :class:`plotnine.ggtitle` including the current date & time."""

--- a/message_ix_models/report/sim.py
+++ b/message_ix_models/report/sim.py
@@ -1,4 +1,5 @@
 """Simulated solution data for testing :mod:`~message_ix_models.report`."""
+
 import logging
 from collections import ChainMap, defaultdict
 from collections.abc import Mapping

--- a/message_ix_models/report/util.py
+++ b/message_ix_models/report/util.py
@@ -10,8 +10,6 @@ from iam_units import registry
 from message_ix import Reporter
 from sdmx.model.v21 import Code
 
-from message_ix_models.util import eval_anno
-
 log = logging.getLogger(__name__)
 
 
@@ -198,6 +196,9 @@ def copy_ts(rep: Reporter, other: str, filters: Optional[dict]) -> Key:
 def add_replacements(dim: str, codes: Iterable[Code]) -> None:
     """Update :data:`REPLACE_DIMS` for dimension `dim` with values from `codes`."""
     for code in codes:
-        label = eval_anno(code, "report")
-        if label is not None:
+        try:
+            label = str(code.get_annotation(id="report").text)
+        except KeyError:
+            pass
+        else:
             REPLACE_DIMS[dim][f"{code.id.title()}$"] = label

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -82,6 +82,8 @@ def session_context(pytestconfig, tmp_env):
       the :ref:`pytest tmp_path directory <pytest:tmp_path>`.
 
     """
+    from platformdirs import user_cache_path
+
     ctx = Context.only()
 
     # Temporary, empty local directory for local data
@@ -91,7 +93,7 @@ def session_context(pytestconfig, tmp_env):
     # pick up the existing setting from the user environment. If False, use a pytest-
     # managed cache directory that persists across test sessions.
     ctx.cache_path = (
-        ctx.local_data.joinpath("cache")
+        user_cache_path("message-ix-models", ensure_exists=True)
         if pytestconfig.option.local_cache
         # TODO use pytestconfig.cache.mkdir() when pytest >= 6.3 is available
         else Path(pytestconfig.cache.makedir("cache"))

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -1,21 +1,19 @@
 import logging
 import os
 from base64 import b32hexencode
-from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from random import randbytes
 from tempfile import TemporaryDirectory
 
-import click.testing
 import message_ix
 import pandas as pd
 import pytest
 from ixmp import Platform
 from ixmp import config as ixmp_config
 
-from message_ix_models import cli, util
-from message_ix_models.util._logging import mark_time, preserve_log_level
+from message_ix_models import util
+from message_ix_models.util._logging import mark_time
 from message_ix_models.util.context import Context
 
 log = logging.getLogger(__name__)
@@ -148,84 +146,22 @@ def user_context(request):  # pragma: no cover
     raise NotImplementedError
 
 
-class CliRunner(click.testing.CliRunner):
-    """Subclass of :class:`click.testing.CliRunner` with extra features."""
-
-    # NB decorator ensures any changes that the CLI makes to the logger level are
-    #    restored
-    @preserve_log_level()
-    def invoke(self, *args, **kwargs):
-        """Invoke the :program:`mix-models` CLI."""
-        result = super().invoke(cli.main, *args, **kwargs)
-
-        # Store the result to be used by assert_exit_0()
-        self.last_result = result
-
-        return result
-
-    def assert_exit_0(self, *args, **kwargs):
-        """Assert a result has exit_code 0, or print its traceback.
-
-        If any `args` or `kwargs` are given, :meth:`.invoke` is first called. Otherwise,
-        the result from the last call of :meth:`.invoke` is used.
-
-        Raises
-        ------
-        AssertionError
-            if the result exit code is not 0. The exception contains the traceback from
-            within the CLI.
-
-        Returns
-        -------
-        click.testing.Result
-        """
-        __tracebackhide__ = True
-
-        if len(args) + len(kwargs):
-            self.invoke(*args, **kwargs)
-
-        # Retrieve the last result
-        result = self.last_result
-
-        if result.exit_code != 0:
-            print(f"{result.exit_code = }\nresult.output =\n{result.output}")
-            # Re-raise the exception triggered within the CLI invocation
-            raise (result.exc_info[1].__context__ or result.exc_info[1]) from None
-
-        return result
-
-    @property
-    def add_command(self):
-        return cli_test_group.add_command
-
-    @contextmanager
-    def temporary_command(self, func: "click.Command", set_target: bool = True):
-        """Temporarily attach command `func` to :func:`cli_test_group`."""
-        assert func.name is not None
-        try:
-            cli_test_group.add_command(func)
-            yield
-        finally:
-            cli_test_group.commands.pop(func.name)
-
-
 @pytest.fixture
-def mix_models_cli(request, test_context, tmp_env):
-    """A :class:`.CliRunner` object that invokes the :program:`mix-models` CLI."""
-    # Require the `test_context` fixture in order to (a) set Context.local_data and (b)
-    # ensure changes to the Context from tested CLI commands are isolated from other
-    # tests
-    yield CliRunner(env=tmp_env)
+def mix_models_cli(session_context, tmp_env):
+    """A :class:`.CliRunner` object that invokes the :program:`mix-models` CLI.
 
+    NB this requires:
 
-@cli.main.group("_test", hidden=True)
-def cli_test_group():
-    """Hidden group of CLI commands.
-
-    Other code which needs to test CLI behaviour **may** attach temporary/throw-away
-    commands to this group and then invoke them using :func:`mix_models_cli`. This
-    avoids the need to expose additional commands for testing purposes only.
+    - The :mod:`ixmp` :func:`.tmp_env` fixture. This sets ``IXMP_DATA`` to a temporary
+      directory managed by :mod:`pytest`.
+    - The :func:`session_context` fixture. This (a) sets :attr:`.Config.local_data` to
+      a temporary directory within ``IXMP_DATA`` and (b) ensures changes to
+      :class:`.Context` made by invoked commands do not reach other tests.
     """
+    from message_ix_models import cli
+    from message_ix_models.util.click import CliRunner
+
+    yield CliRunner(cli.main, cli.__name__, env=tmp_env)
 
 
 # Testing utility functions

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -9,7 +9,6 @@ from tempfile import TemporaryDirectory
 import message_ix
 import pandas as pd
 import pytest
-from ixmp import Platform
 from ixmp import config as ixmp_config
 
 from message_ix_models import util
@@ -109,10 +108,7 @@ def session_context(pytestconfig, tmp_env):
         url=f"jdbc:hsqldb:mem://{platform_name}",
         jvmargs=pytestconfig.option.jvmargs,
     )
-
-    # Launch Platform and connect to testdb (reconnect if closed)
-    mp = Platform(name=platform_name)
-    mp.open_db()
+    ixmp_config.save()
 
     ctx.platform_info["name"] = platform_name
 

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -48,17 +48,6 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_sessionstart():
-    # Quiet logs for some upstream packages
-    for name in (
-        "graphviz._tools",
-        "pycountry.db",
-        "matplotlib.backends",
-        "matplotlib.font_manager",
-    ):
-        logging.getLogger(name).setLevel(logging.DEBUG + 1)
-
-
 # Fixtures
 
 

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -1,4 +1,5 @@
 """Tests of :mod:`.model.disutility`."""
+
 from itertools import product
 
 import pandas as pd

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -278,4 +278,6 @@ def test_process_units_anno():
     process_units_anno("", codes[0])
 
     # Parents' units are propagated to the child
-    assert registry.Unit("kg") == codes[1].eval_annotation("units")
+    assert registry.Unit("kg") == codes[1].eval_annotation(
+        "units", dict(registry=registry)
+    )

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -15,7 +15,7 @@ from message_ix_models.model.structure import (
     process_commodity_codes,
     process_units_anno,
 )
-from message_ix_models.util import as_codes, eval_anno
+from message_ix_models.util import as_codes
 
 
 @pytest.mark.parametrize(
@@ -97,8 +97,9 @@ class TestGetCodes:
             assert check in data
 
         # Units for one commodity can be retrieved and parsed
+        g = dict(registry=registry)
         coal = data[data.index("coal")]
-        assert isinstance(eval_anno(coal, "units"), registry.Unit)
+        assert isinstance(coal.eval_annotation("units", globals=g), registry.Unit)
 
         # Descriptions are parsed without new lines
         crudeoil = data[data.index("crudeoil")]
@@ -107,7 +108,7 @@ class TestGetCodes:
         # Processing a second time does not double-wrap the unit expressions
         process_commodity_codes(data)
         coal = data[data.index("coal")]
-        assert isinstance(eval_anno(coal, "units"), registry.Unit)
+        assert isinstance(coal.eval_annotation("units", globals=g), registry.Unit)
 
     def test_levels(self):
         data = get_codes("level")
@@ -277,4 +278,4 @@ def test_process_units_anno():
     process_units_anno("", codes[0])
 
     # Parents' units are propagated to the child
-    assert registry.Unit("kg") == eval_anno(codes[1], "units")
+    assert registry.Unit("kg") == codes[1].eval_annotation("units")

--- a/message_ix_models/tests/test_cli.py
+++ b/message_ix_models/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Basic tests of the command line."""
+
 import ixmp
 import pytest
 from message_ix.testing import make_dantzig

--- a/message_ix_models/tests/test_report.py
+++ b/message_ix_models/tests/test_report.py
@@ -1,4 +1,5 @@
 """Tests for :mod:`message_ix_models.report`."""
+
 from importlib.metadata import version
 
 import numpy as np

--- a/message_ix_models/tests/test_testing.py
+++ b/message_ix_models/tests/test_testing.py
@@ -1,8 +1,5 @@
 import os
 
-import click
-import pytest
-
 from message_ix_models.testing import bare_res, not_ci
 
 
@@ -21,8 +18,8 @@ def test_bare_res_solved(request, test_context):
 
 
 def test_cli_runner(mix_models_cli):
-    with pytest.raises(click.exceptions.UsageError, match="No such command 'foo'"):
-        mix_models_cli.assert_exit_0(["foo", "bar"])
+    result = mix_models_cli.invoke(["foo", "bar"])
+    assert "No such command 'foo'" in result.output
 
 
 @not_ci(reason="foo", action="skip")

--- a/message_ix_models/tests/test_util.py
+++ b/message_ix_models/tests/test_util.py
@@ -1,4 +1,5 @@
 """Tests of :mod:`message_ix_models.util`."""
+
 import logging
 import re
 from importlib.metadata import version

--- a/message_ix_models/tests/test_workflow.py
+++ b/message_ix_models/tests/test_workflow.py
@@ -148,7 +148,9 @@ def test_workflow(caplog, request, test_context, wf) -> None:
 
     # Log messages reflect workflow steps executed
     start_index = 1 if caplog.messages[0].startswith("Cull") else 0
-    m = "MESSAGEix-GLOBIOM R14 YB"
+    # This setting obtains the value R11 on some Windows GHA jobs, but is otherwise R14.
+    # TODO Debug and fix.
+    m = f"MESSAGEix-GLOBIOM {test_context.model.regions} YB"
     messages = [
         f"Loaded ixmp://{mp}/{m}/test_workflow#1",
         f"Step runs on ixmp://{mp}/{m}/test_workflow#1",
@@ -166,7 +168,7 @@ def test_workflow(caplog, request, test_context, wf) -> None:
         assert re.match(expr, message)
 
     assert re.match(
-        r"""'B':
+        rf"""'B':
 - <Step changes_b\(\)>
 - 'context':
   - <Context object at \w+ with \d+ keys>
@@ -174,7 +176,7 @@ def test_workflow(caplog, request, test_context, wf) -> None:
   - <Step changes_a\(\)>
   - 'context' \(above\)
   - 'base':
-    - <Step load -> MESSAGEix-GLOBIOM R14 YB/test_workflow>
+    - <Step load -> {m}/test_workflow>
     - 'context' \(above\)
     - None""",
         wf.describe("B"),
@@ -185,12 +187,12 @@ def test_workflow(caplog, request, test_context, wf) -> None:
 
     # Description reflects that changes_a() will no longer be called
     assert re.match(
-        r"""'B':
+        rf"""'B':
 - <Step changes_b\(\)>
 - 'context':
   - <Context object at \w+ with \d+ keys>
 - 'A':
-  - <Step load -> MESSAGEix-GLOBIOM R14 YB/test_workflow>
+  - <Step load -> {m}/test_workflow>
   - 'context' \(above\)
   - None""",
         wf.describe("B"),

--- a/message_ix_models/tests/tools/iea/test_web.py
+++ b/message_ix_models/tests/tools/iea/test_web.py
@@ -7,6 +7,7 @@ from genno import Computer
 from message_ix_models.testing import GHA
 from message_ix_models.tools.exo_data import prepare_computer
 from message_ix_models.tools.iea.web import DIMS, generate_code_lists, load_data
+from message_ix_models.util import HAS_MESSAGE_DATA
 
 
 class TestIEA_EWEB:
@@ -68,7 +69,9 @@ PROVIDER_EDITION = (
     pytest.param(
         "IEA",
         "2023",
-        marks=pytest.mark.xfail(GHA, reason="No fuzzed version of this data"),
+        marks=pytest.mark.xfail(
+            GHA or not HAS_MESSAGE_DATA, reason="No fuzzed version of this data"
+        ),
     ),
     ("OECD", "2023"),
     ("OECD", "2022"),

--- a/message_ix_models/tests/util/test_click.py
+++ b/message_ix_models/tests/util/test_click.py
@@ -1,4 +1,5 @@
 """Basic tests of the command line."""
+
 import click
 
 from message_ix_models.util.click import common_params

--- a/message_ix_models/tests/util/test_click.py
+++ b/message_ix_models/tests/util/test_click.py
@@ -2,7 +2,8 @@
 
 import click
 
-from message_ix_models.util.click import common_params
+from message_ix_models.cli import cli_test_group
+from message_ix_models.util.click import common_params, temporary_command
 
 
 def test_default_path_cb(session_context, mix_models_cli):
@@ -23,7 +24,7 @@ def test_default_path_cb(session_context, mix_models_cli):
     expected = session_context.local_data / "reporting_output"
 
     # Run the command
-    with mix_models_cli.temporary_command(func):
+    with temporary_command(cli_test_group, func):
         result = mix_models_cli.assert_exit_0(cmd)
 
     # The value was stored on, and retrieved from, `ctx`
@@ -49,7 +50,7 @@ def test_regions(mix_models_cli):
         print(context.model.regions)
 
     # Give the option for the outer group, but not for the inner command
-    with mix_models_cli.temporary_command(outer):
+    with temporary_command(cli_test_group, outer):
         result = mix_models_cli.assert_exit_0(
             ["_test", "outer", "--regions=ZMB", "inner"]
         )
@@ -69,7 +70,7 @@ def test_store_context(mix_models_cli):
         print(ctx["ssp"])  # Print the value stored on the Context object
 
     # Run the command with a valid value
-    with mix_models_cli.temporary_command(func):
+    with temporary_command(cli_test_group, func):
         result = mix_models_cli.assert_exit_0(["_test", func.name, "SSP2"])
 
     # The value was stored on, and retrieved from, `ctx`
@@ -96,7 +97,7 @@ baz/qux#123
     p.write_text(text)
 
     # Run the command, referring to the temporary file
-    with mix_models_cli.temporary_command(func):
+    with temporary_command(cli_test_group, func):
         result = mix_models_cli.assert_exit_0(
             ["_test", func.name, f"--urls-from-file={p}"]
         )

--- a/message_ix_models/tests/util/test_context.py
+++ b/message_ix_models/tests/util/test_context.py
@@ -157,11 +157,12 @@ class TestContext:
         """:meth:`.write_debug_archive` works."""
         # Create a CLI command attached to the hidden "_test" group
 
-        from message_ix_models.testing import cli_test_group
+        from message_ix_models.cli import cli_test_group
+        from message_ix_models.util.click import temporary_command
 
-        @cli_test_group.command("write-debug-archive")
+        @click.command("write-debug-archive")
         @click.pass_obj
-        def _(context):
+        def command(context):
             # Register one file to be archived
             p = context.core.local_data.joinpath("foo.txt")
             context.core.debug_paths.append(p)
@@ -176,7 +177,8 @@ class TestContext:
             context.write_debug_archive()
 
         # Invoke the command; I/O occurs in a temporary directory
-        result = mix_models_cli.invoke(["_test", "write-debug-archive"])
+        with temporary_command(cli_test_group, command):
+            result = mix_models_cli.invoke(["_test", "write-debug-archive"])
 
         # Output path is constructed as expected; file exists
         match = re.search(

--- a/message_ix_models/tests/util/test_logging.py
+++ b/message_ix_models/tests/util/test_logging.py
@@ -1,7 +1,6 @@
 import logging
 import re
 
-import click
 import pytest
 
 from message_ix_models.util._logging import mark_time, silence_log
@@ -38,15 +37,11 @@ class TestQueueListener:
         and captured by the :class:`.CliRunner`.
         """
 
-        @click.command("log-threads")
-        def func():
-            # Emit many log records
-            log = logging.getLogger("message_ix_models")
-            [log.info(f"{k = } {i = }") for i in range(self.N)]
-
-        with mix_models_cli.temporary_command(func):
-            # Run the command, capture output
-            result = mix_models_cli.assert_exit_0(["_test", func.name])
+        # Run the command, capture output
+        # See message_ix_models.cli._log_threads
+        result = mix_models_cli.assert_exit_0(
+            ["_test", "log-threads", str(k), str(self.N)], method="click"
+        )
 
         # All records are emitted; the last record ends with N - 1
         assert result.output.rstrip().endswith(f"{self.N - 1}"), result.output.split(

--- a/message_ix_models/tests/util/test_logging.py
+++ b/message_ix_models/tests/util/test_logging.py
@@ -26,8 +26,12 @@ class TestQueueListener:
     #: Number of times to run the test.
     k = 4
 
+    @pytest.mark.parametrize(
+        "method",
+        ("click", pytest.param("subprocess", marks=pytest.mark.skip(reason="Slow."))),
+    )
     @pytest.mark.parametrize("k", range(k))
-    def test_flush(self, caplog, mix_models_cli, k):
+    def test_flush(self, caplog, mix_models_cli, method, k):
         """Test logging in multiple processes, multiple threads, and with :mod:`click`.
 
         With pytest-xdist, these :attr:`k` test cases will run in multiple processes.
@@ -40,7 +44,7 @@ class TestQueueListener:
         # Run the command, capture output
         # See message_ix_models.cli._log_threads
         result = mix_models_cli.assert_exit_0(
-            ["_test", "log-threads", str(k), str(self.N)], method="click"
+            ["_test", "log-threads", str(k), str(self.N)], method=method
         )
 
         # All records are emitted; the last record ends with N - 1

--- a/message_ix_models/tests/util/test_logging.py
+++ b/message_ix_models/tests/util/test_logging.py
@@ -70,7 +70,7 @@ def test_silence_log(caplog):
         log.warning(msg)
 
     assert [
-        "Set level=40 for logger(s): message_ix_models message_data",
+        "Set level=40 for logger(s): message_data message_ix_models",
         "…restored.",
     ] == caplog.messages
     caplog.clear()

--- a/message_ix_models/tests/util/test_node.py
+++ b/message_ix_models/tests/util/test_node.py
@@ -1,4 +1,5 @@
 """Tests of :mod:`message_ix_models.util.node`."""
+
 import re
 
 import pandas as pd

--- a/message_ix_models/tests/util/test_sdmx.py
+++ b/message_ix_models/tests/util/test_sdmx.py
@@ -7,14 +7,17 @@ from sdmx.model.v21 import Annotation, Code
 from message_ix_models.util.sdmx import eval_anno, make_enum, read
 
 
-def test_eval_anno(caplog):
+def test_eval_anno(caplog, recwarn):
     c = Code()
 
-    assert None is eval_anno(c, "foo")
+    with pytest.warns(DeprecationWarning):
+        assert None is eval_anno(c, "foo")
 
     c.annotations.append(Annotation(id="foo", text="bar baz"))
 
-    with caplog.at_level(logging.DEBUG, logger="message_ix_models"):
+    with caplog.at_level(logging.DEBUG, logger="message_ix_models"), pytest.warns(
+        DeprecationWarning
+    ):
         assert "bar baz" == eval_anno(c, "foo")
 
     assert re.fullmatch(
@@ -23,7 +26,8 @@ def test_eval_anno(caplog):
 
     c.annotations.append(Annotation(id="qux", text="3 + 4"))
 
-    assert 7 == eval_anno(c, id="qux")
+    with pytest.warns(DeprecationWarning):
+        assert 7 == eval_anno(c, id="qux")
 
 
 def test_make_enum():

--- a/message_ix_models/tools/advance.py
+++ b/message_ix_models/tools/advance.py
@@ -1,4 +1,5 @@
 """Handle data from the ADVANCE project."""
+
 import logging
 from pathlib import Path
 from typing import Optional

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -1,4 +1,5 @@
 """Generic tools for working with exogenous data sources."""
+
 import logging
 from abc import ABC, abstractmethod
 from operator import itemgetter

--- a/message_ix_models/tools/exo_data.py
+++ b/message_ix_models/tools/exo_data.py
@@ -2,6 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from operator import itemgetter
 from pathlib import Path
 from typing import Any, Dict, Literal, Mapping, Optional, Tuple, Type
@@ -112,6 +113,15 @@ class ExoDataSource(ABC):
 
         return k2
 
+    def raise_on_extra_kw(self, kwargs) -> None:
+        """Helper for subclasses."""
+        if len(kwargs):
+            log.error(
+                f"Unhandled extra keyword arguments for {type(self).__name__}: "
+                + repr(kwargs)
+            )
+            raise ValueError(kwargs)
+
 
 def prepare_computer(
     context,
@@ -164,7 +174,7 @@ def prepare_computer(
     for cls in SOURCES.values():
         try:
             # Instantiate a Source object to provide this data
-            source_obj = cls(source, source_kw or dict())
+            source_obj = cls(source, deepcopy(source_kw or dict()))
         except Exception:
             pass  # Class does not recognize the arguments
 

--- a/message_ix_models/tools/iamc.py
+++ b/message_ix_models/tools/iamc.py
@@ -1,4 +1,5 @@
 """Tools for working with IAMC-structured data."""
+
 from typing import Optional
 
 import pandas as pd

--- a/message_ix_models/tools/iea/web.py
+++ b/message_ix_models/tools/iea/web.py
@@ -1,4 +1,5 @@
 """Tools for IEA (Extended) World Energy Balance (WEB) data."""
+
 import logging
 import zipfile
 from copy import copy

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -1,4 +1,5 @@
 """Tools for World Bank data."""
+
 import logging
 from collections import defaultdict
 from functools import lru_cache

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def assign_income_groups(
+# FIXME Reduce complexity from 12 → ≤11
+def assign_income_groups(  # noqa: C901
     cl_node: "sdmx.model.common.Codelist",
     cl_income_group: "sdmx.model.common.Codelist",
     method: str = "population",

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from collections import ChainMap, defaultdict
+from datetime import datetime
 from functools import partial, update_wrapper
 from importlib.metadata import version
 from itertools import count
@@ -278,6 +279,12 @@ def copy_column(column_name):
     return lambda df: df[column_name]
 
 
+def datetime_now_with_tz() -> datetime:
+    """Current date and time with time zone information."""
+    tz = datetime.now().astimezone().tzinfo
+    return datetime.now(tz)
+
+
 def ffill(
     df: pd.DataFrame, dim: str, values: Sequence[CodeLike], expr: Optional[str] = None
 ) -> pd.DataFrame:
@@ -321,8 +328,7 @@ def ffill(
 
 
 class KeyIterator(Protocol):
-    def __call__(self) -> "genno.Key":
-        ...
+    def __call__(self) -> "genno.Key": ...
 
 
 def iter_keys(base: "genno.Key") -> KeyIterator:
@@ -662,6 +668,19 @@ def same_time(df: pd.DataFrame) -> pd.DataFrame:
     """Fill 'time_origin'/'time_dest' in `df` from 'time'."""
     cols = list(set(df.columns) & {"time_origin", "time_dest"})
     return df.assign(**{c: copy_column("time") for c in cols})
+
+
+def show_versions() -> str:
+    """Output of :func:`ixmp.show_versions`, as a :class:`str`."""
+    from io import StringIO
+
+    from . import ixmp
+
+    # Retrieve package versions
+    buf = StringIO()
+    ixmp.show_versions(buf)
+
+    return buf.getvalue()
 
 
 # FIXME Reduce complexity from 14 to ≤13

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -214,7 +214,9 @@ def broadcast(
             _check_dim(dim)
         # Concatenate 1 copy of `df` for each row in `labels`
         df = pd.concat(
-            [df.assign(**row) for _, row in labels.iterrows()], ignore_index=True
+            [df.assign(**row) for _, row in labels.iterrows()],
+            ignore_index=True,
+            sort=False,
         )
 
     # Next, broadcast other dimensions given as keyword arguments
@@ -231,7 +233,7 @@ def broadcast(
         # - Re-add the column from the constructed MultiIndex
         # - Reindex for sequential row numbers
         df = (
-            pd.concat([df] * len(levels), keys=levels, names=[dim])
+            pd.concat([df] * len(levels), keys=levels, names=[dim], sort=False)
             .drop(dim, axis=1)
             .reset_index(dim)
             .reset_index(drop=True)

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -681,10 +681,15 @@ def show_versions() -> str:
     from io import StringIO
 
     from . import ixmp
+    from ._logging import preserve_log_handlers
 
     # Retrieve package versions
     buf = StringIO()
-    ixmp.show_versions(buf)
+
+    # show_versions() imports pyam-iamc, which in turn imports ixmp4, which removes all
+    # handlers from the root logger (?!). Preserve the message-ix-models logging config.
+    with preserve_log_handlers():
+        ixmp.show_versions(buf)
 
     return buf.getvalue()
 

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -22,6 +22,7 @@ import pandas as pd
 import pint
 
 from ._convert_units import convert_units, series_of_pint_quantity
+from ._logging import mark_time, preserve_log_level, silence_log
 from .cache import cached
 from .common import (
     HAS_MESSAGE_DATA,
@@ -68,15 +69,18 @@ __all__ = [
     "make_io",
     "make_matched_dfs",
     "make_source_tech",
+    "mark_time",
     "maybe_query",
     "merge_data",
     "minimum_version",
     "package_data_path",
+    "preserve_log_level",
     "private_data_path",
     "replace_par_data",
     "same_node",
     "same_time",
     "series_of_pint_quantity",
+    "silence_log",
     "strip_par_data",
 ]
 

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -59,6 +59,7 @@ __all__ = [
     "check_support",
     "convert_units",
     "copy_column",
+    "datetime_now_with_tz",
     "eval_anno",
     "ffill",
     "identify_nodes",
@@ -80,6 +81,7 @@ __all__ = [
     "same_node",
     "same_time",
     "series_of_pint_quantity",
+    "show_versions",
     "silence_log",
     "strip_par_data",
 ]

--- a/message_ix_models/util/_logging.py
+++ b/message_ix_models/util/_logging.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from queue import SimpleQueue
 from time import process_time
-from typing import Dict, List, Union, cast
+from typing import Dict, List, Optional, Union, cast
 
 # NB mark_time, preserve_log_level, and silence_log are exposed by util/__init__.py
 __all__ = [
@@ -198,6 +198,25 @@ def mark_time(quiet: bool = False) -> None:
         logging.getLogger(__name__).info(
             f" +{_TIMES[-1] - _TIMES[-2]:.1f} = {_TIMES[-1]:.1f} seconds"
         )
+
+
+@contextmanager
+def preserve_log_handlers(name: Optional[str] = None):
+    """Context manager to preserve the handlers of a `logger`."""
+    # Access the named logger
+    logger = logging.getLogger(name)
+    # Make a copy of its list of handlers
+    handlers = list(logger.handlers)
+
+    try:
+        yield
+    finally:
+        # Make a list of handlers which have disappeared from the logger
+        to_restore = list(filter(lambda h: h not in logger.handlers, handlers))
+        for h in to_restore:
+            logger.addHandler(h)
+        # Log after the handlers have been restored
+        log.debug(f"Restore to {logger}.handlers: {to_restore or '(none)'}")
 
 
 @contextmanager

--- a/message_ix_models/util/_logging.py
+++ b/message_ix_models/util/_logging.py
@@ -15,66 +15,59 @@ from typing import List, Union
 # NB mark_time, preserve_log_level, and silence_log are exposed by util/__init__.py
 __all__ = [
     "Formatter",
+    "QueueHandler",
+    "StreamHandler",
     "setup",
 ]
 
 log = logging.getLogger(__name__)
 
-
-@contextmanager
-def silence_log(names=None, level=logging.ERROR):
-    """Context manager to temporarily quiet 1 or more loggers.
-
-    Parameters
-    ----------
-    names : str, *optional*
-        Space-separated names of loggers to quiet.
-    level : int, *optional*
-        Minimum level of log messages to allow.
-
-    Examples
-    --------
-    >>> with silence_log():
-    >>>     log.warning("This message is not recorded.")
-    """
-    # Default: the top-level logger for the package containing this file
-    if names is None:
-        names = [__name__.split(".")[0], "message_data"]
-    elif isinstance(names, str):
-        names = [names]
-
-    log.info(f"Set level={level} for logger(s): {' '.join(names)}")
-
-    # Retrieve the logger objects
-    loggers = list(map(logging.getLogger, names))
-    # Store their current levels
-    levels = []
-
-    try:
-        for logger in loggers:
-            levels.append(logger.getEffectiveLevel())  # Store the current levels
-            logger.setLevel(level)  # Set the level
-        yield
-    finally:
-        # Restore the levels
-        for logger, original_level in zip(loggers, levels):
-            logger.setLevel(original_level)
-        log.info("…restored.")
+# NB This is only separate to avoid complaints from mypy
+_HANDLER_CONFIG = dict(
+    console={
+        "class": "message_ix_models.util._logging.StreamHandler",
+        "level": 99,
+        "formatter": "color",
+        "stream_name": "stdout",
+    },
+    file={
+        "class": "logging.FileHandler",
+        "level": 99,
+        "formatter": "plain",
+        "delay": True,
+    },
+    queue={
+        "class": "message_ix_models.util._logging.QueueHandler",
+        "handlers": ["console", "file"],
+        "respect_handler_level": True,
+    },
+)
 
 
-@contextmanager
-def preserve_log_level():
-    """Context manager to preserve the level of the ``message_ix_models`` logger."""
-    # Get the top-level logger for the package containing this file
-    main_log = logging.getLogger(__name__.split(".")[0])
+_CONFIG = dict(
+    version=1,
+    disable_existing_loggers=False,
+    formatters=dict(
+        color={"()": "message_ix_models.util._logging.Formatter"},
+        plain={"()": "message_ix_models.util._logging.Formatter", "use_colour": False},
+    ),
+    handlers=_HANDLER_CONFIG,
+    loggers={
+        # Ensure no level set for these packages; the level of the "console"/"file"
+        # handlers determines outputs
+        "message_ix_models": dict(level=logging.NOTSET),
+        "message_data": dict(level=logging.NOTSET),
+        # Hide DEBUG messages for some upstream packages from the file log
+        "graphviz._tools": dict(level=logging.DEBUG + 1),
+        "pycountry.db": dict(level=logging.DEBUG + 1),
+        "matplotlib.backends": dict(level=logging.DEBUG + 1),
+        "matplotlib.font_manager": dict(level=logging.DEBUG + 1),
+    },
+    root=dict(handlers=["queue"]),
+)
 
-    try:
-        # Store the current level
-        level = main_log.getEffectiveLevel()
-        yield
-    finally:
-        # Restore the level
-        main_log.setLevel(level)
+# For mark_time()
+_TIMES = []
 
 
 class Formatter(logging.Formatter):
@@ -135,40 +128,6 @@ class Formatter(logging.Formatter):
         return f"{prefix}{record.funcName}{self.RESET_ALL}  {record.getMessage()}"
 
 
-# For mark_time()
-_TIMES = []
-
-
-def mark_time(quiet: bool = False) -> None:
-    """Record and log (if `quiet` is :obj:`True`) a time mark."""
-    _TIMES.append(process_time())
-    if not quiet and len(_TIMES) > 1:
-        logging.getLogger(__name__).info(
-            f" +{_TIMES[-1] - _TIMES[-2]:.1f} = {_TIMES[-1]:.1f} seconds"
-        )
-
-
-class StreamHandler(logging.StreamHandler):
-    """Like :class:`.logging.StreamHandler`, but refresh sys.stdout on each access.
-
-    This avoids the case that :mod:`click`, :mod:`pytest`, or something else adjusts
-    :py:`sys.stdout` temporarily, but the handler's stored reference to the original is
-    not updated.
-    """
-
-    #: Name of the :mod:`sys` stream to use, as :class:`str` rather than a direct
-    #: reference.
-    stream_name: str
-
-    def __init__(self, stream_name: str):
-        self.stream_name = stream_name
-        logging.Handler.__init__(self)
-
-    @property
-    def stream(self):
-        return getattr(sys, self.stream_name)
-
-
 class QueueHandler(logging.handlers.QueueHandler):
     """Queue handler with custom set-up.
 
@@ -195,49 +154,61 @@ class QueueHandler(logging.handlers.QueueHandler):
         atexit.register(self.listener.stop)
 
 
-# NB This is only separate to avoid complaints from mypy
-HANDLER_CONFIG = dict(
-    console={
-        "class": "message_ix_models.util._logging.StreamHandler",
-        "level": 99,
-        "formatter": "color",
-        "stream_name": "stdout",
-    },
-    file={
-        "class": "logging.FileHandler",
-        "level": 99,
-        "formatter": "plain",
-        "delay": True,
-    },
-    queue={
-        "class": "message_ix_models.util._logging.QueueHandler",
-        "handlers": ["console", "file"],
-        "respect_handler_level": True,
-    },
-)
+class StreamHandler(logging.StreamHandler):
+    """Like :class:`.logging.StreamHandler`, but refresh sys.stdout on each access.
+
+    This avoids the case that :mod:`click`, :mod:`pytest`, or something else adjusts
+    :py:`sys.stdout` temporarily, but the handler's stored reference to the original is
+    not updated.
+    """
+
+    #: Name of the :mod:`sys` stream to use, as :class:`str` rather than a direct
+    #: reference.
+    stream_name: str
+
+    def __init__(self, stream_name: str):
+        self.stream_name = stream_name
+        logging.Handler.__init__(self)
+
+    @property
+    def stream(self):
+        return getattr(sys, self.stream_name)
 
 
-CONFIG = dict(
-    version=1,
-    disable_existing_loggers=False,
-    formatters=dict(
-        color={"()": "message_ix_models.util._logging.Formatter"},
-        plain={"()": "message_ix_models.util._logging.Formatter", "use_colour": False},
-    ),
-    handlers=HANDLER_CONFIG,
-    loggers={
-        # Ensure no level set for these packages; the level of the "console"/"file"
-        # handlers determines outputs
-        "message_ix_models": dict(level=logging.NOTSET),
-        "message_data": dict(level=logging.NOTSET),
-        # Hide DEBUG messages for some upstream packages from the file log
-        "graphviz._tools": dict(level=logging.DEBUG + 1),
-        "pycountry.db": dict(level=logging.DEBUG + 1),
-        "matplotlib.backends": dict(level=logging.DEBUG + 1),
-        "matplotlib.font_manager": dict(level=logging.DEBUG + 1),
-    },
-    root=dict(handlers=["queue"]),
-)
+def _get_handler(name: str) -> logging.Handler:
+    """Retrieve one of the handlers of the :class:`logging.handlers.QueueListener`."""
+    queue_handler = logging.getLogger().handlers[0]
+    assert isinstance(queue_handler, QueueHandler)
+
+    for h in queue_handler.listener.handlers:
+        if h.name == name:
+            return h
+
+    raise ValueError(name)
+
+
+def mark_time(quiet: bool = False) -> None:
+    """Record and log (if `quiet` is :obj:`True`) a time mark."""
+    _TIMES.append(process_time())
+    if not quiet and len(_TIMES) > 1:
+        logging.getLogger(__name__).info(
+            f" +{_TIMES[-1] - _TIMES[-2]:.1f} = {_TIMES[-1]:.1f} seconds"
+        )
+
+
+@contextmanager
+def preserve_log_level():
+    """Context manager to preserve the level of the ``message_ix_models`` logger."""
+    # Get the top-level logger for the package containing this file
+    main_log = logging.getLogger(__name__.split(".")[0])
+
+    try:
+        # Store the current level
+        level = main_log.getEffectiveLevel()
+        yield
+    finally:
+        # Restore the level
+        main_log.setLevel(level)
 
 
 def setup(
@@ -266,34 +237,63 @@ def setup(
         .replace(":", "")
     )
     log_dir = user_log_path("message-ix-models", ensure_exists=True)
-    HANDLER_CONFIG["file"].setdefault("filename", log_dir.joinpath(filename))
-    CONFIG["handlers"] = HANDLER_CONFIG
+    _HANDLER_CONFIG["file"].setdefault("filename", log_dir.joinpath(filename))
+    _CONFIG["handlers"] = _HANDLER_CONFIG
 
     root = logging.getLogger()
     if not root.handlers:
         # Not yet configured → apply the configuration
-        logging.config.dictConfig(CONFIG)
+        logging.config.dictConfig(_CONFIG)
 
     # Apply settings to loggers and handlers: either just-created, or pre-existing
 
     # Set the level of the console handler
-    get_handler("console").setLevel(99 if console is False else level)
+    _get_handler("console").setLevel(99 if console is False else level)
 
-    file_handler = get_handler("file")
+    file_handler = _get_handler("file")
     if file is False:
         file_handler.setLevel(99)
     else:
         file_handler.setLevel("DEBUG")
-        log.info(f"Log to {HANDLER_CONFIG['file']['filename']!s}")
+        log.info(f"Log to {_HANDLER_CONFIG['file']['filename']!s}")
 
 
-def get_handler(name: str) -> logging.Handler:
-    """Retrieve one of the handlers of the :class:`logging.handlers.QueueListener`."""
-    queue_handler = logging.getLogger().handlers[0]
-    assert isinstance(queue_handler, QueueHandler)
+@contextmanager
+def silence_log(names=None, level=logging.ERROR):
+    """Context manager to temporarily quiet 1 or more loggers.
 
-    for h in queue_handler.listener.handlers:
-        if h.name == name:
-            return h
+    Parameters
+    ----------
+    names : str, *optional*
+        Space-separated names of loggers to quiet.
+    level : int, *optional*
+        Minimum level of log messages to allow.
 
-    raise ValueError(name)
+    Examples
+    --------
+    >>> with silence_log():
+    >>>     log.warning("This message is not recorded.")
+    """
+    # Default: the top-level logger for the package containing this file
+    if names is None:
+        names = [__name__.split(".")[0], "message_data"]
+    elif isinstance(names, str):
+        names = [names]
+
+    log.info(f"Set level={level} for logger(s): {' '.join(names)}")
+
+    # Retrieve the logger objects
+    loggers = list(map(logging.getLogger, names))
+    # Store their current levels
+    levels = []
+
+    try:
+        for logger in loggers:
+            levels.append(logger.getEffectiveLevel())  # Store the current levels
+            logger.setLevel(level)  # Set the level
+        yield
+    finally:
+        # Restore the levels
+        for logger, original_level in zip(loggers, levels):
+            logger.setLevel(original_level)
+        log.info("…restored.")

--- a/message_ix_models/util/_logging.py
+++ b/message_ix_models/util/_logging.py
@@ -131,16 +131,21 @@ class Formatter(logging.Formatter):
 class QueueHandler(logging.handlers.QueueHandler):
     """Queue handler with custom set-up.
 
-    This emulates the default behaviour available in Python 3.12.
+    This emulates the default behaviour available in Python 3.12 for Python 3.11 and
+    earlier; it is also compatible with Python 3.12.
     """
 
     #: Corresponding listener that dispatches to the actual handlers.
     listener: logging.handlers.QueueListener
 
     def __init__(
-        self, *, handlers: List[str] = [], respect_handler_level: bool = False
+        self,
+        queue=None,  # For Python 3.12
+        *,
+        handlers: List[str] = [],  # For Python 3.11 and earlier
+        respect_handler_level: bool = False,
     ) -> None:
-        super().__init__(SimpleQueue())
+        super().__init__(queue or SimpleQueue())
 
         # Construct the listener
         # NB This relies on the non-public collection logging._handlers

--- a/message_ix_models/util/cache.py
+++ b/message_ix_models/util/cache.py
@@ -4,24 +4,28 @@ This module extends :class:`genno.caching.Encoder` to handle classes common in
 :mod:`message_ix_models`, so these can be used as arguments to cached functions and
 included in the computed cache key:
 
-- :class:`sdmx.model.IdentifiableArtefact`, including :class:`.Code`: hashed as
-  their string representation / ID.
+- :class:`sdmx.model.IdentifiableArtefact`, including :class:`.Code`: hashed as their
+  string representation / ID.
 - :class:`ixmp.Platform`, :class:`xarray.Dataset`: ignored, with a warning logged.
 - :class:`ScenarioInfo`: only the :attr:`~ScenarioInfo.set` entries are hashed.
 
 """
+
 import json
 import logging
 from dataclasses import asdict, is_dataclass
-from typing import Callable
+from typing import TYPE_CHECKING, Callable, Set
 
 import genno.caching
 import ixmp
 import sdmx.model
 import xarray as xr
+from platformdirs import user_cache_path
 
-from .context import Context
 from .scenarioinfo import ScenarioInfo
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +35,7 @@ log = logging.getLogger(__name__)
 SKIP_CACHE = False
 
 # Paths already logged, to decrease verbosity
-PATHS_SEEN = set()
+PATHS_SEEN: Set["Path"] = set()
 
 
 # Show genno how to hash function arguments seen in message_ix_models
@@ -73,8 +77,7 @@ def cached(func: Callable) -> Callable:
     :doc:`genno:cache` in the :mod:`genno` documentation
     """
     # Determine and create the cache path
-    cache_path = Context.get_instance(-1).get_cache_path()
-    cache_path.mkdir(exist_ok=True, parents=True)
+    cache_path = user_cache_path("message-ix-models", ensure_exists=True)
 
     if cache_path not in PATHS_SEEN:
         log.debug(f"{func.__name__}() will cache in {cache_path}")

--- a/message_ix_models/util/cache.py
+++ b/message_ix_models/util/cache.py
@@ -8,7 +8,6 @@ included in the computed cache key:
   string representation / ID.
 - :class:`ixmp.Platform`, :class:`xarray.Dataset`: ignored, with a warning logged.
 - :class:`ScenarioInfo`: only the :attr:`~ScenarioInfo.set` entries are hashed.
-
 """
 
 import json
@@ -20,8 +19,8 @@ import genno.caching
 import ixmp
 import sdmx.model
 import xarray as xr
-from platformdirs import user_cache_path
 
+from .context import Context
 from .scenarioinfo import ScenarioInfo
 
 if TYPE_CHECKING:
@@ -77,11 +76,12 @@ def cached(func: Callable) -> Callable:
     :doc:`genno:cache` in the :mod:`genno` documentation
     """
     # Determine and create the cache path
-    cache_path = user_cache_path("message-ix-models", ensure_exists=True)
+    cache_path = Context.get_instance(-1).core.cache_path
 
     if cache_path not in PATHS_SEEN:
         log.debug(f"{func.__name__}() will cache in {cache_path}")
         PATHS_SEEN.add(cache_path)
+        cache_path.mkdir(parents=True, exist_ok=True)
 
     # Use the genno internals to wrap the function.
     cached_load = genno.caching.decorate(

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -2,6 +2,7 @@
 
 These are used for building CLIs using :mod:`click`.
 """
+
 import logging
 from datetime import datetime
 from pathlib import Path

--- a/message_ix_models/util/common.py
+++ b/message_ix_models/util/common.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 try:
     import message_data
 except ImportError:
-    log.warning("message_data is not installed or cannot be imported")
     MESSAGE_DATA_PATH: Optional[Path] = None
     HAS_MESSAGE_DATA = False
 else:  # pragma: no cover  (needs message_data)

--- a/message_ix_models/util/common.py
+++ b/message_ix_models/util/common.py
@@ -258,11 +258,15 @@ def package_data_path(*parts) -> Path:
     return _make_path(MESSAGE_MODELS_PATH / "data", *parts)
 
 
-def private_data_path(*parts) -> Path:  # pragma: no cover (needs message_data)
+def private_data_path(*parts) -> Path:
     """Construct a path to a file under :file:`data/` in :mod:`message_data`.
 
-    Use this function to access non-public (e.g. embargoed or proprietary) data stored
-    in the :mod:`message_data` repository.
+    Use this function to access non-public (for instance, embargoed or proprietary) data
+    stored in the :mod:`message_data` repository.
+
+    If the repository is not available, the function falls back to
+    :meth:`.Context.get_local_path`, where users may put files obtained through other
+    messages.
 
     Parameters
     ----------
@@ -273,4 +277,11 @@ def private_data_path(*parts) -> Path:  # pragma: no cover (needs message_data)
     --------
     :ref:`Choose locations for data <private-data>`
     """
-    return _make_path(cast(Path, MESSAGE_DATA_PATH) / "data", *parts)
+    if HAS_MESSAGE_DATA:
+        return _make_path(cast(Path, MESSAGE_DATA_PATH) / "data", *parts)
+    else:
+        from .context import Context
+
+        base = Context.get_instance(-1).get_local_path()
+        log.warning(f"message_data not installed; fall back to {base}")
+        return base.joinpath(*parts)

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -165,7 +165,8 @@ class Config:
     dest: Optional[str] = None
 
     #: Base path for cached data, e.g. as given by the :program:`--cache-path` CLI
-    #: option. Default: :file:`{local_data}/cache/`.
+    #: option. Default: the directory :file:`message-ix-models` within the directory
+    #: given by :func:`.platformdirs.user_cache_path`.
     cache_path: Optional[str] = None
 
     #: Paths of files containing debug outputs. See :meth:`Context.write_debug_archive`.
@@ -179,3 +180,9 @@ class Config:
     #: Flag for causing verbose output to logs or stdout. Different modules will respect
     #: :attr:`verbose` in distinct ways.
     verbose: bool = False
+
+    def __post_init__(self):
+        if self.cache_path is None:
+            from platformdirs import user_cache_path
+
+            self.cache_path = user_cache_path("message-ix-models", ensure_exists=True)

--- a/message_ix_models/util/config.py
+++ b/message_ix_models/util/config.py
@@ -10,6 +10,7 @@ from .scenarioinfo import ScenarioInfo
 
 log = logging.getLogger(__name__)
 
+ixmp.config.register("no message_data", bool, False)
 ixmp.config.register("message local data", Path, Path.cwd())
 
 

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -1,4 +1,5 @@
 """Context and settings for :mod:`message_ix_models` code."""
+
 import logging
 from copy import deepcopy
 from dataclasses import fields
@@ -10,6 +11,7 @@ import message_ix
 from click import BadOptionUsage
 
 from .config import Config
+from .ixmp import parse_url
 
 log = logging.getLogger(__name__)
 
@@ -371,7 +373,7 @@ class Context(dict):
                 )
 
             self.core.url = url
-            urlinfo = ixmp.utils.parse_url(url)
+            urlinfo = parse_url(url)
             platform_info.update(urlinfo[0])
             scenario_info.update(urlinfo[1])
         elif platform:

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -139,6 +139,12 @@ class Context(dict):
 
         return result
 
+    def __eq__(self, other) -> bool:
+        # Don't compare contents, only identity, for _CONTEXTS.index()
+        if not isinstance(other, Context):
+            return NotImplemented
+        return id(self) == id(other)
+
     def __repr__(self):
         return f"<{self.__class__.__name__} object at {id(self)} with {len(self)} keys>"
 

--- a/message_ix_models/util/context.py
+++ b/message_ix_models/util/context.py
@@ -271,14 +271,8 @@ class Context(dict):
         The directory containing the resulting path is created if it does not already
         exist.
         """
-        # Construct relative to local_data if cache_path is not defined
-        base = self.core.cache_path or self.core.local_data.joinpath("cache")
-
-        result = base.joinpath(*parts)
-
-        # Ensure the directory exists
-        result.parent.mkdir(parents=True, exist_ok=True)
-
+        result = self.core.cache_path.joinpath(*parts)
+        result.parent.mkdir(parents=True, exist_ok=True)  # Ensure the directory exists
         return result
 
     def get_local_path(self, *parts: str, suffix=None) -> Path:

--- a/message_ix_models/util/ixmp.py
+++ b/message_ix_models/util/ixmp.py
@@ -2,7 +2,13 @@ from typing import Dict
 
 try:
     # ixmp 3.8.0 and later
-    from ixmp.util import discard_on_error, maybe_check_out, maybe_commit, parse_url
+    from ixmp.util import (
+        discard_on_error,
+        maybe_check_out,
+        maybe_commit,
+        parse_url,
+        show_versions,
+    )
 except ImportError:
     # ixmp <= 3.7.0
     from contextlib import nullcontext
@@ -11,6 +17,7 @@ except ImportError:
         maybe_check_out,
         maybe_commit,
         parse_url,
+        show_versions,
     )
 
     def discard_on_error(*args):

--- a/message_ix_models/util/node.py
+++ b/message_ix_models/util/node.py
@@ -127,8 +127,6 @@ def identify_nodes(scenario: Scenario) -> str:
 def nodes_ex_world(nodes: Sequence[Union[str, Code]]) -> List[Union[str, Code]]:
     """Exclude "World" and anything containing "GLB" from `nodes`.
 
-    May also be used as a reporting computation.
-
-    .. todo:: Make available from :mod:`message_ix_models.report`.
+    May also be used as a genno (reporting) operator.
     """
     return list(filter(lambda n_: "GLB" not in n_ and n_ != "World", nodes))

--- a/message_ix_models/util/node.py
+++ b/message_ix_models/util/node.py
@@ -1,4 +1,5 @@
 """Utilities for nodes."""
+
 import logging
 from typing import List, Sequence, Union
 

--- a/message_ix_models/util/pooch.py
+++ b/message_ix_models/util/pooch.py
@@ -1,4 +1,5 @@
 """Utilities for using :doc:`Pooch <pooch:about>`."""
+
 import logging
 from pathlib import Path
 from typing import Tuple

--- a/message_ix_models/util/scenarioinfo.py
+++ b/message_ix_models/util/scenarioinfo.py
@@ -1,4 +1,5 @@
 """:class:`ScenarioInfo` class."""
+
 import logging
 import re
 from collections import defaultdict
@@ -11,7 +12,6 @@ import pint
 import sdmx.model.v21 as sdmx_model
 
 from .ixmp import parse_url
-from .sdmx import eval_anno
 
 if TYPE_CHECKING:
     from message_ix import Scenario
@@ -235,13 +235,16 @@ class ScenarioInfo:
         --------
         io_units
         """
+
         try:
             idx = self.set[set_name].index(id)
         except ValueError:
             print(self.set[set_name])
             raise
 
-        return eval_anno(self.set[set_name][idx], "units")
+        return self.set[set_name][idx].eval_annotation(
+            id="units", globals=dict(registry=pint.get_application_registry())
+        )
 
     def io_units(
         self, technology: str, commodity: str, level: Optional[str] = None
@@ -309,8 +312,6 @@ class ScenarioInfo:
         [2090, 2100, 2110]
 
         """
-        from message_ix_models.util import eval_anno
-
         # Clear existing values
         if len(self.set["year"]):
             log.debug(f"Discard existing 'year' elements: {repr(self.set['year'])}")
@@ -333,7 +334,7 @@ class ScenarioInfo:
             self.set["year"].append(year)
 
             # Check for an annotation 'firstmodelyear: true'
-            if eval_anno(code, "firstmodelyear"):
+            if code.eval_annotation(id="firstmodelyear"):
                 if fmy_set:
                     # No coverage: data that triggers this should not be committed
                     raise ValueError(  # pragma: no cover
@@ -349,7 +350,7 @@ class ScenarioInfo:
             duration_period.append(
                 dict(
                     year=year,
-                    value=eval_anno(code, "duration_period")
+                    value=code.eval_annotation(id="duration_period")
                     or (year - duration_period[-1]["year"]),
                     unit="y",
                 )

--- a/message_ix_models/util/sdmx.py
+++ b/message_ix_models/util/sdmx.py
@@ -1,10 +1,12 @@
 """Utilities for handling objects from :mod:`sdmx`."""
+
 import logging
 from datetime import datetime
 from enum import Enum, Flag
 from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
+from warnings import warn
 
 import sdmx
 import sdmx.message
@@ -99,6 +101,13 @@ def eval_anno(obj: AnnotableArtefact, id: str):
        Use :meth:`sdmx.model.common.AnnotableArtefact.eval_annotation`, which provides
        the same functionality.
     """
+    warn(
+        "message_ix_models.util.eval_anno; use sdmx.model.common.AnnotableArtefact"
+        ".eval_annotation() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     try:
         value = str(obj.get_annotation(id=id).text)
     except KeyError:  # No such attribute

--- a/message_ix_models/util/sdmx.py
+++ b/message_ix_models/util/sdmx.py
@@ -25,7 +25,10 @@ log = logging.getLogger(__name__)
 CodeLike = Union[str, Code]
 
 
-def as_codes(data: Union[List[str], Dict[str, CodeLike]]) -> List[Code]:
+# FIXME Reduce complexity from 13 → ≤11
+def as_codes(  # noqa: C901
+    data: Union[List[str], Dict[str, CodeLike]],
+) -> List[Code]:
     """Convert `data` to a :class:`list` of |Code| objects.
 
     Various inputs are accepted:

--- a/message_ix_models/workflow.py
+++ b/message_ix_models/workflow.py
@@ -1,4 +1,5 @@
 """Tools for modeling workflows."""
+
 import logging
 import re
 from typing import (
@@ -320,6 +321,8 @@ def make_click_command(wf_callback: str, name: str, slug: str, **kwargs) -> "Com
     def _func(context, go, truncate_step, target_step, **kwargs):
         from importlib import import_module
 
+        from message_ix_models.util import show_versions
+
         # Import the module and retrieve the callback function
         module_name, callback_name = wf_callback.rsplit(".", maxsplit=1)
         module = import_module(module_name)
@@ -361,7 +364,8 @@ def make_click_command(wf_callback: str, name: str, slug: str, **kwargs) -> "Com
                 )
             target_step = wf.default_key
 
-        log.info(f"Execute workflow:\n{wf.describe(target_step)}")
+        log.info(f"Execute workflow\n{wf.describe(target_step)}")
+        log.debug(f"…with package versions:\n{show_versions()}")
 
         if not go:
             path = context.get_local_path(f"{slug}-workflow.svg")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,12 @@ no_implicit_optional = false
 addopts = "-p no:faulthandler --cov=message_ix_models --cov-report="
 filterwarnings = "ignore:distutils Version classes.*:DeprecationWarning"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]
-
-[tool.ruff.mccabe]
-max-complexity = 13
+# Exceptions:
+# - .tools.wb.assign_income_groups(): 12 > 11
+# - .util.sdmx.as_codes(): 13 > 11
+mccabe.max-complexity = 11
 
 [tool.setuptools.packages]
 find = {}


### PR DESCRIPTION
- Update the SSPUpdate class to pull data from the SSP 2024 "release 3.0" data files, and to handle both the earlier and current structures.
  - Improve ExoDataSource with raise_on_extra_kw() utility method, automatic copy of source keyword arguments.
- Expose `.util.nodes_ex_world()` for use as a reporting (genno) operator.
- Raise DeprecationWarning from `.util.sdmx.eval_anno()`; remove internal usage of this deprecated method.
- Close #37.
- Improve logging.
  - Use multi-threaded logging for better performance; logging to stdout and file is on a separate thread.
  - Add automatic file logging. Log versions of packages to file when using .workflow.make_click_command().
  - Add `mix-models last-log` CLI command to retrieve the location of the latest log file.
- Improve performance in .disutility.data_conversion().
- Use platformdirs.user_cache_path() in more places; remove cache-path handling code.
- Add .util.datetime_now_with_tz().
- Add .util.show_versions().
- .util.private_data_path() now returns an alternate, local data path if message_data is not installed.

Housekeeping/CI:
- Bump versions of GitHub Actions.
- Add dependabot config for GitHub Actions.
- Bump ruff, mypy versions; update ruff config locations.
- Apply ruff v0.3.2 to all code.
- Reduce max-complexity 13 → 11.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.