### PR TITLE
Use 2023 WEO data in `tools.costs`

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,12 +4,13 @@ What's new
 Next release
 ============
 
-Changes to :doc:`/api/tools-costs` (:pull:`186`)
-------------------------------------------------
+Changes to :doc:`/api/tools-costs` (:pull:`186`, :pull:`187`)
+-------------------------------------------------------------
   - Fix jumps in cost projections for technologies with first technology year that's after than the first model year.
   - Change the use of base_year to mean the year to start modeling cost changes.
   - Update cost assumptions for certain CCS technologies.
   - Change the default fixed O&M reduction rate to 0.
+  - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year.
 
 v2024.4.22
 ==========

--- a/message_ix_models/data/iea/WEO_2023_PG_Assumptions_STEPSandNZE_Scenario.xlsx
+++ b/message_ix_models/data/iea/WEO_2023_PG_Assumptions_STEPSandNZE_Scenario.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94bc78917d1521fa12c04203c99b004f326f4758cdfe3f2a84338512387f1a92
+size 66039

--- a/message_ix_models/tests/tools/costs/test_regional_differentiation.py
+++ b/message_ix_models/tests/tools/costs/test_regional_differentiation.py
@@ -15,7 +15,7 @@ def test_get_weo_data() -> None:
     result = get_weo_data()
 
     # Check that the minimum and maximum years are correct
-    assert min(result.year) == "2021"
+    assert min(result.year) == "2022"
     assert max(result.year) == "2050"
 
     # Check that the regions are correct
@@ -37,11 +37,11 @@ def test_get_weo_data() -> None:
 
     # Check one sample value
     assert np.isclose(
-        1324.68,
+        1238.018,
         result.query(
             "weo_technology == 'steam_coal_subcritical'"
             "and weo_region == 'United States'"
-            "and year == '2021'"
+            "and year == '2022'"
             "and cost_type == 'inv_cost'"
         )["value"].item(),
     )

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -468,7 +468,7 @@ def create_message_outputs(
         )
         .astype(dtypes)
         .query("year_vtg in @config.Y")
-        .astype({"first_technology_year": float})
+        .astype({"first_technology_year": float})  # has to be float; int gives error
         .query("year_vtg >= first_technology_year")
         .reset_index(drop=True)
         .drop_duplicates()
@@ -531,7 +531,7 @@ def create_message_outputs(
         )
         .astype(dtypes)
         .query("year_act in @config.Y and year_vtg in @config.Y")
-        .astype({"first_technology_year": float})
+        .astype({"first_technology_year": float})  # has to be float; int gives error
         .query("year_vtg >= first_technology_year")
         .reset_index(drop=True)
         .drop_duplicates()

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -468,21 +468,11 @@ def create_message_outputs(
         )
         .astype(dtypes)
         .query("year_vtg in @config.Y")
-        .assign(first_technology_year=lambda x: x.first_technology_year.astype(float))
-        .assign(first_technology_year=lambda x: x.first_technology_year.astype(int))
+        .astype({"first_technology_year": float})
         .query("year_vtg >= first_technology_year")
         .reset_index(drop=True)
-        .drop_duplicates()[
-            [
-                "scenario_version",
-                "scenario",
-                "node_loc",
-                "technology",
-                "year_vtg",
-                "value",
-                "unit",
-            ]
-        ]
+        .drop_duplicates()
+        .drop("first_technology_year", axis=1)
     )
 
     dtypes.update(year_act=int)
@@ -491,7 +481,8 @@ def create_message_outputs(
         .drop(columns=["inv_cost"])
         .assign(key=1)
         .merge(
-            pd.DataFrame(data={"year_act": config.seq_years}).assign(key=1), on="key"
+            pd.DataFrame(data={"year_act": config.seq_years}).assign(key=1),
+            on="key",
         )
         .drop(columns=["key"])
         .query("year_act >= year_vtg")
@@ -540,22 +531,12 @@ def create_message_outputs(
         )
         .astype(dtypes)
         .query("year_act in @config.Y and year_vtg in @config.Y")
-        .assign(first_technology_year=lambda x: x.first_technology_year.astype(float))
-        .assign(first_technology_year=lambda x: x.first_technology_year.astype(int))
+        .astype({"first_technology_year": float})
         .query("year_vtg >= first_technology_year")
         .reset_index(drop=True)
-    ).drop_duplicates()[
-        [
-            "scenario_version",
-            "scenario",
-            "node_loc",
-            "technology",
-            "year_vtg",
-            "year_act",
-            "value",
-            "unit",
-        ]
-    ]
+        .drop_duplicates()
+        .drop("first_technology_year", axis=1)
+    )
 
     return inv, fom
 

