### PR TITLE
Create option in `tools.costs` to keep fixed O&M costs same across vintages

### DIFF
--- a/doc/api/tools-costs.rst
+++ b/doc/api/tools-costs.rst
@@ -118,6 +118,7 @@ Those settings include the following; click each for the full description, allow
    :attr:`~.Config.scenario_version`,
    :attr:`~.Config.base_year`,
    :attr:`~.Config.convergence_year`,
+   :attr:`~.Config.use_vintages`, 
    :attr:`~.Config.fom_rate`, and
    :attr:`~.Config.format`.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -17,7 +17,7 @@ Changes to :doc:`/api/tools-costs`
   - Change the default fixed O&M reduction rate to 0 (:pull:`186`).
   - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year (:pull:`187`).
   - Change the default final year to 2110 (:pull:`190`).
-  - Add option to not or not use vintages for fixed O&M costs (:pull:`195`).
+  - Add option to use or not use vintages for fixed O&M costs (:pull:`195`).
 
 v2024.4.22
 ==========

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -17,7 +17,7 @@ Changes to :doc:`/api/tools-costs`
   - Change the default fixed O&M reduction rate to 0 (:pull:`186`).
   - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year (:pull:`187`).
   - Change the default final year to 2110 (:pull:`190`).
-  - Add option to use or not use vintages for fixed O&M costs (:pull:`195`).
+  - Add :attr:`~.costs.Config.use_vintages` to control whether vintages are used in computing fixed O&M costs (:pull:`195`).  
 
 v2024.4.22
 ==========

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,9 +8,8 @@ Next release
 - Update :doc:`/material/index` (:pull:`201`).
 - Add :doc:`/project/edits` project code and documentation (:pull:`204`).
 - Reduce log verbosity of :func:`.apply_spec` (:pull:`202`).
+- Made fixes and updates to :doc:`/api/tools-costs` (:pull:`186`, :pull:`187`, :pull:`190`, :pull:`195`).
 
-Changes to :doc:`/api/tools-costs`
-----------------------------------
   - Fix jumps in cost projections for technologies with first technology year that's after than the first model year (:pull:`186`).
   - Change the use of base_year to mean the year to start modeling cost changes (:pull:`186`).
   - Update cost assumptions for certain CCS technologies (:pull:`186`).

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -17,6 +17,7 @@ Changes to :doc:`/api/tools-costs`
   - Change the default fixed O&M reduction rate to 0 (:pull:`186`).
   - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year (:pull:`187`).
   - Change the default final year to 2110 (:pull:`190`).
+  - Add option to not or not use vintages for fixed O&M costs (:pull:`195`).
 
 v2024.4.22
 ==========

--- a/message_ix_models/tools/costs/config.py
+++ b/message_ix_models/tools/costs/config.py
@@ -55,10 +55,11 @@ class Config:
     #: Model variant for which to project costs.
     module: Literal["energy", "materials"] = "energy"
 
-    #: Use vintages
-    #: If True, for each vintage, the fixed O&M costs will be calculated as a
+    #: Use vintages.
+    #:
+    #: - If True, for each vintage, the fixed O&M costs will be calculated as a
     #: ratio of the investment costs, that decreases by the rate of :attr:`fom_rate`.
-    #: If False, the fix_cost is the ratio of the investment cost for each year_act.
+    #: - If False, the fix_cost is the ratio of the investment cost for each year_act.
     #: In this case, the fix_cost is the same for all vintages of the same year_act.
     use_vintages: bool = False
 

--- a/message_ix_models/tools/costs/config.py
+++ b/message_ix_models/tools/costs/config.py
@@ -55,6 +55,13 @@ class Config:
     #: Model variant for which to project costs.
     module: Literal["energy", "materials"] = "energy"
 
+    #: Use vintages
+    #: If True, for each vintage, the fixed O&M costs will be calculated as a
+    #: ratio of the investment costs, that decreases by the rate of :attr:`fom_rate`.
+    #: If False, the fix_cost is the ratio of the investment cost for each year_act.
+    #: In this case, the fix_cost is the same for all vintages of the same year_act.
+    use_vintages: bool = False
+
     #: .. todo:: Document the meaning of this setting.
     pre_last_year_rate: float = 0.01
 

--- a/message_ix_models/tools/costs/config.py
+++ b/message_ix_models/tools/costs/config.py
@@ -57,9 +57,9 @@ class Config:
 
     #: Use vintages.
     #:
