### PR TITLE
Bump GAMS version in CI workflows to adjust for ixmp changes

### DIFF
--- a/.github/workflows/pytest-snapshots.yaml
+++ b/.github/workflows/pytest-snapshots.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: 25.1.1
+        version: 43.4.1
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v2

--- a/.github/workflows/pytest-snapshots.yaml
+++ b/.github/workflows/pytest-snapshots.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: 43.4.1
+        version: 29.1.0
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -87,7 +87,7 @@ jobs:
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: 43.4.1
+        version: 29.1.0
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -87,7 +87,7 @@ jobs:
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: 25.1.1
+        version: 43.4.1
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v2


### PR DESCRIPTION
https://github.com/iiasa/ixmp/pull/532 deleted some libraries that were used to run GAMS, which should now be read directly from a GAMS subdirectory. This PR adjusts the version of GAMS used in CI to check if this newer version enables finding the libraries.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just internal CI.
- ~[ ] Add, expand, or update documentation.~ Just internal CI.
- ~[ ] Update doc/whatsnew.~ Just internal CI.

