### PR TITLE
Adjust packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ select = ["C9", "E", "F", "I", "W"]
 # - .util.sdmx.as_codes(): 13 > 11
 mccabe.max-complexity = 11
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = ["message_ix_models*"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
I checked the results of `python -m build` after merging #159 and found that both the .tar.gz and .whl outputs were about 10 MB. This was because the entire /doc/ directory—including many images added by that other PR—was included in both files.

This PR adjusts our setuptools config so that the /doc/ directory is:
- included in the .tar.gz source distribution,
- excluded from the .whl distribution.

This follows the practice of [`coverage`](https://pypi.org/project/coverage/#files) and several other packages I looked at. It also ensures that users who install from .whl (with pip) don't wind up with an extra directory named `site-packages/doc/` that contains the message-ix-models docs. (AFAIK, distributing these 'dangling' directories outside the ones strictly related to the package is bad practice.)

With these changes, the .whl file is also nice and slim at under 600 kB.

## How to review

Note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, packaging changes only
- ~Update doc/whatsnew.~