-    #: - If True, for each vintage, the fixed O&M costs will be calculated as a
+    #: If True, for each vintage, the fixed O&M costs will be calculated as a
     #: ratio of the investment costs, that decreases by the rate of :attr:`fom_rate`.
-    #: - If False, the fix_cost is the ratio of the investment cost for each year_act.
+    #: If False, the fix_cost is the ratio of the investment cost for each year_act.
     #: In this case, the fix_cost is the same for all vintages of the same year_act.
     use_vintages: bool = False
 

--- a/message_ix_models/tools/costs/demo.py
+++ b/message_ix_models/tools/costs/demo.py
@@ -17,6 +17,7 @@ from message_ix_models.tools.costs.projections import create_cost_projections
 # - format="message",
 # - method="gdp",
 # - module="energy",
+# - use_vintages=False,
 # - node="R12",
 # - ref_region —automatically determined from node
 # - scenario="all",

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -393,27 +393,23 @@ def create_message_outputs(
         .rename(columns={"inv_cost": "inv_cost_2100", "fix_cost": "fix_cost_2100"})
     )
 
+    dims = [
+        "scenario_version",
+        "scenario",
+        "message_technology",
+        "first_technology_year",
+        "region",
+    ]
+
     df_merge = (
         (
             df_prod.merge(
                 val_2020,
-                on=[
-                    "scenario_version",
-                    "scenario",
-                    "message_technology",
-                    "first_technology_year",
-                    "region",
-                ],
+                on=dims,
             )
             .merge(
                 val_2100,
-                on=[
-                    "scenario_version",
-                    "scenario",
-                    "message_technology",
-                    "first_technology_year",
-                    "region",
-                ],
+                on=dims,
             )
             .merge(
                 df_projections,

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -397,11 +397,23 @@ def create_message_outputs(
         (
             df_prod.merge(
                 val_2020,
-                on=["scenario_version", "scenario", "message_technology", "region"],
+                on=[
+                    "scenario_version",
+                    "scenario",
+                    "message_technology",
+                    "first_technology_year",
+                    "region",
+                ],
             )
             .merge(
                 val_2100,
-                on=["scenario_version", "scenario", "message_technology", "region"],
+                on=[
+                    "scenario_version",
+                    "scenario",
+                    "message_technology",
+                    "first_technology_year",
+                    "region",
+                ],
             )
             .merge(
                 df_projections,

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -486,114 +486,73 @@ def create_message_outputs(
 
     dtypes.update(year_act=int)
 
-    if config.use_vintages:
-        fom = (
-            df_merge.copy()
-            .drop(columns=["inv_cost"])
-            .assign(key=1)
-            .merge(
-                pd.DataFrame(data={"year_act": config.seq_years}).assign(key=1),
-                on="key",
-            )
-            .drop(columns=["key"])
-            .query("year_act >= year_vtg")
-            .assign(
-                val=lambda x: np.where(
-                    x.year_vtg <= y_base,
-                    np.where(
-                        x.year_act <= y_base,
-                        x.fix_cost,
-                        np.where(
-                            config.fom_rate == 0,
-                            x.fix_cost,
-                            x.fix_cost
-                            * (1 + float(config.fom_rate)) ** (x.year_act - y_base),
-                        ),
-                    ),
+    to_merge = pd.DataFrame(
+        {"year_act" if config.use_vintages else "year_vtg": config.seq_years}
+    ).assign(key=1)
+
+    def _compute_value(df: pd.DataFrame) -> pd.Series:
+        if config.use_vintages:
+            df["val"] = np.where(
+                df.year_vtg <= y_base,
+                np.where(
+                    df.year_act <= y_base,
+                    df.fix_cost,
                     np.where(
                         config.fom_rate == 0,
-                        x.fix_cost,
-                        x.fix_cost
-                        * (1 + float(config.fom_rate)) ** (x.year_act - x.year_vtg),
+                        df.fix_cost,
+                        df.fix_cost
+                        * (1 + float(config.fom_rate)) ** (df.year_act - y_base),
                     ),
-                )
+                ),
+                np.where(
+                    config.fom_rate == 0,
+                    df.fix_cost,
+                    df.fix_cost
+                    * (1 + float(config.fom_rate)) ** (df.year_act - df.year_vtg),
+                ),
             )
-            .assign(unit="USD/kWa")
-            .rename(
-                columns={
-                    "val": "value",
-                    "message_technology": "technology",
-                    "region": "node_loc",
-                }
-            )
-            .reindex(
-                [
-                    "scenario_version",
-                    "scenario",
-                    "node_loc",
-                    "technology",
-                    "first_technology_year",
-                    "year_vtg",
-                    "year_act",
-                    "value",
-                    "unit",
-                ],
-                axis=1,
-            )
-            .astype(dtypes)
-            .query("year_act in @config.Y and year_vtg in @config.Y")
-            .astype(
-                {"first_technology_year": float}
-            )  # has to be float; int gives error
-            .query("year_vtg >= first_technology_year")
-            .reset_index(drop=True)
-            .drop_duplicates()
-            .drop("first_technology_year", axis=1)
+            return df.val
+
+        else:
+            return df.fix_cost
+
+    fom = (
+        df_merge.copy()
+        .drop(columns=["inv_cost"])
+        .rename(columns={"year_vtg": "year_vtg" if config.use_vintages else "year_act"})
+        .assign(key=1)
+        .merge(to_merge, on="key")
+        .drop(columns=["key"])
+        .query("year_act >= year_vtg")
+        .assign(value=_compute_value, unit="USD/kWa")
+        .rename(
+            columns={
+                "message_technology": "technology",
+                "region": "node_loc",
+            }
         )
-    else:
-        fom = (
-            df_merge.drop(columns=["inv_cost"])
-            .rename(columns={"year_vtg": "year_act"})
-            .assign(key=1)
-            .copy()
-            .merge(
-                pd.DataFrame(data={"year_vtg": config.seq_years}).assign(key=1),
-                on="key",
-            )
-            .drop(columns=["key"])
-            .query("year_act >= year_vtg")
-            .assign(unit="USD/kWa")
-            .rename(
-                columns={
-                    "fix_cost": "value",
-                    "message_technology": "technology",
-                    "region": "node_loc",
-                }
-            )
-            .reindex(
-                [
-                    "scenario_version",
-                    "scenario",
-                    "node_loc",
-                    "technology",
-                    "first_technology_year",
-                    "year_vtg",
-                    "year_act",
-                    "value",
-                    "unit",
-                ],
-                axis=1,
-            )
-            .astype(dtypes)
-            .query("year_act in @config.Y and year_vtg in @config.Y")
-            .astype(
-                {"first_technology_year": float}
-            )  # has to be float; int gives error
-            .query("year_vtg >= first_technology_year")
-            .reset_index(drop=True)
-            .drop_duplicates()
-            .drop("first_technology_year", axis=1)
+        .reindex(
+            [
+                "scenario_version",
+                "scenario",
+                "node_loc",
+                "technology",
+                "first_technology_year",
+                "year_vtg",
+                "year_act",
+                "value",
+                "unit",
+            ],
+            axis=1,
         )
+        .astype(dtypes)
+        .query("year_act in @config.Y and year_vtg in @config.Y")
+        .astype({"first_technology_year": float})  # has to be float; int gives error
+        .query("year_vtg >= first_technology_year")
+        .reset_index(drop=True)
+        .drop_duplicates()
+        .drop("first_technology_year", axis=1)
+    )
 
     return inv, fom
 

--- a/message_ix_models/tools/costs/projections.py
+++ b/message_ix_models/tools/costs/projections.py
@@ -490,7 +490,7 @@ def create_message_outputs(
 
     dtypes.update(year_act=int)
 
-    if config.use_vintages is True:
+    if config.use_vintages:
         fom = (
             df_merge.copy()
             .drop(columns=["inv_cost"])


### PR DESCRIPTION
Add option in costs model (`use_vintages`) which affect how fixed O&M costs are projected

Currently, fixed O&M costs (`fix_cost`) are projected in this way: for a certain `year_vtg`, the `fix_cost` is a percentage of investment cost (`inv_cost`). Then from the `year_vtg` to the end of the modeling horizon, the fixed O&M cost changes by a rate specified by `fom_rate` (as of present, the default `fom_rate` is 0, so there is no change).

However, this does not match with the current implementation in MESSAGEix. To match the MESSAGEix implementation, the `fix_cost` in a certain `year_act` should be the same across all `year_vtg`. As such, I've added an option to specify `use_vintage`. If `True` then the first projection method for `fix_cost` is used. If `False` (which is the default setting now), then `fix_cost` is calculated for each `year_act` instead as a percentage of the `inv_cost` in that year. 

Here is a figure showing the difference (Previous refers to `use_vintages=True` and Updated refers to `use_vintages=False`) using solar_pv_ppl as an example.

![solar-fom-vintages](https://github.com/iiasa/message-ix-models/assets/21201137/6384ea21-4971-4542-a237-70f0f6670d0e)



## How to review

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.
