### PR TITLE
Mark incompatible dask-python-combination-tests as XFail

### DIFF
--- a/message_ix_models/tests/tools/iea/test_web.py
+++ b/message_ix_models/tests/tools/iea/test_web.py
@@ -17,6 +17,11 @@ dask_python_incompatibility_condition = parse(version("message_ix")) < parse("3.
 
 
 class TestIEA_EWEB:
+    @pytest.mark.xfail(
+        condition=dask_python_incompatibility_condition,
+        reason="Pinned dask version and certain Python versions are incompatible",
+        raises=TypeError,
+    )
     @pytest.mark.parametrize("source", ("IEA_EWEB",))
     @pytest.mark.parametrize(
         "source_kw",
@@ -47,6 +52,8 @@ class TestIEA_EWEB:
         ),
     )
     def test_prepare_computer(self, test_context, source, source_kw):
+        import message_ix_models.tools.iea.web  # noqa: F401
+
         # FIXME The following should be redundant, but appears mutable on GHA linux and
         #       Windows runners.
         test_context.model.regions = "R14"

--- a/message_ix_models/tests/tools/iea/test_web.py
+++ b/message_ix_models/tests/tools/iea/test_web.py
@@ -1,13 +1,19 @@
 """Tests of :mod:`.tools`."""
 
+from importlib.metadata import version
+
 import pandas as pd
 import pytest
 from genno import Computer
+from packaging.version import parse
 
 from message_ix_models.testing import GHA
 from message_ix_models.tools.exo_data import prepare_computer
-from message_ix_models.tools.iea.web import DIMS, generate_code_lists, load_data
 from message_ix_models.util import HAS_MESSAGE_DATA
+
+# Dask < 2024.4.1 is incompatible with Python >= 3.11.9, but we pin dask in this range
+# for tests of message_ix < 3.7.0. XFail these tests:
+dask_python_incompatibility_condition = parse(version("message_ix")) < parse("3.7.0")
 
 
 class TestIEA_EWEB:
@@ -79,8 +85,14 @@ PROVIDER_EDITION = (
 )
 
 
+@pytest.mark.xfail(
+    condition=dask_python_incompatibility_condition,
+    reason="Pinned dask version and certain Python versions are incompatible",
+    raises=TypeError,
+)
 @pytest.mark.parametrize("provider, edition", PROVIDER_EDITION)
 def test_load_data(test_context, tmp_path, provider, edition):
+    from message_ix_models.tools.iea.web import DIMS, load_data
     # # Store in the temporary directory for this test
     # test_context.cache_path = tmp_path.joinpath("cache")
 
@@ -96,8 +108,15 @@ def test_load_data(test_context, tmp_path, provider, edition):
     assert (set(DIMS) & {"Value"}) < set(result.columns)
 
 
+@pytest.mark.xfail(
+    condition=dask_python_incompatibility_condition,
+    reason="Pinned dask version and certain Python versions are incompatible",
+    raises=TypeError,
+)
 @pytest.mark.parametrize("provider, edition", PROVIDER_EDITION)
 def test_generate_code_lists(tmp_path, provider, edition):
+    from message_ix_models.tools.iea.web import generate_code_lists
+
     # generate_code_lists() runs
     generate_code_lists(provider, edition, tmp_path)
 

--- a/message_ix_models/tests/tools/iea/test_web.py
+++ b/message_ix_models/tests/tools/iea/test_web.py
@@ -17,10 +17,9 @@ dask_python_incompatibility_condition = parse(version("message_ix")) < parse("3.
 
 
 class TestIEA_EWEB:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=dask_python_incompatibility_condition,
         reason="Pinned dask version and certain Python versions are incompatible",
-        raises=TypeError,
     )
     @pytest.mark.parametrize("source", ("IEA_EWEB",))
     @pytest.mark.parametrize(
@@ -92,7 +91,7 @@ PROVIDER_EDITION = (
 )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     condition=dask_python_incompatibility_condition,
     reason="Pinned dask version and certain Python versions are incompatible",
     raises=TypeError,
@@ -115,7 +114,7 @@ def test_load_data(test_context, tmp_path, provider, edition):
     assert (set(DIMS) & {"Value"}) < set(result.columns)
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     condition=dask_python_incompatibility_condition,
     reason="Pinned dask version and certain Python versions are incompatible",
     raises=TypeError,


### PR DESCRIPTION
We can currently observe [an incompatibility of dask with python 3.11.9](https://github.com/dask/dask/issues/11038) e.g. in the message-ix-models CI. This is fixed in version 2024.4.1 of dask, but our CI runs `pip install .[docs,tests] "dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"` for message-ix-models with message_ix 3.6.0 and below.
We expect that removing the pin for the dask version entails solving a dependency mess since we would need to adhere to requiring dask-expr. So for now, we opt to XFail the test depending on dask instead.

## How to review

@khaeru, should I mention this PR in a comment in-line? I'm not sure what else to reference there.

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Update tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just test suite changes.
- ~[ ] Update doc/whatsnew.~ Just test suite changes.

