### PR TITLE
Extend data handling for the EDITS transport MCE

### DIFF
--- a/message_ix_models/project/edits/__init__.py
+++ b/message_ix_models/project/edits/__init__.py
@@ -11,6 +11,7 @@ from sdmx.message import StructureMessage
 from sdmx.model.common import Codelist
 from sdmx.model.v21 import DataStructureDefinition
 
+from message_ix_models.tools.exo_data import ExoDataSource
 from message_ix_models.util import local_data_path
 
 if TYPE_CHECKING:
@@ -157,6 +158,21 @@ DATA_MAP = {
     "TKM": ("freight activity", "km"),
     "VKM": ("vehicle activity", "km"),
 }
+
+
+class PASTA(ExoDataSource):
+    """Retrieve and process PASTA data for use in MESSAGEix-Transport."""
+
+    id = "PASTA"
+
+    def __init__(self, source, source_kw):
+        if not source == self.id:
+            raise ValueError(source)
+
+        self.raise_on_extra_kw(source_kw)
+
+    def __call__(self):
+        raise NotImplementedError
 
 
 def gen_demand(context: "Context") -> dict[str, "AnyQuantity"]:

--- a/message_ix_models/tests/project/test_edits.py
+++ b/message_ix_models/tests/project/test_edits.py
@@ -2,7 +2,7 @@ from shutil import copyfile
 
 import pytest
 
-from message_ix_models.project.edits import gen_demand, pasta_native_to_sdmx
+from message_ix_models.project.edits import PASTA, gen_demand, pasta_native_to_sdmx
 from message_ix_models.util import package_data_path
 
 
@@ -13,6 +13,11 @@ def test_pasta_data(test_context):
     target = test_context.get_local_path(*parts)
     target.parent.mkdir(parents=True, exist_ok=True)
     copyfile(package_data_path("test", *parts), target)
+
+
+class TestPASTA:
+    def test_init(self) -> None:
+        PASTA("PASTA", {})
 
 
 def test_pasta_native_to_sdmx(test_context, test_pasta_data):


### PR DESCRIPTION
- Add .edits.PASTA, an ExoDataSource subclass for the PASTA transport activity data.
- More TBA.

## How to review

**TBA**

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Build the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  doc/whatsnew.rst, where '999' is the GitHub pull request number:

  - Title or single-sentence description from above (:pull:`999`:).

  Commit with a message like “Add #999 to doc/whatsnew”
  -->
