### PR TITLE
Change the default final year in `tools.costs` to 2110

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,13 +4,14 @@ What's new
 Next release
 ============
 
-Changes to :doc:`/api/tools-costs` (:pull:`186`, :pull:`187`)
+Changes to :doc:`/api/tools-costs` (:pull:`186`, :pull:`187`, :pull:`190`)
 -------------------------------------------------------------
   - Fix jumps in cost projections for technologies with first technology year that's after than the first model year.
   - Change the use of base_year to mean the year to start modeling cost changes.
   - Update cost assumptions for certain CCS technologies.
   - Change the default fixed O&M reduction rate to 0.
   - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year.
+  - Change the default final year to 2110.
 
 v2024.4.22
 ==========

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,14 +4,14 @@ What's new
 Next release
 ============
 
-Changes to :doc:`/api/tools-costs` (:pull:`186`, :pull:`187`, :pull:`190`)
--------------------------------------------------------------
-  - Fix jumps in cost projections for technologies with first technology year that's after than the first model year.
-  - Change the use of base_year to mean the year to start modeling cost changes.
-  - Update cost assumptions for certain CCS technologies.
-  - Change the default fixed O&M reduction rate to 0.
-  - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year.
-  - Change the default final year to 2110.
+Changes to :doc:`/api/tools-costs`
+----------------------------------
+  - Fix jumps in cost projections for technologies with first technology year that's after than the first model year (:pull:`186`).
+  - Change the use of base_year to mean the year to start modeling cost changes (:pull:`186`).
+  - Update cost assumptions for certain CCS technologies (:pull:`186`).
+  - Change the default fixed O&M reduction rate to 0 (:pull:`186`).
+  - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year (:pull:`187`).
+  - Change the default final year to 2110 (:pull:`190`).
 
 v2024.4.22
 ==========

--- a/message_ix_models/tools/costs/config.py
+++ b/message_ix_models/tools/costs/config.py
@@ -25,9 +25,9 @@ class Config:
     #: See :func:`.create_projections_converge`.
     convergence_year: int = 2050
 
-    #: Final year for projections. Note that the default is different from the final
+    #: Final year for projections. Note that the default is the same as the final
     #: model year of 2110 commonly used in MESSAGEix-GLOBIOM (:doc:`/pkg-data/year`).
-    final_year: int = 2100
+    final_year: int = 2110
 
     #: Rate of exponential growth (positive values) or decrease of fixed operating and
     #: maintenance costs over time. The default of 0 implies no change over time.

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -421,7 +421,8 @@ def create_message_outputs(
             fix_cost=lambda x: np.where(x.year <= y_base, x.fix_cost_2020, x.fix_cost),
         )
         .assign(
-            # FIXME Clarify the purpose of these hard-coded periods
+            # NOTE: This portion carries over the 2100 values to years beyond 2100.
+            # This is applicable in the case where Config.final_year > 2100.
             inv_cost=lambda x: np.where(x.year >= 2100, x.inv_cost_2100, x.inv_cost),
             fix_cost=lambda x: np.where(x.year >= 2100, x.fix_cost_2100, x.fix_cost),
         )


### PR DESCRIPTION
Update costs module to include 2110 in output by default

Currently the default `final_year` in `tools.costs` is 2100, which does not pair well with MESSAGEix's final year usally being 2110. Currently, users can change the `final_year` themselves as a parameter when creating their `Config` file, but given the use-base of this tool is mostly our internal team, I'm changing the default `final_year` to 2110.

Note that this does not mean costs are projected to 2110 now -- costs are still only projected to 2100. The module copies over 2100 projected costs for all years after 2100.

~~Also note that this PR is currently pointing to #187 -- I was thinking it would be best to wait for that PR to be merged first, then point this PR to main. But happy to revise as necessary.~~

Branch now has been rebased and points to main.

## How to review

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Update doc/whatsnew.