### PR TITLE
Add doc/material/index to doc/index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -79,6 +79,7 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    :caption: Model variants
 
    global/index
+   material/index
    water/index
 
 .. toctree::


### PR DESCRIPTION
This was missed in #189, and as a result one can't see the new module in the "Model variants" section of the left navbar or the ToC on the index page.

## How to review

Look at the RTD docs build for this PR and confirm that .model.material appears in both places: https://iiasa-energy-program-message-ix--196.com.readthedocs.build/projects/models/en/196/

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update doc/whatsnew.~ Silent clean-up of PR that's already mentioned.