### PR TITLE
Remove workaround for #173

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -103,10 +103,6 @@ jobs:
       # for open PRs), temporarily uncomment, add, or edit lines below
       # as needed. DO NOT merge such changes to `main`.
       run: |
-        # Temporary, to work around iiasa/message-ix-models#173
-        # TODO Remove after a pyam release that fixes logging
-        pip install --upgrade "pyam-iamc @ git+https://github.com/IAMconsortium/pyam.git@main"
-
         # pip install --upgrade "genno @ git+https://github.com/khaeru/genno.git@main"
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@${{ matrix.upstream.version }}"
         pip install --upgrade "message-ix @ git+https://github.com/iiasa/message_ix.git@${{ matrix.upstream.version }}"


### PR DESCRIPTION
Closes #173 by removing the workaround. Pyam released v2.2.2 recently, which should include the fix we were waiting for.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Only internal clean up.
- ~[ ] Add, expand, or update documentation.~ Only internal clean up.
- ~[ ] Update doc/whatsnew.~ Only internal clean up.