--- a/message_ix_models/tools/costs/regional_differentiation.py
+++ b/message_ix_models/tools/costs/regional_differentiation.py
@@ -49,31 +49,31 @@ def get_weo_data() -> pd.DataFrame:
     # their respective sheet in the Excel file,
     # and the start row
     DICT_TECH_ROWS = {
-        "bioenergy_ccus": ["Renewables", 95],
-        "bioenergy_cofiring": ["Renewables", 75],
-        "bioenergy_large": ["Renewables", 65],
-        "bioenergy_medium_chp": ["Renewables", 85],
-        "ccgt": ["Gas", 5],
-        "ccgt_ccs": ["Fossil fuels equipped with CCUS", 25],
-        "ccgt_chp": ["Gas", 25],
-        "csp": ["Renewables", 105],
-        "fuel_cell": ["Gas", 35],
-        "gas_turbine": ["Gas", 15],
-        "geothermal": ["Renewables", 115],
-        "hydropower_large": ["Renewables", 45],
-        "hydropower_small": ["Renewables", 55],
-        "igcc": ["Coal", 35],
-        "igcc_ccs": ["Fossil fuels equipped with CCUS", 15],
-        "marine": ["Renewables", 125],
-        "nuclear": ["Nuclear", 5],
-        "pulverized_coal_ccs": ["Fossil fuels equipped with CCUS", 5],
-        "solarpv_buildings": ["Renewables", 15],
-        "solarpv_large": ["Renewables", 5],
-        "steam_coal_subcritical": ["Coal", 5],
-        "steam_coal_supercritical": ["Coal", 15],
-        "steam_coal_ultrasupercritical": ["Coal", 25],
-        "wind_offshore": ["Renewables", 35],
-        "wind_onshore": ["Renewables", 25],
+        "bioenergy_ccus": ["Renewables", 99],
+        "bioenergy_cofiring": ["Renewables", 79],
+        "bioenergy_large": ["Renewables", 69],
+        "bioenergy_medium_chp": ["Renewables", 89],
+        "ccgt": ["Gas", 9],
+        "ccgt_ccs": ["Fossil fuels equipped with CCUS", 29],
+        "ccgt_chp": ["Gas", 29],
+        "csp": ["Renewables", 109],
+        "fuel_cell": ["Gas", 39],
+        "gas_turbine": ["Gas", 19],
+        "geothermal": ["Renewables", 119],
+        "hydropower_large": ["Renewables", 49],
+        "hydropower_small": ["Renewables", 59],
+        "igcc": ["Coal", 39],
+        "igcc_ccs": ["Fossil fuels equipped with CCUS", 19],
+        "marine": ["Renewables", 129],
+        "nuclear": ["Nuclear", 9],
+        "pulverized_coal_ccs": ["Fossil fuels equipped with CCUS", 9],
+        "solarpv_buildings": ["Renewables", 19],
+        "solarpv_large": ["Renewables", 9],
+        "steam_coal_subcritical": ["Coal", 9],
+        "steam_coal_supercritical": ["Coal", 19],
+        "steam_coal_ultrasupercritical": ["Coal", 29],
+        "wind_offshore": ["Renewables", 39],
+        "wind_onshore": ["Renewables", 29],
     }
 
     # Dict of cost types to read in and the required columns
@@ -81,17 +81,17 @@ def get_weo_data() -> pd.DataFrame:
 
     # Set file path for raw IEA WEO cost data
     file_path = package_data_path(
-        "iea", "WEO_2022_PG_Assumptions_STEPSandNZE_Scenario.xlsb"
+        "iea", "WEO_2023_PG_Assumptions_STEPSandNZE_Scenario.xlsx"
     )
 
     # Retrieve conversion factor
-    conversion_factor = registry("1.0 USD_2021").to("USD_2005").magnitude  # noqa: F841
+    conversion_factor = registry("1.0 USD_2022").to("USD_2005").magnitude  # noqa: F841
 
     # Loop through Excel sheets to read in data and process:
     # - Convert to long format
     # - Only keep investment costs
     # - Replace "n.a." with NaN
-    # - Convert units from 2021 USD to 2005 USD
+    # - Convert units from 2022 USD to 2005 USD
     dfs_cost = []
     for tech_key, cost_key in product(DICT_TECH_ROWS, DICT_COST_COLS):
         df = (
@@ -103,7 +103,7 @@ def get_weo_data() -> pd.DataFrame:
                 nrows=9,
                 usecols=DICT_COST_COLS[cost_key],
             )
-            .set_axis(["weo_region", "2021", "2030", "2050"], axis=1)
+            .set_axis(["weo_region", "2022", "2030", "2050"], axis=1)
             .melt(id_vars=["weo_region"], var_name="year", value_name="value")
             .assign(
                 weo_technology=tech_key,
@@ -419,8 +419,8 @@ def get_weo_regional_differentiation(config: "Config") -> pd.DataFrame:
     # Grab WEO data and keep only investment costs
     df_weo = get_weo_data()
 
-    # Even if config.base_year is greater than 2021, use 2021 WEO data
-    sel_year = str(2021)
+    # Even if config.base_year is greater than 2022, use 2022 WEO values
+    sel_year = str(2022)
     log.info("…using year " + str(sel_year) + " data from WEO")
 
     # - Retrieve a map from MESSAGEix node IDs to WEO region names.

--- a/message_ix_models/tools/costs/regional_differentiation.py
+++ b/message_ix_models/tools/costs/regional_differentiation.py
@@ -85,7 +85,7 @@ def get_weo_data() -> pd.DataFrame:
     )
 
     # Retrieve conversion factor
-    conversion_factor = registry("1.0 USD_2022").to("USD_2005").magnitude  # noqa: F841
+    conversion_factor = registry("1.0 USD_2022").to("USD_2005").magnitude
 
     # Loop through Excel sheets to read in data and process:
     # - Convert to long format
@@ -122,7 +122,7 @@ def get_weo_data() -> pd.DataFrame:
                 axis=1,
             )
             .replace({"value": "n.a."}, np.nan)
-            .eval("value = value * @conversion_factor")
+            .assign(value=lambda x: x.value * conversion_factor)
         )
 
         dfs_cost.append(df)


### PR DESCRIPTION
Update costs module to move from using the 2022 WEO release to using the 2023 WEO data release

Main changes made:
- Upload 2023 data file
- Modify code to read in 2023 data release
- Use 2022 USD to 2001 USD conversion (instead of 2021 USD to 2001 USD)
- Use the new latest historical values (2022) for the regional differentation

Additionally, I've changed a few lines in the code to address the comments that were left on #186 which were not properly fixed in that PR.

## How to review

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Update doc/whatsnew.
