### PR TITLE
Adjust CI for numpy 2.0, graphviz, pint

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -109,6 +109,10 @@ jobs:
 
         pip install .[docs,tests] ${{ matrix.upstream.extra-deps }}
 
+        # TEMPORARY Work around hgrecco/pint#2007, unionai-oss/pandera#1685;
+        # see https://github.com/khaeru/genno/issues/140
+        pip install "pint != 0.24.0" "numpy < 2"
+
     - name: Configure local data path
       run: |
         mkdir -p message-local-data/cache

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -91,8 +91,8 @@ jobs:
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v2
-      with:
-        macos-skip-brew-update: true
+      # TEMPORARY Work around ts-graphviz/setup-graphviz#630
+      if: ${{ ! startswith(matrix.os, 'macos-') }}
 
     - name: Install packages and dependencies
       # By default, install:

--- a/message_ix_models/tests/test_workflow.py
+++ b/message_ix_models/tests/test_workflow.py
@@ -1,3 +1,4 @@
+import platform
 import re
 from typing import Optional
 
@@ -6,12 +7,19 @@ import pytest
 from message_ix import make_df
 
 from message_ix_models import Workflow, testing
+from message_ix_models.testing import GHA
 from message_ix_models.workflow import WorkflowStep, make_click_command, solve
 
-MARK = pytest.mark.skipif(
-    condition=ixmp.__version__ < "3.5",
-    reason="ixmp.TimeSeries.url not available prior to ixmp 3.5.0",
-)
+MARK = {
+    0: pytest.mark.skipif(
+        condition=ixmp.__version__ < "3.5",
+        reason="ixmp.TimeSeries.url not available prior to ixmp 3.5.0",
+    ),
+    1: pytest.mark.xfail(
+        condition=GHA and platform.system() == "Darwin",
+        reason="Graphviz not available for GitHub Actions jobs on macOS",
+    ),
+}
 
 
 # Functions for WorkflowSteps
@@ -87,7 +95,8 @@ def _wf(
     return wf
 
 
-@MARK
+@MARK[0]
+@MARK[1]
 def test_make_click_command(mix_models_cli) -> None:
     import click
 
@@ -123,7 +132,7 @@ def test_make_click_command(mix_models_cli) -> None:
             assert output in result.output
 
 
-@MARK
+@MARK[0]
 def test_workflow(caplog, request, test_context, wf) -> None:
     # Retrieve some information from the fixture
     mp = wf.graph.pop("_base_platform")


### PR DESCRIPTION
This PR updates the "pytest" CI workflow to address three causes of failures:

- With NumPy 2.0.0 we run into unionai-oss/pandera#1685, which is a dependency via various reporting code → `pyam-iamc` → `ixmp4`. We apply the mitigation discussed at khaeru/genno#140. This is parallel to iiasa/message_ix#854.
- hgrecco/pint#2007; see iiasa/ixmp#534.
- ts-graphviz/setup-graphviz#630. This mirrors changes made in iiasa/ixmp#535 and iiasa/message_ix#854.

These are temporary work-arounds, are marked accordingly, and should be removed when the respective upstream packages are fixed.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅ CI changes only.
- ~Add, expand, or update documentation.~
- ~Update release notes.~