### PR TITLE
Adjust apply_spec() to reduce log verbosity

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -5,6 +5,8 @@ Next release
 ============
 
 - Add :doc:`/material/index` (:pull:`188`, :pull:`189`).
+- Reduce log verbosity of :func:`.apply_spec` (:pull:`202`).
+
 Changes to :doc:`/api/tools-costs`
 ----------------------------------
   - Fix jumps in cost projections for technologies with first technology year that's after than the first model year (:pull:`186`).

--- a/message_ix_models/model/build.py
+++ b/message_ix_models/model/build.py
@@ -84,6 +84,9 @@ def apply_spec(  # noqa: C901
     # sets that may reference them.
     sets = sorted((len(scenario.idx_sets(s)), s) for s in scenario.set_list())
 
+    # Existing 'region' codes stored on the Platform associated with `scenario`
+    platform_regions = set(scenario.platform.regions()["region"])
+
     for _, set_name in sets:
         # Check whether this set is mentioned at all in the spec
         if 0 == sum(map(lambda info: len(info.set[set_name]), spec.values())):
@@ -129,7 +132,7 @@ def apply_spec(  # noqa: C901
         for element in add:
             name = element.id if isinstance(element, Code) else element
             scenario.add_set(set_name, name)
-            if set_name == "node":
+            if set_name == "node" and name not in platform_regions:
                 scenario.platform.add_region(name, "region")
 
         if len(add):
@@ -146,10 +149,6 @@ def apply_spec(  # noqa: C901
     for unit in spec["add"].set["unit"]:
         unit = unit if isinstance(unit, Code) else Code(id=unit, name=unit)
         _add_unit(scenario.platform, unit.id, str(unit.name))
-
-    # Add nodes to the Platform before adding data
-    for node in spec["add"].set["node"]:
-        scenario.platform.add_region(node, hierarchy="")
 
     # Add data
     if callable(data):

--- a/message_ix_models/tests/model/test_build.py
+++ b/message_ix_models/tests/model/test_build.py
@@ -1,12 +1,16 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ixmp.testing import assert_logs
 from message_ix import make_df
 from message_ix.testing import make_dantzig
 
-from message_ix_models import ScenarioInfo
+from message_ix_models import Spec
 from message_ix_models.model.build import apply_spec
+
+if TYPE_CHECKING:
+    from ixmp import Scenario
 
 
 @pytest.fixture
@@ -16,11 +20,12 @@ def scenario(test_context):
 
 
 @pytest.fixture(scope="function")
-def spec():
-    yield dict(add=ScenarioInfo(), require=ScenarioInfo(), remove=ScenarioInfo())
+def spec() -> Spec:
+    """An empty Spec."""
+    yield Spec()
 
 
-def test_apply_spec0(caplog, scenario, spec):
+def test_apply_spec0(caplog, scenario: "Scenario", spec: Spec):
     """Require missing element raises ValueError."""
     spec["require"].set["node"].append("vienna")
 
@@ -34,7 +39,7 @@ def test_apply_spec0(caplog, scenario, spec):
     ) in caplog.record_tuples
 
 
-def test_apply_spec1(caplog, scenario, spec):
+def test_apply_spec1(caplog, scenario: "Scenario", spec: Spec):
     """Add data using the data= argument."""
 
     def add_data_func(scenario, dry_run):
@@ -68,7 +73,7 @@ def test_apply_spec1(caplog, scenario, spec):
     assert 1 == sum(301.0 == scenario.par("demand")["value"])
 
 
-def test_apply_spec2(caplog, scenario, spec):
+def test_apply_spec2(caplog, scenario: "Scenario", spec: Spec):
     """Remove an element, with fast=True."""
     spec["remove"].set["node"] = ["new-york", "not-a-node"]
 
@@ -85,7 +90,7 @@ def test_apply_spec2(caplog, scenario, spec):
     )
 
 
-def test_apply_spec3(caplog, scenario, spec):
+def test_apply_spec3(caplog, scenario: "Scenario", spec: Spec):
     """Actually remove data."""
     spec["remove"].set["node"] = ["new-york"]
 

--- a/message_ix_models/tests/model/test_build.py
+++ b/message_ix_models/tests/model/test_build.py
@@ -106,3 +106,26 @@ def test_apply_spec3(caplog, scenario: "Scenario", spec: Spec):
             "  3 rows total",
         ),
     )
+
+
+def test_apply_spec4(request, caplog, scenario: "Scenario", spec: Spec):
+    """Test that platform region IDs are added as necessary."""
+
+    # Existing region code list on `scenario.platform`
+    regions_pre = scenario.platform.regions()
+
+    # Add a unique node ID
+    node = f"{request.node.name} {len(regions_pre)}"
+    spec.add.set["node"] = [node]
+
+    # Also add a node ID that already exists as a region ID on `scenario.platform`
+    spec.add.set["node"].append(regions_pre["region"].iloc[0])
+
+    # Function runs
+    apply_spec(scenario, spec)
+
+    # `scenario.platform` gains a region ID corresponding to the new node ID
+    assert node in scenario.platform.regions()["region"].tolist()
+
+    # Nothing logged for the already-existing region ID
+    assert not any("already defined" in message for message in caplog.messages)

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -424,7 +424,7 @@ def make_io(src, dest, efficiency, on="input", **kwargs):
 
 
 def make_matched_dfs(
-    base: MutableMapping, **par_value: Union[float, pint.Quantity]
+    base: Union[MutableMapping, pd.DataFrame], **par_value: Union[float, pint.Quantity]
 ) -> Dict[str, pd.DataFrame]:
     """Return data frames derived from `base` for multiple parameters.
 


### PR DESCRIPTION
In #159 we adjusted `.model.build.apply_spec()` to add any new `node` set elements also to the ixmp.Platform `region` codelist.

I noticed this generates a lot of "log spam", such as [here](https://github.com/iiasa/message_data/actions/runs/9738457433/job/26872089471#step:17:8678):
```
____________________________ test_add_missing_years ____________________________
[gw7] linux -- Python 3.12.2 /home/runner/actions-runner/_work/_tool/Python/3.12.2/x64/bin/python
----------------------------- Captured stdout call -----------------------------
message_ix_models.testing.bare_res: Create 'MESSAGEix-GLOBIOM R11 YB/baseline' for testing
—.testing.bare_res  Create 'MESSAGEix-GLOBIOM R11 YB/baseline' for testing
message_ix_models.model.bare.create_res: Create 'ixmp://message-ix-models/MESSAGEix-GLOBIOM R11 YB/baseline#new'
—.model.bare.create_res  Create 'ixmp://message-ix-models/MESSAGEix-GLOBIOM R11 YB/baseline#new'
ixmp.core.platform._existing_node: region 'World' is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node  region 'World' is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code World: World> is already defined on the Platform under parent 'World'
..._existing_node  region <Code World: World> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_AFR: Sub-Saharan Africa> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_AFR: Sub-Saharan Africa> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_CPA: Centrally Planned Asia> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_CPA: Centrally Planned Asia> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_EEU: Central and Eastern Europe> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_EEU: Central and Eastern Europe> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_FSU: Former Soviet Union> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_FSU: Former Soviet Union> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_LAM: Latin America and The Caribbean> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_LAM: Latin America and The Caribbean> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_MEA: Middle East and North Africa> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_MEA: Middle East and North Africa> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_NAM: North America> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_NAM: North America> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_PAO: Pacific OECD> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_PAO: Pacific OECD> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_PAS: Other Pacific Asia> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_PAS: Other Pacific Asia> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_SAS: South Asia> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_SAS: South Asia> is already defined on the Platform under parent 'World'
ixmp.core.platform._existing_node: region <Code R11_WEU: Western Europe> is already defined on the Platform under parent 'World'
..._existing_node  region <Code R11_WEU: Western Europe> is already defined on the Platform under parent 'World'
```

This PR adjusts to only call `ixmp.Platform.add_region()` if each code does not exist.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ No functional changes.
- [x] Update doc/whatsnew.