### PR TITLE
Manual adjustments for `.model.transport` migration

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [ main , "migrate-*"]
+    branches: [ main , "migrate**"]
   schedule:
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   - cron: "0 5 * * *"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -123,7 +123,7 @@ jobs:
     - name: Run test suite using pytest
       run: |
         pytest message_ix_models \
-          -m "not snapshot" \
+          -m "not (ece_db or snapshot)" \
           -rA --verbose --color=yes --durations=20 \
           --cov-report=term-missing --cov-report=xml \
           --numprocesses=auto \

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_install:
+    # Remove requests-cache, which appears to cause segfaults on RTD workers
+    - pip uninstall --yes requests-cache
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,6 @@
 # Modules containing fixtures to use in testing
-pytest_plugins = ["ixmp.testing", "message_ix_models.testing"]
+pytest_plugins = [
+    "genno.testing",
+    "ixmp.testing",
+    "message_ix_models.testing",
+]

--- a/doc/api/report/index.rst
+++ b/doc/api/report/index.rst
@@ -13,7 +13,7 @@ Elsewhere:
 - Reporting for specific model variants:
 
   - :mod:`.water.reporting`
-  - (Private) :doc:`Reporting of message_data.model.transport <m-data:reference/model/transport/report>`
+  - :doc:`transport/output` of :mod:`.model.transport`
 
 - :doc:`‘Legacy’ reporting <legacy>`.
 

--- a/doc/api/tools-messagev.rst
+++ b/doc/api/tools-messagev.rst
@@ -1,0 +1,54 @@
+MESSAGE V input files
+*********************
+
+This document describes some of the file formats for the pre-:mod:`.ixmp` MESSAGE model, a.k.a. **MESSAGE V**, and code in :mod:`message_ix_models.tools.messagev` that reads these formats.
+
+.. note:: See also the earlier :doc:`import_from_msgV_sqlite` for similar code/descriptions.
+
+.. contents::
+   :local:
+
+``easemps3.free``: soft dynamic constraints
+-------------------------------------------
+
+Each constraint is specified by a single row with the following, space-separated entries:
+
+1. **Constraint type.** `mpa` (constraint on activity) or `mpc` (constraint on capacity).
+2. **Technology name.** Four-letter internal name/code of a technology, e.g. `uHap`.
+3. **Lower/upper bound.** Either `LO` (decline constraint) or `UP` (growth constraint).
+4. **Cost type.** One of:
+
+   - `lev`: levelized costs.
+   - `abs`: absolute costs.
+   - `var`: variable costs.
+
+5. **Growth rate for step 1.** Percentage points of growth/decline at which the constraint becomes active.
+
+6. **Additional cost for step 1.** Additional cost applied to activity/capacity growth or decline beyond the rate in #5. Depending on #4, specified:
+
+   - `lev`: in percentage points of the levelized cost of the technology.
+   - `abs`, `var`: in absolute monetary value.
+
+7. **Up to 4 additional pairs of 5 and 6.** Growth rates for successive constraints are cumulative.
+
+An example:
+
+.. code::
+
+   mpa uEAp UP lev 5 50 15 300000
+
+Here the constraint relates to a growth constraint (UP) for activities (mpa) and the technology for which the constraint is to be extended is uEAp.
+The allowed rate of growth is increased by 5 %-points and each additional unit of output that can be produced costs 50 % of the levelized costs additional on top of the normal costs (i.e. the costs that result from building and using the additional capacity required for the additional production).
+
+The second step increases the maximum growth rate further, by 15 %-points, but the costs are prohibitive (300000).
+
+Soft constraints can be set for each technology individually. This can be done globally ("regions = all -glb") or for each region separately ("regions = cpa").
+
+
+API reference
+-------------
+
+.. currentmodule:: message_ix_models.tools.messagev
+
+.. automodule:: message_ix_models.tools.messagev
+   :members:

--- a/doc/global/energy/enduse/index.rst
+++ b/doc/global/energy/enduse/index.rst
@@ -1,6 +1,6 @@
 Energy end-use
 =================
-MESSAGEix distinguishes three energy end-use sectors, i.e. transport, residential/commercial (also referred to as the buildings sector) and industry. Given the long-term nature of the scenarios, the model version used for the SSPs, represents these end-use sectors in a stylized way. For more detailed short-term analysis, a model version with a more detailed transport sector module that distinguishes different transport modes, vehicle classes and consumer types exists (McCollum et al., 2016 :cite:`mccollum_transport_2016`).
+MESSAGEix distinguishes three energy end-use sectors, i.e. transport, residential/commercial (also referred to as the buildings sector) and industry. Given the long-term nature of the scenarios, the model version used for the SSPs, represents these end-use sectors in a stylized way. For more detailed short-term analysis, a model version with a more detailed transport sector module that distinguishes different transport modes, vehicle classes and consumer types exists (McCollum et al., 2017 :cite:`mccollum-2016`).
 
 .. toctree::
    :maxdepth: 1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,6 +69,7 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    api/report/index
    api/tools
    api/tools-costs
+   api/tools-messagev
    api/data-sources
    api/util
    api/testing

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,6 +81,7 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
 
    global/index
    material/index
+   transport/index
    water/index
 
 .. toctree::

--- a/doc/main.bib
+++ b/doc/main.bib
@@ -1496,12 +1496,29 @@
   year = {2014}
 }
 
-@article{mccollum_transport_2016,
-  author = {McCollum, David L. and Wilson, Charlie and Pettifor, Hazel and Ramea, Kalai and Krey, Volker and Riahi, Keywan and Bertram, Christoph and Lin, Zhenhong and Edelenbosch, Oreane Y. and Fujisawa, Sei},
-  journal = {Transportation Research Part D: Transport and Environment},
-  title = {Improving the behavioral realism of global integrated assessment models: An application to consumers’ vehicle choices},
-  type = {Journal Article},
-  year = {2016}
+@article{mccollum-2017,
+	author = {McCollum, David L. and Wilson, Charlie and Pettifor, Hazel and Ramea, Kalai and Krey, Volker and Riahi, Keywan and Bertram, Christoph and Lin, Zhenhong and Edelenbosch, Oreane Y. and Fujisawa, Sei},
+	doi = {10.1016/j.trd.2016.04.003},
+	issn = {13619209},
+	journal = {Transportation Research Part D: Transport and Environment},
+	keywords = {Climate change mitigation; Consumer choice; Human behavior; Light-duty vehicles; Transport},
+	pages = {322--342},
+	publisher = {Elsevier Ltd},
+	title = {{Improving the behavioral realism of global integrated assessment models: An application to consumers' vehicle choices}},
+	volume = {55},
+	year = {2017}
+}
+
+@article{mccollum-2018,
+	author = {McCollum, David L. and Wilson, Charlie and Bevione, Michela and Carrara, Samuel and Edelenbosch, Oreane Y. and Emmerling, Johannes and Guivarch, C{\'e}line and Karkatsoulis, Panagiotis and Keppo, Ilkka and Krey, Volker and Lin, Zhenhong and Broin, Eoin {\'O} and Paroussos, Leonidas and Pettifor, Hazel and Ramea, Kalai and Riahi, Keywan and Sano, Fuminori and Rodriguez, Baltazar Solano and van Vuuren, Detlef P.},
+	doi = {10.1038/s41560-018-0195-z},
+	issn = {2058-7546},
+	journal = {Nature Energy},
+	number = {8},
+	pages = {664–673},
+	title = {Interaction of consumer preferences and climate policies in the global transition to low-carbon vehicles},
+	volume = {3},
+	year = {2018},
 }
 
 @article{mcjeon_gas_2014,

--- a/doc/transport/index.rst
+++ b/doc/transport/index.rst
@@ -4,34 +4,35 @@ MESSAGEix-Transport
 .. warning::
 
    MESSAGEix-Transport is **under development**.
-   For details, see the `project board <https://github.com/orgs/iiasa/projects/29>`_.
 
-:mod:`message_data.model.transport` adds a technology-rich representation of transport to models in the MESSAGEix-GLOBIOM family.
+   - The code and data documented on these pages were recently :doc:`migrated </migrate>` from :mod:`.message_data`.
+     The text may still contain references to the old location.
+   - For details, see the `project board <https://github.com/orgs/iiasa/projects/29>`_.
+
+:mod:`message_ix_models.model.transport` adds a technology-rich representation of transport to models in the MESSAGEix-GLOBIOM family.
 The resulting “model variant” is variously referred to as:
 
 - **MESSAGEix-Transport**,
-- “MESSAGEix-GLOBIOM ‘T’” or, with other variants like :mod:`.buildings` and :mod:`.material`, “MESSAGEix-GLOBIOM BMT”, or
+- “MESSAGEix-GLOBIOM ‘T’” or, with other variants like :mod:`.buildings` and :mod:`~message_ix_models.model.material`, “MESSAGEix-GLOBIOM BMT”, or
 - “MESSAGEix-XX-Transport” where built on a single-country base model (again, in the MESSAGEix-GLOBIOM family) named like “MESSAGEix-XX”.
 
-MESSAGEix-Transport extends the formulation described by McCollum et al. (2016) :cite:`McCollum2017` for the older, MESSAGE V framework that predated MESSAGEix.
-Some inherited information about the older model is collected at :doc:`transport/old`.
+MESSAGEix-Transport extends the formulation described by McCollum et al. (2017) :cite:`mccollum-2017` for the older, MESSAGE V framework that predated MESSAGEix.
+Some inherited information about the older model is collected at :doc:`old`.
 
 Information about MESSAGEix-Transport, its inputs, configuration, implementation, and output, are organized according to this diagram:
 
 .. figure:: https://raw.githubusercontent.com/khaeru/doc/main/image/data-stages.svg
 
-   Information about MESSAGEix-Transport is separated into:
-
-- :doc:`transport/input` (separate page)—line (1) in the diagram.
+- :doc:`input` (separate page)—line (1) in the diagram.
 - :ref:`transport-implementation` (below)—between lines (1) and (3) in the diagram.
-- :doc:`transport/output` (separate page)—between lines (3) and (4) in the diagram.
+- :doc:`output` (separate page)—between lines (3) and (4) in the diagram.
 
 .. toctree::
    :hidden:
    :maxdepth: 2
 
-   transport/input
-   transport/output
+   input
+   output
 
 On this page:
 
@@ -67,7 +68,7 @@ The code:
     - Add these data to the target :class:`.Scenario`.
 
 - **Solves** the :class:`.Scenario`.
-- Provides :mod:`message_ix_models.report` extensions to **report or post-process** the model solution data and prepare detailed transport outputs in various formats (see :doc:`transport/output`).
+- Provides :mod:`message_ix_models.report` extensions to **report or post-process** the model solution data and prepare detailed transport outputs in various formats (see :doc:`output`).
 
 Details
 -------
@@ -76,9 +77,9 @@ Details
    :hidden:
    :maxdepth: 2
 
-   transport/disutility
+   disutility
 
-On other page(s): :doc:`transport/disutility`.
+On other page(s): :doc:`disutility`.
 
 - For light-duty vehicle technologies annotated with ``historical-only: True``, parameter data for ``bound_new_capacity_up`` are created with a value of 0.0.
   These prevent new capacity of these technologies from being created during the model horizon, but allow pre-horizon installed capacity (represented by ``historical_new_capacity``) to continue to be operated within its technical lifetime.
@@ -92,7 +93,7 @@ Usage
 Automated workflow
 ------------------
 
-:mod:`.transport.workflow.generate` returns a :class:`.Workflow` instance.
+:func:`.transport.workflow.generate` returns a :class:`.Workflow` instance.
 This can be invoked or modified by other code, or through the command-line::
 
   $ mix-models transport run --help
@@ -162,7 +163,7 @@ Debug the build for a single scenario
    With a different target or :program:`--nodes` option, the directory name will differ accordingly.
 
 Debug the build for all scenarios
-   This performs the above debug build step for all SSPs, and then runs :func:`debug_multi` to generate plots that compare the contents of the debug :file:`.csv` files for all 5 SSPs.
+   This performs the above debug build step for all SSPs, and then runs :func:`.debug_multi` to generate plots that compare the contents of the debug :file:`.csv` files for all 5 SSPs.
    The plots are output to the directory :file:`{local-data-path}/transport/`.
 
    .. code-block:: shell
@@ -202,7 +203,7 @@ Manual
 This subsection contains an older, manual, step-by-step workflow.
 
 **Preliminaries.**
-Check the list of :doc:`pre-requisite knowledge <message_ix:prereqs>` for working with :mod:`.message_data`.
+Check the list of :doc:`pre-requisite knowledge <message-ix:prereqs>` for working with :mod:`.message_ix_models`.
 
 .. note:: One pre-requisite is basic familiarity with using a shell/command line.
 
@@ -243,7 +244,7 @@ The following is equivalent to calling :meth:`message_ix.Scenario.solve`::
     $ message-ix --url="$URL" solve
 
 **Report the results.**
-The ``-m model.transport`` option indicates that additional reporting calculations from :mod:`model.transport.report` should be added to the base reporting configuration for MESSAGEix-GLOBIOM::
+The ``-m model.transport`` option indicates that additional reporting calculations from :mod:`.model.transport.report` should be added to the base reporting configuration for MESSAGEix-GLOBIOM::
 
     $ mix-models --url="$URL" report -m model.transport "transport plots"
 
@@ -317,23 +318,23 @@ The following existing scenarios are targets for the MESSAGEix-Transport code to
    regions=R12, years=B. Includes MACRO calibration
 
 ``ixmp://ixmp-dev/MESSAGEix-Materials/NoPolicy_GLOBIOM_R12_s#1``
-  regions=R12, years=B. Includes :doc:`material` detail.
+  regions=R12, years=B. Includes :doc:`/material/index` detail.
 
 ``ixmp://ixmp-dev/MESSAGEix-Materials/NoPolicy_2305#?``
-  regions=R12, years=B. Includes :doc:`material` detail.
+  regions=R12, years=B. Includes :doc:`/material/index` detail.
 
 .. _transport-base-structure:
 
 Structure of base scenarios
 ---------------------------
 
-The MESSAGEix-GLOBIOM RES (e.g. :mod:`.model.create` or :mod:`.model.bare`) contains a representation of transport with lower resolution.
+The MESSAGEix-GLOBIOM RES (e.g. :mod:`.model.bare` or :mod:`message_data.model.create`) contains a representation of transport with lower resolution.
 Some documentation is in the base-model documentation (:py:`message_doc`; see also `iiasa/message-ix-models#107 <https://github.com/iiasa/message-ix-models/pull/107>`_).
 This section gives additional details missing there, which are relevant to MESSAGEix-Transport.
 
 - Demand (``commodity=transport``, ``level=useful``) is denoted in **energy units**, i.e. GWa.
 - Technologies producing this output; all at ``m=M1``, except where noted.
-  This is the same set as in :doc:`MESSAGE V <transport/old>`, i.e. in MESSAGE V, the aggregate transport representation is inactive but still present.
+  This is the same set as in :doc:`MESSAGE V <old>`, i.e. in MESSAGE V, the aggregate transport representation is inactive but still present.
 
   - ``coal_trp``
   - ``foil_trp``
@@ -428,7 +429,7 @@ This workflow:
   This artifact contains, *inter alia*:
 
   - One directory per job.
-  - In each directory, files :file:`transport.csv` and :file:`transport.xlsx` containing :doc:`MESSAGEix-Transport reporting output <transport/output>`.
+  - In each directory, files :file:`transport.csv` and :file:`transport.xlsx` containing :doc:`MESSAGEix-Transport reporting output <output>`.
   - In each directory, files :file:`demand.csv` and :file:`bound_activity_{lo,up}.csv` containing data suitable for parametrizing the base MESSAGEix-GLOBIOM model.
 - May be triggered manually.
   Use the “Run workflow” button and choose a branch; the code and data on this branch will be the ones used to build, solve, and report MESSAGEix-Transport.
@@ -466,14 +467,14 @@ Code reference
 
 The entire module and its contents are documented recursively:
 
-.. currentmodule:: message_data.model
+.. currentmodule:: message_ix_models.model
 
 .. autosummary::
    :toctree: _autosummary
    :template: autosummary-module.rst
    :recursive:
 
-   message_data.model.transport
+   message_ix_models.model.transport
 
 Other documents
 ===============
@@ -481,4 +482,4 @@ Other documents
 .. toctree::
    :maxdepth: 2
 
-   transport/old
+   old

--- a/doc/transport/input.rst
+++ b/doc/transport/input.rst
@@ -10,7 +10,7 @@ This page describes the structure and format of inputs required for building MES
 Both input data and configuration are stored in files under :file:`/data/transport/` in the :mod:`message_data` repository.
 (When migrated to :mod:`message_ix_models`, these files will live in :file:`message_ix_models/data/transport`.)
 
-In most cases, these files are read from a subdirectory like :file:`/data/transport/{nodes}/`, where `nodes` denotes the :mod:`message_ix_models` :doc:`node code list <message_ix_models:pkg-data/node>`—for instance, "R12"—for which MESSAGEix-Transport will be built.
+In most cases, these files are read from a subdirectory like :file:`/data/transport/{nodes}/`, where `nodes` denotes the :mod:`message_ix_models` :doc:`node code list </pkg-data/node>`—for instance, "R12"—for which MESSAGEix-Transport will be built.
 This value is retrieved from the :attr:`Context.regions <.model.Config.regions>` setting.
 
 - If the file data or configuration settings have a node (:math:`n`) dimension, the file **must** be placed in such a subdirectory.
@@ -40,7 +40,7 @@ Technology code list (:file:`technology.yaml`)
 ----------------------------------------------
 
 This file gives the code list for the MESSAGE ``technology`` concept/set/dimension.
-Some annotations (``iea-eweb-flow``, ``input``, ``report``) and the :attr:`.child` hierarchy give information about technologies' grouping according to transport modes.
+Some annotations (``iea-eweb-flow``, ``input``, ``report``) and the :attr:`~sdmx.model.common.Code.child` hierarchy give information about technologies' grouping according to transport modes.
 
 → View :source:`data/transport/technology.yaml` on GitHub
 
@@ -108,7 +108,7 @@ node = R12_SAS [1]_
 Data on costs and efficiencies of LDV technologies.
 
 Formerly this data was read from :file:`ldv-cost-efficiency.xlsx`, a highly-structured spreadsheet that performs some input calculations.
-The function :func:`get_USTIMES_MA3T` reads data from multiple sheets in this file.
+The function :func:`.get_USTIMES_MA3T` reads data from multiple sheets in this file.
 To understand the sheet names and cell layout expected, see the code for that function.
 
 As the name implies, the data for :doc:`MESSAGE (V)-Transport <old>` was derived from the US-TIMES and MA³T models.
@@ -229,7 +229,7 @@ Other data sources
 
 These include:
 
-- GDP and population from the :mod:`.tools.ssp` databases or other sources including the ADVANCE project, the Global Energy Assessment project, the SHAPE project, etc.
+- GDP and population from the :mod:`.project.ssp` data sources or other sources including the ADVANCE project, the Global Energy Assessment project, the SHAPE project, etc.
 
   .. note:: Formerly, file :file:`gdp.csv` was used.
 

--- a/doc/transport/old.rst
+++ b/doc/transport/old.rst
@@ -294,4 +294,4 @@ MESSAGE_Transport_port_to_ix\\Emails_and_documentation
   I'm not sure how useful these will be at the current stage, but they were a bit helpful for me when trying to refresh my memory of what came from where; therefore, I figured it's worth parking these aside in case someone else needs them.
 
 - There is no outstanding technical documentation for how the detailed transport model works at a fundamental level.
-  The best we have is the more conceptual description, which can be found in the supplementary information of :cite:`McCollum2017`.
+  The best we have is the more conceptual description, which can be found in the supplementary information of :cite:`mccollum-2017`.

--- a/doc/transport/output.rst
+++ b/doc/transport/output.rst
@@ -44,7 +44,7 @@ This section explains how such translation works, serving both as a requirements
 Integrated through legacy reporting
 -----------------------------------
 
-As of 2022-04, the :doc:`/reference/tools/post_processing` is still in active use.
+As of 2022-04, the :doc:`/api/report/legacy` is still in active use.
 One function it performs is **aggregation**: some totals across both transport and other sectors are computed by this code, along with other calculations.
 
 The transport reporting code must compute and store these data before it can be picked up and aggregated.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,6 +6,7 @@ Next release
 
 - Add :doc:`/material/index` (:pull:`188`, :pull:`189`).
 - Update :doc:`/material/index` (:pull:`201`).
+- Add :doc:`/transport/index` (:pull:`207`, :pull:`208`).
 - Add :doc:`/project/edits` project code and documentation (:pull:`204`).
 - Reduce log verbosity of :func:`.apply_spec` (:pull:`202`).
 - Made fixes and updates to :doc:`/api/tools-costs` (:pull:`186`, :pull:`187`, :pull:`190`, :pull:`195`).
@@ -16,7 +17,7 @@ Next release
   - Change the default fixed O&M reduction rate to 0 (:pull:`186`).
   - Modify to use 2023 release of IEA WEO data and to use 2022 historic data for the base year (:pull:`187`).
   - Change the default final year to 2110 (:pull:`190`).
-  - Add :attr:`~.costs.Config.use_vintages` to control whether vintages are used in computing fixed O&M costs (:pull:`195`).  
+  - Add :attr:`~.costs.Config.use_vintages` to control whether vintages are used in computing fixed O&M costs (:pull:`195`).
 
 v2024.4.22
 ==========

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -160,6 +160,7 @@ main.add_command(ixmp_cli.commands["config"])
 submodules = [
     "message_ix_models.model.cli",
     "message_ix_models.model.structure",
+    "message_ix_models.model.transport.cli",
     "message_ix_models.model.water.cli",
     "message_ix_models.project.edits.cli",
     "message_ix_models.project.ssp",

--- a/message_ix_models/model/transport/CHN_IND.py
+++ b/message_ix_models/model/transport/CHN_IND.py
@@ -6,7 +6,7 @@ import pandas as pd
 from iam_units import registry
 from item import historical  # type: ignore [import-not-found]
 
-from message_ix_models.util import private_data_path
+from message_ix_models.util import package_data_path
 
 UNITS = {
     "Population": (1.0e-6, None, "dimensionless"),
@@ -146,7 +146,7 @@ def get_chn_ind_pop():
         DataFrame containing population data for China and India.
     """
     # Read csv file
-    pop = pd.read_csv(private_data_path("transport", POP_FILE), header=1)
+    pop = pd.read_csv(package_data_path("transport", POP_FILE), header=1)
     # Drop irrelevant columns and rename when necessary
     pop = pop.drop(
         [x for x in pop.columns if x not in ["LOCATION", "Time", "Value"]],
@@ -184,7 +184,7 @@ def get_chn_ind_data(private_vehicles=False):
     for file, skip_footer in FILES.values():
         # Read excel sheet
         df_aux = pd.read_csv(
-            private_data_path("transport", file),
+            package_data_path("transport", file),
             skipfooter=skip_footer,
             header=2,
         )

--- a/message_ix_models/model/transport/CHN_IND.py
+++ b/message_ix_models/model/transport/CHN_IND.py
@@ -4,7 +4,8 @@ Bureau of Statistics) and for India (iTEM)."""
 import numpy as np
 import pandas as pd
 from iam_units import registry
-from item import historical
+from item import historical  # type: ignore [import-not-found]
+
 from message_ix_models.util import private_data_path
 
 UNITS = {

--- a/message_ix_models/model/transport/base.py
+++ b/message_ix_models/model/transport/base.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 import pandas as pd
-from genno import KeySeq
+from genno import Computer, KeySeq
 from genno.core.key import single_key
 
 from message_ix_models.util import minimum_version
@@ -40,7 +40,7 @@ UE_SHARE_HEADER = (
 
 
 @minimum_version("pandas 2")
-def smooth(c: "genno.Computer", key: "genno.Key", *, dim: str = "ya") -> "genno.Key":
+def smooth(c: Computer, key: "genno.Key", *, dim: str = "ya") -> "genno.Key":
     """Implement ‘smoothing’ for `key` along the dimension `dim`.
 
     1. Identify values which do not meet a certain criterion. Currently the criterion

--- a/message_ix_models/model/transport/base.py
+++ b/message_ix_models/model/transport/base.py
@@ -9,6 +9,8 @@ import pandas as pd
 from genno import KeySeq
 from genno.core.key import single_key
 
+from message_ix_models.util import minimum_version
+
 from .key import gdp_exo
 
 if TYPE_CHECKING:
@@ -37,6 +39,7 @@ UE_SHARE_HEADER = (
 )
 
 
+@minimum_version("pandas 2")
 def smooth(c: "genno.Computer", key: "genno.Key", *, dim: str = "ya") -> "genno.Key":
     """Implement ‘smoothing’ for `key` along the dimension `dim`.
 

--- a/message_ix_models/model/transport/build.py
+++ b/message_ix_models/model/transport/build.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 import pandas as pd
 from genno import Computer, KeyExistsError, Quantity, quote
 from message_ix import Scenario
+
 from message_ix_models import Context, ScenarioInfo
 from message_ix_models.model import bare, build
 from message_ix_models.util._logging import mark_time
@@ -29,6 +30,7 @@ def write_report(qty: "AnyQuantity", path: Path, kwargs=None) -> None:
     .. todo:: Move upstream, to :mod:`genno`.
     """
     from genno import operator
+
     from message_ix_models.util import datetime_now_with_tz
 
     kwargs = kwargs or dict()
@@ -194,7 +196,7 @@ def add_exogenous_data(c: Computer, info: ScenarioInfo) -> None:
     # Add data for MERtoPPP
     kw = dict(measure="MERtoPPP", nodes=context.model.regions)
     prepare_computer(
-        context, c, "message_data.model.transport", source_kw=kw, strict=False
+        context, c, "message_ix_models.model.transport", source_kw=kw, strict=False
     )
 
     # Add IEA Extended World Energy Balances data; select only the flows related to

--- a/message_ix_models/model/transport/build.py
+++ b/message_ix_models/model/transport/build.py
@@ -11,6 +11,7 @@ from message_ix import Scenario
 
 from message_ix_models import Context, ScenarioInfo
 from message_ix_models.model import bare, build
+from message_ix_models.util import minimum_version
 from message_ix_models.util._logging import mark_time
 
 from . import Config
@@ -373,6 +374,7 @@ def add_structure(c: Computer):
     c.add("indexers::iea to transport", itemgetter(2), "groups::iea eweb")
 
 
+@minimum_version("message_ix 3.8")
 def get_computer(
     context: Context,
     obj: Optional[Computer] = None,

--- a/message_ix_models/model/transport/cli.py
+++ b/message_ix_models/model/transport/cli.py
@@ -83,7 +83,7 @@ def export_emissions_factors(context, path_stem):
     """
     from datetime import datetime
 
-    from message_ix_models.util import private_data_path
+    from message_ix_models.util import package_data_path
 
     # List of techs
     techs = context.transport.spec.remove.set["technology"]
@@ -92,7 +92,7 @@ def export_emissions_factors(context, path_stem):
     scenario = context.get_scenario()
 
     # Output path
-    out_dir = private_data_path("transport", "emi")
+    out_dir = package_data_path("transport", "emi")
     out_dir.mkdir(exist_ok=True, parents=True)
 
     for name in ("emission_factor", "relation_activity"):

--- a/message_ix_models/model/transport/cli.py
+++ b/message_ix_models/model/transport/cli.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 
 import click
+
 from message_ix_models import ScenarioInfo
 from message_ix_models.util._logging import silence_log
 from message_ix_models.util.click import PARAMS, common_params, exec_cb

--- a/message_ix_models/model/transport/config.py
+++ b/message_ix_models/model/transport/config.py
@@ -5,14 +5,14 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import message_ix
 from genno import Quantity
+
 from message_ix_models import Context, ScenarioInfo, Spec
+from message_ix_models.project.navigate import T35_POLICY as NAVIGATE_SCENARIO
 from message_ix_models.project.ssp import SSP_2024, ssp_field
+from message_ix_models.project.transport_futures import SCENARIO as FUTURES_SCENARIO
 from message_ix_models.report.util import as_quantity
 from message_ix_models.util import identify_nodes, private_data_path
 from message_ix_models.util.config import ConfigHelper
-
-from message_data.projects.navigate import T35_POLICY as NAVIGATE_SCENARIO
-from message_data.projects.transport_futures import SCENARIO as FUTURES_SCENARIO
 
 log = logging.getLogger(__name__)
 
@@ -41,9 +41,10 @@ class Config(ConfigHelper):
     """Configuration for MESSAGEix-Transport.
 
     This dataclass stores and documents all configuration settings required and used by
-    :mod:`~message_data.model.transport`. It also handles (via :meth:`.from_context`)
-    loading configuration and values from files like :file:`config.yaml`, while
-    respecting higher-level configuration, for instance :attr:`.model.Config.regions`.
+    :mod:`~message_ix_models.model.transport`. It also handles (via
+    :meth:`.from_context`) loading configuration and values from files like
+    :file:`config.yaml`, while respecting higher-level configuration, for instance
+    :attr:`.model.Config.regions`.
     """
 
     #: Information about the base model.
@@ -208,8 +209,8 @@ class Config(ConfigHelper):
 
     #: **Temporary** setting for the SSP 2024 project: indicates whether the base
     #: scenario used is a policy (carbon pricing) scenario, or not. This currently does
-    #: not affect *any* behaviour of :mod:`~message_data.model.transport` except the
-    #: selection of a base scenario via :func:`.base_scenario_url`.
+    #: not affect *any* behaviour of :mod:`~message_ix_models.model.transport` except
+    #: the selection of a base scenario via :func:`.base_scenario_url`.
     policy: bool = False
 
     #: Flags for distinct scenario features according to projects. In addition to

--- a/message_ix_models/model/transport/config.py
+++ b/message_ix_models/model/transport/config.py
@@ -11,7 +11,7 @@ from message_ix_models.project.navigate import T35_POLICY as NAVIGATE_SCENARIO
 from message_ix_models.project.ssp import SSP_2024, ssp_field
 from message_ix_models.project.transport_futures import SCENARIO as FUTURES_SCENARIO
 from message_ix_models.report.util import as_quantity
-from message_ix_models.util import identify_nodes, private_data_path
+from message_ix_models.util import identify_nodes, package_data_path
 from message_ix_models.util.config import ConfigHelper
 
 log = logging.getLogger(__name__)
@@ -353,7 +353,7 @@ class Config(ConfigHelper):
         try:
             # Update with region-specific configuration
             config.read_file(
-                private_data_path("transport", context.model.regions, "config.yaml")
+                package_data_path("transport", context.model.regions, "config.yaml")
             )
         except FileNotFoundError as e:
             log.warning(e)

--- a/message_ix_models/model/transport/data.py
+++ b/message_ix_models/model/transport/data.py
@@ -10,6 +10,7 @@ import pandas as pd
 from genno import Computer, Key, Quantity
 from genno.core.key import single_key
 from message_ix import make_df
+
 from message_ix_models import ScenarioInfo
 from message_ix_models.tools.exo_data import ExoDataSource, register_source
 from message_ix_models.util import (
@@ -177,7 +178,7 @@ def navigate_ele(
 
     Currently only items (1) and (2) are implemented.
     """
-    from message_data.projects.navigate import T35_POLICY
+    from message_ix_models.project.navigate import T35_POLICY
 
     if not (T35_POLICY.ELE & config["transport"].project["navigate"]):
         return dict()
@@ -302,7 +303,7 @@ class MERtoPPP(ExoDataSource):
     def __init__(self, source, source_kw):
         from .util import path_fallback
 
-        if not source.startswith("message_data.model.transport"):
+        if not source.startswith("message_ix_models.model.transport"):
             raise ValueError(source)
         elif source_kw.pop("measure") != "MERtoPPP":
             raise ValueError(source_kw)

--- a/message_ix_models/model/transport/data.py
+++ b/message_ix_models/model/transport/data.py
@@ -19,7 +19,7 @@ from message_ix_models.util import (
     make_matched_dfs,
     make_source_tech,
     merge_data,
-    private_data_path,
+    package_data_path,
     same_node,
 )
 from message_ix_models.util.ixmp import rename_dims
@@ -239,7 +239,7 @@ class IEA_Future_of_Trucks(ExoDataSource):
 
         self.measure = source_kw.pop("measure")
         self.name, self._unit = self._name_unit[self.measure]
-        self.path = private_data_path("transport", f"iea-2017-t4-{self.measure}.csv")
+        self.path = package_data_path("transport", f"iea-2017-t4-{self.measure}.csv")
 
     def __call__(self):
         from genno.operator import load_file

--- a/message_ix_models/model/transport/demand.py
+++ b/message_ix_models/model/transport/demand.py
@@ -9,6 +9,7 @@ import pandas as pd
 from dask.core import literal
 from genno import Computer, KeySeq
 from message_ix import make_df
+
 from message_ix_models.util import broadcast
 
 from .key import (

--- a/message_ix_models/model/transport/emission.py
+++ b/message_ix_models/model/transport/emission.py
@@ -8,6 +8,7 @@ from genno import Quantity
 from genno.operator import convert_units, load_file, mul
 from iam_units import registry
 from message_ix import make_df
+
 from message_ix_models import Context
 from message_ix_models.util import private_data_path
 

--- a/message_ix_models/model/transport/emission.py
+++ b/message_ix_models/model/transport/emission.py
@@ -10,7 +10,7 @@ from iam_units import registry
 from message_ix import make_df
 
 from message_ix_models import Context
-from message_ix_models.util import private_data_path
+from message_ix_models.util import package_data_path
 
 from .util import path_fallback
 
@@ -32,7 +32,7 @@ def get_emissions_data(context: Context) -> Dict[str, pd.DataFrame]:
 def get_intensity(context: Context) -> "AnyQuantity":
     """Load emissions intensity data from a file."""
     # FIXME use through the build computer
-    return load_file(private_data_path("transport", "fuel-emi-intensity.csv"))
+    return load_file(package_data_path("transport", "fuel-emi-intensity.csv"))
 
 
 def strip_emissions_data(scenario, context):

--- a/message_ix_models/model/transport/factor.py
+++ b/message_ix_models/model/transport/factor.py
@@ -29,6 +29,7 @@ from typing import (
 import pandas as pd
 from genno import Computer, Key, Quantity
 from genno import operator as g
+
 from message_ix_models.project.ssp import SSP_2024
 
 if TYPE_CHECKING:

--- a/message_ix_models/model/transport/files.py
+++ b/message_ix_models/model/transport/files.py
@@ -8,6 +8,7 @@ from .key import pdt_cap
 if TYPE_CHECKING:
     import genno
     from genno.core.key import KeyLike
+
     from message_ix_models import Context
 
 #: List of all :class:`.ExogenousDataFile`.

--- a/message_ix_models/model/transport/freight.py
+++ b/message_ix_models/model/transport/freight.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING, Dict, List
 import pandas as pd
 from genno import Computer
 from iam_units import registry
+from sdmx.model.v21 import Code
+
 from message_ix_models import Context
 from message_ix_models.model.structure import get_codes
 from message_ix_models.util import broadcast, make_io, make_matched_dfs, same_node
-from sdmx.model.v21 import Code
 
 from .util import input_commodity_level
 

--- a/message_ix_models/model/transport/groups.py
+++ b/message_ix_models/model/transport/groups.py
@@ -130,6 +130,7 @@ def urban_rural_shares(pop: Quantity, config: dict) -> Quantity:
         Dimensions: at least area_type, possibly also n, y. Units: dimensionless.
     """
     from genno.operator import div
+
     from message_ix_models.util import broadcast
 
     if "area_type" in pop.dims:

--- a/message_ix_models/model/transport/ikarus.py
+++ b/message_ix_models/model/transport/ikarus.py
@@ -22,7 +22,7 @@ from message_ix_models.util import (
     convert_units,
     make_matched_dfs,
     nodes_ex_world,
-    private_data_path,
+    package_data_path,
     same_node,
     same_time,
     series_of_pint_quantity,
@@ -164,7 +164,7 @@ def read_ikarus_data(occupancy, k_output, k_inv_cost):
     """
     # Open the input file using openpyxl
     wb = load_workbook(
-        private_data_path("transport", FILE), read_only=True, data_only=True
+        package_data_path("transport", FILE), read_only=True, data_only=True
     )
     # Open the 'updateTRPdata' sheet
     sheet = wb["updateTRPdata"]

--- a/message_ix_models/model/transport/ikarus.py
+++ b/message_ix_models/model/transport/ikarus.py
@@ -12,6 +12,8 @@ from genno import Computer, Key, KeySeq, Quantity, quote
 from genno.core.key import single_key
 from iam_units import registry
 from message_ix import make_df
+from openpyxl import load_workbook
+
 from message_ix_models.model.structure import get_codes
 from message_ix_models.util import (
     ScenarioInfo,
@@ -25,7 +27,6 @@ from message_ix_models.util import (
     same_time,
     series_of_pint_quantity,
 )
-from openpyxl import load_workbook
 
 from .non_ldv import UNITS
 from .util import input_commodity_level

--- a/message_ix_models/model/transport/ldv.py
+++ b/message_ix_models/model/transport/ldv.py
@@ -12,6 +12,9 @@ from genno import Computer, quote
 from genno.operator import load_file
 from message_ix import make_df
 from message_ix.report.operator import as_message_df
+from openpyxl import load_workbook
+from sdmx.model.v21 import Code
+
 from message_ix_models.model import disutility
 from message_ix_models.model.structure import get_codes
 from message_ix_models.util import (
@@ -28,8 +31,6 @@ from message_ix_models.util import (
     same_node,
 )
 from message_ix_models.util.ixmp import rename_dims
-from openpyxl import load_workbook
-from sdmx.model.v21 import Code
 
 from .emission import ef_for_input
 from .operator import extend_y

--- a/message_ix_models/model/transport/ldv.py
+++ b/message_ix_models/model/transport/ldv.py
@@ -11,7 +11,6 @@ import pandas as pd
 from genno import Computer, quote
 from genno.operator import load_file
 from message_ix import make_df
-from message_ix.report.operator import as_message_df
 from openpyxl import load_workbook
 from sdmx.model.v21 import Code
 
@@ -27,6 +26,7 @@ from message_ix_models.util import (
     make_io,
     make_matched_dfs,
     merge_data,
+    minimum_version,
     package_data_path,
     same_node,
 )
@@ -453,6 +453,7 @@ def get_dummy(context) -> Dict[str, pd.DataFrame]:
     return data
 
 
+@minimum_version("message_ix 3.6")
 def capacity_factor(
     qty: "AnyQuantity", t_ldv: dict, y, y_broadcast: "AnyQuantity"
 ) -> Dict[str, pd.DataFrame]:
@@ -476,6 +477,11 @@ def capacity_factor(
         All periods, including pre-model periods.
     """
     from genno.operator import convert_units
+
+    try:
+        from message_ix.report.operator import as_message_df
+    except ImportError:
+        from message_ix.reporting.computations import as_message_df
 
     # TODO determine units from technology annotations
     data = convert_units(qty.expand_dims(y=y) * y_broadcast, "Mm / year")

--- a/message_ix_models/model/transport/ldv.py
+++ b/message_ix_models/model/transport/ldv.py
@@ -27,7 +27,7 @@ from message_ix_models.util import (
     make_io,
     make_matched_dfs,
     merge_data,
-    private_data_path,
+    package_data_path,
     same_node,
 )
 from message_ix_models.util.ixmp import rename_dims
@@ -218,7 +218,7 @@ def read_USTIMES_MA3T(nodes: List[str], subdir=None) -> Mapping[str, "AnyQuantit
     particular context settings.
     """
     # Open workbook
-    path = private_data_path("transport", subdir or "", FILE)
+    path = package_data_path("transport", subdir or "", FILE)
     wb = load_workbook(path, read_only=True, data_only=True)
 
     # Tables
@@ -272,7 +272,7 @@ def read_USTIMES_MA3T_2(nodes: Any, subdir=None) -> Dict[str, "AnyQuantity"]:
     result = {}
     for name in "fix_cost", "fuel economy", "inv_cost":
         result[name] = load_file(
-            path=private_data_path(
+            path=package_data_path(
                 "transport", subdir or "", f"ldv-{name.replace(' ', '-')}.csv"
             ),
             dims=rename_dims(),

--- a/message_ix_models/model/transport/migrate.py
+++ b/message_ix_models/model/transport/migrate.py
@@ -13,7 +13,7 @@ from itertools import product
 import pandas as pd
 from tqdm import tqdm
 
-from message_data.tools.messagev import CHNFile, DICFile, INPFile
+from message_ix_models.tools.messagev import CHNFile, DICFile, INPFile
 
 log = logging.getLogger(__name__)
 

--- a/message_ix_models/model/transport/non_ldv.py
+++ b/message_ix_models/model/transport/non_ldv.py
@@ -18,7 +18,7 @@ from message_ix_models.util import (
     make_io,
     make_matched_dfs,
     merge_data,
-    private_data_path,
+    package_data_path,
     same_node,
     same_time,
 )
@@ -105,7 +105,7 @@ def prepare_computer(c: Computer):
     )
     ####
     c.add(e[1] / "flow", "select", e[0], indexers=dict(flow="OTHER"), drop=True)
-    path = private_data_path("transport", context.regions, "energy-other.csv")
+    path = package_data_path("transport", context.regions, "energy-other.csv")
     kw = dict(header_comment=ENERGY_OTHER_HEADER)
     c.add("energy other csv", "write_report", e[1] / "flow", path=path, kwargs=kw)
 

--- a/message_ix_models/model/transport/non_ldv.py
+++ b/message_ix_models/model/transport/non_ldv.py
@@ -11,6 +11,8 @@ import pandas as pd
 from genno import Computer, Key, KeySeq, MissingKeyError, Quantity, quote
 from genno.core.key import KeyLike, iter_keys, single_key
 from message_ix import make_df
+from sdmx.model.v21 import Code
+
 from message_ix_models.util import (
     broadcast,
     make_io,
@@ -20,7 +22,6 @@ from message_ix_models.util import (
     same_node,
     same_time,
 )
-from sdmx.model.v21 import Code
 
 from .emission import ef_for_input
 

--- a/message_ix_models/model/transport/operator.py
+++ b/message_ix_models/model/transport/operator.py
@@ -26,8 +26,11 @@ import xarray as xr
 from genno import Computer, KeySeq, Operator, quote
 from genno.operator import apply_units, rename_dims
 from genno.testing import assert_qty_allclose, assert_units
+from sdmx.model.v21 import Code
+
 from message_ix_models import ScenarioInfo
 from message_ix_models.model.structure import get_codelist, get_codes
+from message_ix_models.project.navigate import T35_POLICY
 from message_ix_models.report.operator import compound_growth
 from message_ix_models.report.util import as_quantity
 from message_ix_models.util import (
@@ -37,19 +40,16 @@ from message_ix_models.util import (
     nodes_ex_world,
     show_versions,
 )
-from sdmx.model.v21 import Code
-
-from message_data.projects.navigate import T35_POLICY
 
 from .config import Config
 
 if TYPE_CHECKING:
     from genno.types import AnyQuantity
     from message_ix import Scenario
-    from message_ix_models import Context
     from xarray.core.types import Dims
 
-    import message_data.model.transport.factor
+    import message_ix_models.model.transport.factor
+    from message_ix_models import Context
 
 log = logging.getLogger(__name__)
 
@@ -468,7 +468,7 @@ def factor_ssp(
     nodes: List[str],
     years: List[int],
     *others: List,
-    info: "message_data.model.transport.factor.Factor",
+    info: "message_ix_models.model.transport.factor.Factor",
     extra_dims: Optional[Sequence[str]] = None,
 ) -> "AnyQuantity":
     """Return a scaling factor for an SSP realization."""
@@ -643,9 +643,9 @@ def merge_data(
 
 def iea_eei_fv(name: str, config: Dict) -> "AnyQuantity":
     """Returns base-year demand for freight from IEA EEI, with dimensions n-c-y."""
-    from message_data.tools import iea_eei  # type: ignore [attr-defined]
+    from message_ix_models.tools.iea import eei
 
-    result = iea_eei.as_quantity(name, config["regions"])
+    result = eei.as_quantity(name, config["regions"])  # type: ignore [attr-defined]
     ym1 = result.coords["y"].data[-1]
 
     log.info(f"Use y={ym1} data for base-year freight transport activity")

--- a/message_ix_models/model/transport/report.py
+++ b/message_ix_models/model/transport/report.py
@@ -10,6 +10,7 @@ import pandas as pd
 from genno import Computer, Key, KeySeq, MissingKeyError
 from genno.core.key import single_key
 from message_ix import Reporter
+
 from message_ix_models import Context, ScenarioInfo
 from message_ix_models.report.util import add_replacements
 
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     import ixmp
     from genno import Computer
     from genno.types import AnyQuantity
+
     from message_ix_models import Spec
 
 log = logging.getLogger(__name__)
@@ -384,7 +386,7 @@ def callback(rep: Reporter, context: Context) -> None:
 
 def configure_legacy_reporting(config: dict) -> None:
     """Callback to configure the legacy reporting."""
-    from message_data.tools.post_processing.default_tables import COMMODITY
+    from message_ix_models.report.legacy.default_tables import COMMODITY
 
     # NB the legacy reporting doesn't pass a context object to the hook that calls this
     #    function, so get an instance directly

--- a/message_ix_models/model/transport/roadmap.py
+++ b/message_ix_models/model/transport/roadmap.py
@@ -15,8 +15,9 @@ The countries belonging to the Africa region in the Roadmap 1.0 model are:
 """
 
 import pandas as pd
-from message_ix_models.util import private_data_path
 from plotnine import save_as_pdf_pages
+
+from message_ix_models.util import private_data_path
 
 #: Name of the file containing the data.
 FILE = "RoadmapResults_2017.xlsx"
@@ -116,7 +117,8 @@ def get_roadmap_data(context, region=("Africa", "R11_AFR"), years=None, plot=Fal
     Returns
     -------
     DataFrame : pandas.DataFrame
-        Same format as returned by :func:`~message_data.tools.iea_eei.get_eei_data`.
+        Same format as returned by
+        :func:`~message_ix_models.tools.iea.eei.get_eei_data`.
     """
     # Load and process data for Africa
     # Check years provided

--- a/message_ix_models/model/transport/roadmap.py
+++ b/message_ix_models/model/transport/roadmap.py
@@ -17,7 +17,7 @@ The countries belonging to the Africa region in the Roadmap 1.0 model are:
 import pandas as pd
 from plotnine import save_as_pdf_pages
 
-from message_ix_models.util import private_data_path
+from message_ix_models.util import package_data_path
 
 #: Name of the file containing the data.
 FILE = "RoadmapResults_2017.xlsx"
@@ -129,7 +129,7 @@ def get_roadmap_data(context, region=("Africa", "R11_AFR"), years=None, plot=Fal
             assert x in ALL_YEARS
     # Read xlsx file
     df = pd.read_excel(
-        private_data_path("transport", FILE), sheet_name="Model Results", header=0
+        package_data_path("transport", FILE), sheet_name="Model Results", header=0
     )
     df = df[(df["Year"].isin(years)) & (df["Roadmap_Region"] == region[0])].reset_index(
         drop=True

--- a/message_ix_models/model/transport/structure.py
+++ b/message_ix_models/model/transport/structure.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, List, Sequence, Union
 
+from sdmx.model.common import Annotation, Code
+
 from message_ix_models import ScenarioInfo, Spec
 from message_ix_models.model import disutility
 from message_ix_models.model.structure import generate_set_elements, get_region_codes
 from message_ix_models.util import load_private_data, private_data_path
-from sdmx.model.common import Annotation, Code
 
 from .util import path_fallback
 

--- a/message_ix_models/model/transport/structure.py
+++ b/message_ix_models/model/transport/structure.py
@@ -5,7 +5,7 @@ from sdmx.model.common import Annotation, Code
 from message_ix_models import ScenarioInfo, Spec
 from message_ix_models.model import disutility
 from message_ix_models.model.structure import generate_set_elements, get_region_codes
-from message_ix_models.util import load_private_data, private_data_path
+from message_ix_models.util import load_package_data, package_data_path
 
 from .util import path_fallback
 
@@ -68,8 +68,8 @@ def make_spec(regions: str) -> Spec:
 
         # Load and store the data from the YAML file: either in a subdirectory for
         # context.model.regions, or the top-level data directory
-        path = path_fallback(regions, fn).relative_to(private_data_path())
-        tmp[name] = load_private_data(*path.parts)
+        path = path_fallback(regions, fn).relative_to(package_data_path())
+        tmp[name] = load_package_data(*path.parts)
 
     # Merge contents of technology.yaml into set.yaml
     sets.update(tmp.pop("set"))

--- a/message_ix_models/model/transport/testing.py
+++ b/message_ix_models/model/transport/testing.py
@@ -1,14 +1,15 @@
-"""Utilities for testing :mod:`~message_data.model.transport`."""
+"""Utilities for testing :mod:`~message_ix_models.model.transport`."""
 
 import logging
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Optional, Tuple
 
-import message_ix_models.report
 import pytest
 from genno import Computer
 from message_ix import Reporter, Scenario
+
+import message_ix_models.report
 from message_ix_models import Context, ScenarioInfo, testing
 from message_ix_models.report.sim import add_simulated_solution
 from message_ix_models.util._logging import silence_log
@@ -76,7 +77,7 @@ def built_transport(
 
         # Optionally silence logs for code used via build.main()
         log_cm = (
-            silence_log("genno message_data.model.transport message_ix_models")
+            silence_log("genno message_ix_models.model.transport message_ix_models")
             if quiet
             else nullcontext()
         )

--- a/message_ix_models/model/transport/testing.py
+++ b/message_ix_models/model/transport/testing.py
@@ -39,6 +39,9 @@ MARK = {
     5: lambda f: pytest.mark.xfail(
         raises=FileNotFoundError, reason=f"Requires non-public data ({f})"
     ),
+    6: pytest.mark.xfail(
+        reason="Temporary, for https://github.com/iiasa/message-ix-models/pull/207"
+    ),
 }
 
 

--- a/message_ix_models/model/transport/testing.py
+++ b/message_ix_models/model/transport/testing.py
@@ -1,6 +1,7 @@
 """Utilities for testing :mod:`~message_ix_models.model.transport`."""
 
 import logging
+import platform
 from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Mapping, Optional, Tuple, Union
@@ -12,7 +13,8 @@ from message_ix import Reporter, Scenario
 import message_ix_models.report
 from message_ix_models import Context, ScenarioInfo, testing
 from message_ix_models.report.sim import add_simulated_solution
-from message_ix_models.util._logging import silence_log
+from message_ix_models.util import silence_log
+from message_ix_models.util.graphviz import HAS_GRAPHVIZ
 
 from . import Config, build
 
@@ -41,6 +43,10 @@ MARK = {
     ),
     6: pytest.mark.xfail(
         reason="Temporary, for https://github.com/iiasa/message-ix-models/pull/207"
+    ),
+    7: pytest.mark.xfail(
+        condition=testing.GHA and platform.system() == "Darwin" and not HAS_GRAPHVIZ,
+        reason="Graphviz missing on macos-13 GitHub Actions runners",
     ),
 }
 

--- a/message_ix_models/model/transport/testing.py
+++ b/message_ix_models/model/transport/testing.py
@@ -23,19 +23,23 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Common marks for transport code
-MARK = (
-    pytest.mark.xfail(
+MARK = {
+    0: pytest.mark.xfail(
         reason="Missing R14 input data/assumptions", raises=FileNotFoundError
     ),
-    pytest.mark.skip(
+    1: pytest.mark.skip(
         reason="Currently only possible with regions=R12 input data/assumptions",
     ),
-    lambda t: pytest.mark.xfail(
+    2: lambda t: pytest.mark.xfail(
         reason="Missing input data/assumptions for this node codelist", raises=t
     ),
-    pytest.mark.xfail(raises=ValueError, reason="Missing ISR/mer-to-ppp.csv"),
-    pytest.mark.xfail(reason="Currently unsupported"),
-)
+    3: pytest.mark.xfail(raises=ValueError, reason="Missing ISR/mer-to-ppp.csv"),
+    4: pytest.mark.xfail(reason="Currently unsupported"),
+    # Tests that fail with data that cannot be migrated from message_data
+    5: lambda f: pytest.mark.xfail(
+        raises=FileNotFoundError, reason=f"Requires non-public data ({f})"
+    ),
+}
 
 
 def assert_units(

--- a/message_ix_models/model/transport/util.py
+++ b/message_ix_models/model/transport/util.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Union
 
 import pandas as pd
+
 from message_ix_models import Context
 from message_ix_models.model.structure import get_codes
 from message_ix_models.util import private_data_path

--- a/message_ix_models/model/transport/util.py
+++ b/message_ix_models/model/transport/util.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from message_ix_models import Context
 from message_ix_models.model.structure import get_codes
-from message_ix_models.util import private_data_path
+from message_ix_models.util import package_data_path
 
 if TYPE_CHECKING:
     import numbers
@@ -71,8 +71,8 @@ def path_fallback(context_or_regions: Union[Context, str], *parts) -> Path:
         regions = context_or_regions.model.regions
 
     candidates = (
-        private_data_path("transport", regions, *parts),
-        private_data_path("transport", *parts),
+        package_data_path("transport", regions, *parts),
+        package_data_path("transport", *parts),
     )
 
     for c in candidates:

--- a/message_ix_models/model/transport/workflow.py
+++ b/message_ix_models/model/transport/workflow.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal, Optional
 from genno import KeyExistsError
 
 from message_ix_models.project.ssp import SSP_2024
-from message_ix_models.util import private_data_path
+from message_ix_models.util import package_data_path
 
 if TYPE_CHECKING:
     import message_ix_models
@@ -44,7 +44,7 @@ def base_scenario_url(
 
     if method == "auto":
         # Load URL info from file
-        with open(private_data_path("transport", "base-scenario-url.json")) as f:
+        with open(package_data_path("transport", "base-scenario-url.json")) as f:
             info = json.load(f)
 
         # Identify a key that matches the settings on `config`

--- a/message_ix_models/model/transport/workflow.py
+++ b/message_ix_models/model/transport/workflow.py
@@ -5,13 +5,14 @@ from itertools import product
 from typing import TYPE_CHECKING, Literal, Optional
 
 from genno import KeyExistsError
+
 from message_ix_models.project.ssp import SSP_2024
 from message_ix_models.util import private_data_path
 
 if TYPE_CHECKING:
     import message_ix_models
 
-    from message_data.model.transport.config import Config
+    from .config import Config
 
 log = logging.getLogger(__name__)
 
@@ -136,11 +137,10 @@ def generate(
     **options,
 ):
     from message_ix_models import Workflow
+    from message_ix_models.model.workflow import Config as SolveConfig
+    from message_ix_models.model.workflow import solve
+    from message_ix_models.project import navigate
     from message_ix_models.report import register, report
-
-    from message_data.model.workflow import Config as SolveConfig
-    from message_data.projects import navigate
-    from message_data.projects.navigate.workflow import solve
 
     from . import build
     from .config import Config

--- a/message_ix_models/model/workflow.py
+++ b/message_ix_models/model/workflow.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from message_ix import Scenario
+
 from message_ix_models.util.config import ConfigHelper
 
 if TYPE_CHECKING:

--- a/message_ix_models/project/engage/workflow.py
+++ b/message_ix_models/project/engage/workflow.py
@@ -1,9 +1,12 @@
 """ENGAGE workflow pieces for reuse with :class:`message_ix_models.Workflow`.
 
-These functions emulate the collective behaviour of :class:`.engage.runscript_main`,
-:class:`.engage.scenario_runner` and the associated configuration, but are adapted to be
-reusable, particularly in the Workflow pattern used in e.g. :mod:`.projects.navigate`.
+These functions emulate the collective behaviour of
+:class:`message_data.engage.runscript_main`,
+:class:`message_data.engage.scenario_runner` and the associated configuration, but are
+adapted to be reusable, particularly in the Workflow pattern used in e.g.
+:mod:`.project.navigate`.
 """
+
 import logging
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
@@ -11,14 +14,19 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from iam_units import convert_gwp
 from message_ix import Scenario
+
 from message_ix_models import Context, ScenarioInfo
+from message_ix_models.model.workflow import Config, solve
 from message_ix_models.util import broadcast, identify_nodes
 from message_ix_models.workflow import Workflow
 
-from message_data.model.workflow import Config, solve
-
-from .runscript_main import glb_co2_relation as RELATION_GLOBAL_CO2
-from .scenario_runner import ScenarioRunner
+try:
+    # NB These modules have not been migrated from message_data.projects.engage
+    from .runscript_main import glb_co2_relation as RELATION_GLOBAL_CO2
+    from .scenario_runner import ScenarioRunner
+except ImportError:
+    RELATION_GLOBAL_CO2: str = ""
+    ScenarioRunner = type("ScenarioRunner", (), {})
 
 log = logging.getLogger(__name__)
 

--- a/message_ix_models/project/navigate/__init__.py
+++ b/message_ix_models/project/navigate/__init__.py
@@ -15,14 +15,14 @@ from sdmx.model.v21 import Annotation, Code
 
 from message_ix_models.model.workflow import Config as WfConfig
 from message_ix_models.project.engage.workflow import PolicyConfig
-from message_ix_models.util import MESSAGE_DATA_PATH, as_codes
+from message_ix_models.util import MESSAGE_MODELS_PATH, as_codes
 
 log = logging.getLogger(__name__)
 
 ixmp.config.register(
     "navigate workflow dir",
     Path,
-    cast(Path, MESSAGE_DATA_PATH).parent.joinpath("navigate-workflow"),
+    cast(Path, MESSAGE_MODELS_PATH).parent.joinpath("navigate-workflow"),
 )
 
 

--- a/message_ix_models/project/navigate/__init__.py
+++ b/message_ix_models/project/navigate/__init__.py
@@ -11,11 +11,11 @@ from typing import Dict, Generator, List, Literal, Mapping, Optional, Union, cas
 
 import ixmp
 import yaml
-from message_ix_models.util import MESSAGE_DATA_PATH, as_codes
 from sdmx.model.v21 import Annotation, Code
 
-from message_data.model.workflow import Config as WfConfig
-from message_data.projects.engage.workflow import PolicyConfig
+from message_ix_models.model.workflow import Config as WfConfig
+from message_ix_models.project.engage.workflow import PolicyConfig
+from message_ix_models.util import MESSAGE_DATA_PATH, as_codes
 
 log = logging.getLogger(__name__)
 

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -51,6 +51,24 @@ def pytest_addoption(parser):
 # Fixtures
 
 
+@pytest.fixture(scope="function")
+def preserve_report_callbacks():
+    """Protect :data:`.report.CALLBACKS` from effects of a test function.
+
+    Use this fixture for test functions that call :func:`.report.register` to avoid
+    changing the global/default configuration for other tests.
+    """
+
+    from message_ix_models import report
+
+    try:
+        tmp = report.CALLBACKS.copy()
+        yield
+    finally:
+        report.CALLBACKS.clear()
+        report.CALLBACKS.extend(tmp)
+
+
 @pytest.fixture(scope="session")
 def session_context(pytestconfig, tmp_env):
     """A :class:`.Context` connected to a temporary, in-memory database.

--- a/message_ix_models/tests/model/transport/test_base.py
+++ b/message_ix_models/tests/model/transport/test_base.py
@@ -2,9 +2,9 @@ import numpy as np
 from genno import Computer, KeySeq
 from genno.operator import relabel
 from genno.testing import random_qty
-from message_ix_models.model.structure import get_codes
 
-from message_data.model.transport.base import smooth
+from message_ix_models.model.structure import get_codes
+from message_ix_models.model.transport.base import smooth
 
 
 def test_smooth(recwarn) -> None:

--- a/message_ix_models/tests/model/transport/test_base.py
+++ b/message_ix_models/tests/model/transport/test_base.py
@@ -7,6 +7,7 @@ from message_ix_models.model.structure import get_codes
 from message_ix_models.model.transport.base import smooth
 
 
+@smooth.minimum_version
 def test_smooth(recwarn) -> None:
     c = Computer()
 

--- a/message_ix_models/tests/model/transport/test_build.py
+++ b/message_ix_models/tests/model/transport/test_build.py
@@ -6,12 +6,12 @@ import ixmp
 import pytest
 from genno import Quantity
 from genno.testing import assert_units
-from message_ix_models.model.structure import get_codes
-from message_ix_models.testing import bare_res
 from pytest import mark, param
 
-from message_data.model.transport import build, report, structure
-from message_data.model.transport.testing import MARK, configure_build
+from message_ix_models.model.structure import get_codes
+from message_ix_models.model.transport import build, report, structure
+from message_ix_models.model.transport.testing import MARK, configure_build
+from message_ix_models.testing import bare_res
 
 log = logging.getLogger(__name__)
 

--- a/message_ix_models/tests/model/transport/test_build.py
+++ b/message_ix_models/tests/model/transport/test_build.py
@@ -36,6 +36,7 @@ def test_make_spec(regions_arg, regions_exp, years):
     assert expected == spec["require"].set["node"]
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions, years, ldv, nonldv, solve",
     [
@@ -161,6 +162,7 @@ def test_build_existing(tmp_path, test_context, url, solve=False):
     del mp
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions, years, N_node, options",
     [

--- a/message_ix_models/tests/model/transport/test_build.py
+++ b/message_ix_models/tests/model/transport/test_build.py
@@ -118,6 +118,7 @@ def test_build_bare_res(
         # "ixmp://local/MESSAGEix-Transport on ENGAGE_SSP2_v4.1.7/baseline",
     ),
 )
+@pytest.mark.usefixtures("preserve_report_callbacks")
 def test_build_existing(tmp_path, test_context, url, solve=False):
     """Test that model.transport.build works on certain existing scenarios.
 

--- a/message_ix_models/tests/model/transport/test_build.py
+++ b/message_ix_models/tests/model/transport/test_build.py
@@ -36,6 +36,7 @@ def test_make_spec(regions_arg, regions_exp, years):
     assert expected == spec["require"].set["node"]
 
 
+@MARK[7]
 @build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions, years, ldv, nonldv, solve",

--- a/message_ix_models/tests/model/transport/test_callback.py
+++ b/message_ix_models/tests/model/transport/test_callback.py
@@ -1,6 +1,6 @@
 import pytest
 
-from message_data.model.transport.callback import main
+from message_ix_models.model.transport.callback import main
 
 
 @pytest.mark.xfail(reason="Don't actually attempt to run the code.")

--- a/message_ix_models/tests/model/transport/test_config.py
+++ b/message_ix_models/tests/model/transport/test_config.py
@@ -1,9 +1,9 @@
 import pytest
-from message_ix_models.project.ssp import SSP_2017, SSP_2024
 
-from message_data.model.transport.config import Config
-from message_data.projects.navigate import T35_POLICY
-from message_data.projects.transport_futures import SCENARIO as TF_SCENARIO
+from message_ix_models.model.transport.config import Config
+from message_ix_models.project.navigate import T35_POLICY
+from message_ix_models.project.ssp import SSP_2017, SSP_2024
+from message_ix_models.project.transport_futures import SCENARIO as TF_SCENARIO
 
 FUTURES = (
     ("", TF_SCENARIO.BASE),

--- a/message_ix_models/tests/model/transport/test_data.py
+++ b/message_ix_models/tests/model/transport/test_data.py
@@ -3,12 +3,11 @@ import pytest
 from genno import Key, Quantity
 from iam_units import registry
 
-from message_data.model.transport import files, testing
-from message_data.model.transport.CHN_IND import get_chn_ind_data, get_chn_ind_pop
-from message_data.model.transport.roadmap import get_roadmap_data
-from message_data.model.transport.testing import MARK
-from message_data.projects.navigate import T35_POLICY
-from message_data.testing import assert_units
+from message_ix_models.model.transport import files, testing
+from message_ix_models.model.transport.CHN_IND import get_chn_ind_data, get_chn_ind_pop
+from message_ix_models.model.transport.roadmap import get_roadmap_data
+from message_ix_models.model.transport.testing import MARK, assert_units
+from message_ix_models.project.navigate import T35_POLICY
 
 
 @pytest.mark.parametrize("file", files.FILES, ids=lambda f: "-".join(f.parts))

--- a/message_ix_models/tests/model/transport/test_data.py
+++ b/message_ix_models/tests/model/transport/test_data.py
@@ -3,13 +3,14 @@ import pytest
 from genno import Key, Quantity
 from iam_units import registry
 
-from message_ix_models.model.transport import files, testing
+from message_ix_models.model.transport import build, files, testing
 from message_ix_models.model.transport.CHN_IND import get_chn_ind_data, get_chn_ind_pop
 from message_ix_models.model.transport.roadmap import get_roadmap_data
 from message_ix_models.model.transport.testing import MARK, assert_units
 from message_ix_models.project.navigate import T35_POLICY
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize("file", files.FILES, ids=lambda f: "-".join(f.parts))
 def test_data_files(test_context, file):
     """Input data can be read."""
@@ -62,6 +63,7 @@ def test_get_afr_data(test_context, region, length):
     ]
 
 
+@build.get_computer.minimum_version
 def test_get_freight_data(test_context, regions="R12", years="B"):
     ctx = test_context
     c, info = testing.configure_build(ctx, regions=regions, years=years)
@@ -78,6 +80,7 @@ def test_get_freight_data(test_context, regions="R12", years="B"):
     } == set(result.keys())
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize("regions", ["R11", "R12"])
 def test_get_non_ldv_data(test_context, regions, years="B"):
     """:mod:`.non_ldv` returns the expected data."""
@@ -199,6 +202,7 @@ def test_get_chn_ind_pop():
     ]
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize("years", ["A", "B"])
 @pytest.mark.parametrize(
     "regions", [pytest.param("ISR", marks=MARK[3]), "R11", "R12", "R14"]

--- a/message_ix_models/tests/model/transport/test_data.py
+++ b/message_ix_models/tests/model/transport/test_data.py
@@ -25,6 +25,7 @@ def test_data_files(test_context, file):
     assert set(Key(result).dims) == set(file.key.dims)
 
 
+@MARK[5]("RoadmapResults_2017.xlsx")
 @pytest.mark.parametrize(
     "region, length",
     [

--- a/message_ix_models/tests/model/transport/test_demand.py
+++ b/message_ix_models/tests/model/transport/test_demand.py
@@ -6,12 +6,12 @@ import genno
 import pytest
 from genno import Key
 from genno.testing import assert_units
-from message_ix_models.model.structure import get_codes
-from message_ix_models.project.ssp import SSP_2017, SSP_2024
 from pytest import param
 
-from message_data.model.transport import Config, demand, testing
-from message_data.model.transport.testing import MARK
+from message_ix_models.model.structure import get_codes
+from message_ix_models.model.transport import Config, demand, testing
+from message_ix_models.model.transport.testing import MARK
+from message_ix_models.project.ssp import SSP_2017, SSP_2024
 
 log = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ def test_exo(test_context, tmp_path, regions, years, N_node, options):
     ],
 )
 def test_exo_pdt(test_context, ssp, regions="R12", years="B"):
-    from message_data.testing import assert_units
+    from message_ix_models.model.transport.testing import assert_units
 
     c, info = testing.configure_build(
         test_context, regions=regions, years=years, options=dict(ssp=ssp)
@@ -261,7 +261,7 @@ def test_pdt_per_capita(
     Moved from :mod:`.test_operator`.
     """
     # TODO After #551, this is largely similar to test_exo and test_pdt; merge
-    from message_data.model.transport.key import pdt_cap
+    from message_ix_models.model.transport.key import pdt_cap
 
     c, info = testing.configure_build(
         test_context, tmp_path=tmp_path, regions=regions, years=years, options=options

--- a/message_ix_models/tests/model/transport/test_demand.py
+++ b/message_ix_models/tests/model/transport/test_demand.py
@@ -9,7 +9,7 @@ from genno.testing import assert_units
 from pytest import param
 
 from message_ix_models.model.structure import get_codes
-from message_ix_models.model.transport import Config, demand, testing
+from message_ix_models.model.transport import Config, build, demand, testing
 from message_ix_models.model.transport.testing import MARK
 from message_ix_models.project.ssp import SSP_2017, SSP_2024
 
@@ -45,6 +45,7 @@ def test_demand_dummy(test_context, regions, years):
     assert any(data["demand"]["commodity"] == "transport pax URLMM")
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions, years, N_node, options",
     [
@@ -131,6 +132,7 @@ def test_exo(test_context, tmp_path, regions, years, N_node, options):
         assert False, "Negative values in demand"
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "ssp",
     [
@@ -179,6 +181,7 @@ def test_exo_pdt(test_context, ssp, regions="R12", years="B"):
     )
 
 
+@build.get_computer.minimum_version
 def test_exo_report(test_context, tmp_path):
     """Exogenous demand results can be plotted.
 
@@ -209,6 +212,7 @@ def test_exo_report(test_context, tmp_path):
     c.get("demand plots")
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions",
     [
@@ -253,6 +257,7 @@ R11_WEU  2100  300
 """
 
 
+@build.get_computer.minimum_version
 def test_pdt_per_capita(
     tmp_path, test_context, regions="R12", years="B", options=dict()
 ):
@@ -276,6 +281,7 @@ def test_pdt_per_capita(
     assert_units(result, "km / year")
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions,years,pop_scen",
     [
@@ -308,6 +314,7 @@ def test_urban_rural_shares(test_context, tmp_path, regions, years, pop_scen):
     assert set(["UR+SU", "RU"]) == set(result.coords["area_type"].values)
 
 
+@build.get_computer.minimum_version
 @pytest.mark.usefixtures("preserve_report_callbacks")
 @pytest.mark.parametrize(
     "nodes, target",

--- a/message_ix_models/tests/model/transport/test_demand.py
+++ b/message_ix_models/tests/model/transport/test_demand.py
@@ -181,6 +181,7 @@ def test_exo_pdt(test_context, ssp, regions="R12", years="B"):
     )
 
 
+@MARK[7]
 @build.get_computer.minimum_version
 def test_exo_report(test_context, tmp_path):
     """Exogenous demand results can be plotted.
@@ -314,6 +315,7 @@ def test_urban_rural_shares(test_context, tmp_path, regions, years, pop_scen):
     assert set(["UR+SU", "RU"]) == set(result.coords["area_type"].values)
 
 
+@MARK[7]
 @build.get_computer.minimum_version
 @pytest.mark.usefixtures("preserve_report_callbacks")
 @pytest.mark.parametrize(

--- a/message_ix_models/tests/model/transport/test_demand.py
+++ b/message_ix_models/tests/model/transport/test_demand.py
@@ -308,6 +308,7 @@ def test_urban_rural_shares(test_context, tmp_path, regions, years, pop_scen):
     assert set(["UR+SU", "RU"]) == set(result.coords["area_type"].values)
 
 
+@pytest.mark.usefixtures("preserve_report_callbacks")
 @pytest.mark.parametrize(
     "nodes, target",
     [

--- a/message_ix_models/tests/model/transport/test_demand.py
+++ b/message_ix_models/tests/model/transport/test_demand.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import genno
 import pytest
-from genno import Key
+from genno import ComputationError, Key
 from genno.testing import assert_units
 from pytest import param
 
@@ -215,7 +215,7 @@ def test_exo_report(test_context, tmp_path):
         param("ISR", marks=MARK[3]),
         "R11",
         "R12",
-        param("R14", marks=MARK[2](AttributeError)),
+        param("R14", marks=MARK[2]((AttributeError, ComputationError))),
     ],
 )
 @pytest.mark.parametrize("years", ["B"])

--- a/message_ix_models/tests/model/transport/test_disutility.py
+++ b/message_ix_models/tests/model/transport/test_disutility.py
@@ -3,6 +3,7 @@ from ixmp.testing import assert_logs
 from message_ix_models.model.transport import testing
 
 
+@testing.MARK[6]
 def test_disutility(
     caplog, tmp_path, test_context, regions="R12", years="B", options={}
 ):

--- a/message_ix_models/tests/model/transport/test_disutility.py
+++ b/message_ix_models/tests/model/transport/test_disutility.py
@@ -1,6 +1,6 @@
 from ixmp.testing import assert_logs
 
-from message_data.model.transport import testing
+from message_ix_models.model.transport import testing
 
 
 def test_disutility(

--- a/message_ix_models/tests/model/transport/test_emission.py
+++ b/message_ix_models/tests/model/transport/test_emission.py
@@ -2,10 +2,10 @@ import numpy as np
 import pandas as pd
 import pytest
 from message_ix import make_df
-from message_ix_models.util import broadcast, same_node
 
-from message_data.model.transport import Config, DataSourceConfig, testing
-from message_data.model.transport.emission import ef_for_input, get_emissions_data
+from message_ix_models.model.transport import Config, DataSourceConfig, testing
+from message_ix_models.model.transport.emission import ef_for_input, get_emissions_data
+from message_ix_models.util import broadcast, same_node
 
 
 def test_ef_for_input(test_context):

--- a/message_ix_models/tests/model/transport/test_emission.py
+++ b/message_ix_models/tests/model/transport/test_emission.py
@@ -3,11 +3,12 @@ import pandas as pd
 import pytest
 from message_ix import make_df
 
-from message_ix_models.model.transport import Config, DataSourceConfig, testing
+from message_ix_models.model.transport import Config, DataSourceConfig, build, testing
 from message_ix_models.model.transport.emission import ef_for_input, get_emissions_data
 from message_ix_models.util import broadcast, same_node
 
 
+@build.get_computer.minimum_version
 def test_ef_for_input(test_context):
     # Generate a test "input" data frame
     _, info = testing.configure_build(test_context, regions="R11", years="B")

--- a/message_ix_models/tests/model/transport/test_factor.py
+++ b/message_ix_models/tests/model/transport/test_factor.py
@@ -1,4 +1,4 @@
-from message_data.model.transport import factor
+from message_ix_models.model.transport import factor
 
 
 class TestFactor:

--- a/message_ix_models/tests/model/transport/test_ikarus.py
+++ b/message_ix_models/tests/model/transport/test_ikarus.py
@@ -5,7 +5,7 @@ from message_ix import make_df
 from numpy.testing import assert_allclose
 from pandas.testing import assert_series_equal
 
-from message_ix_models.model.transport import ikarus, testing
+from message_ix_models.model.transport import build, ikarus, testing
 from message_ix_models.model.transport.non_ldv import UNITS
 from message_ix_models.model.transport.testing import assert_units
 from message_ix_models.project.navigate import T35_POLICY
@@ -100,6 +100,7 @@ def test_get_ikarus_data0(test_context, regions, N_node, years):
         )
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize("years", ["A", "B"])
 @pytest.mark.parametrize(
     "regions, N_node",

--- a/message_ix_models/tests/model/transport/test_ikarus.py
+++ b/message_ix_models/tests/model/transport/test_ikarus.py
@@ -5,10 +5,10 @@ from message_ix import make_df
 from numpy.testing import assert_allclose
 from pandas.testing import assert_series_equal
 
-from message_data.model.transport import ikarus, testing
-from message_data.model.transport.non_ldv import UNITS
-from message_data.projects.navigate import T35_POLICY
-from message_data.testing import assert_units
+from message_ix_models.model.transport import ikarus, testing
+from message_ix_models.model.transport.non_ldv import UNITS
+from message_ix_models.model.transport.testing import assert_units
+from message_ix_models.project.navigate import T35_POLICY
 
 
 @pytest.mark.skip(reason="Deprecated, slow")

--- a/message_ix_models/tests/model/transport/test_ldv.py
+++ b/message_ix_models/tests/model/transport/test_ldv.py
@@ -4,17 +4,17 @@ import genno
 import pandas as pd
 import pytest
 from iam_units import registry
-from message_ix_models.model.structure import get_codes
 from pytest import param
 
-from message_data.model.transport import testing
-from message_data.model.transport.ldv import (
+from message_ix_models.model.structure import get_codes
+from message_ix_models.model.transport import testing
+from message_ix_models.model.transport.ldv import (
     constraint_data,
     read_USTIMES_MA3T,
     read_USTIMES_MA3T_2,
 )
-from message_data.projects.navigate import T35_POLICY
-from message_data.testing import assert_units
+from message_ix_models.model.transport.testing import assert_units
+from message_ix_models.project.navigate import T35_POLICY
 
 log = logging.getLogger(__name__)
 

--- a/message_ix_models/tests/model/transport/test_ldv.py
+++ b/message_ix_models/tests/model/transport/test_ldv.py
@@ -206,7 +206,15 @@ def test_ldv_constraint_data(test_context, source, regions, years):
         assert info.Y[1:] == sorted(df["year_act"].unique())
 
 
-@pytest.mark.parametrize("func", (read_USTIMES_MA3T, read_USTIMES_MA3T_2))
+@pytest.mark.parametrize(
+    "func",
+    (
+        pytest.param(
+            read_USTIMES_MA3T, marks=testing.MARK[5]("R11/ldv-cost-efficiency.xlsx")
+        ),
+        read_USTIMES_MA3T_2,
+    ),
+)
 def test_read_USTIMES_MA3T(func):
     all_nodes = get_codes("node/R11")
     nodes = all_nodes[all_nodes.index("World")].child

--- a/message_ix_models/tests/model/transport/test_ldv.py
+++ b/message_ix_models/tests/model/transport/test_ldv.py
@@ -7,7 +7,7 @@ from iam_units import registry
 from pytest import param
 
 from message_ix_models.model.structure import get_codes
-from message_ix_models.model.transport import testing
+from message_ix_models.model.transport import build, testing
 from message_ix_models.model.transport.ldv import (
     constraint_data,
     read_USTIMES_MA3T,
@@ -19,6 +19,7 @@ from message_ix_models.project.navigate import T35_POLICY
 log = logging.getLogger(__name__)
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize("source", [None, "US-TIMES MA3T"])
 @pytest.mark.parametrize("years", ["A", "B"])
 @pytest.mark.parametrize(
@@ -149,6 +150,7 @@ def test_get_ldv_data(tmp_path, test_context, source, regions, years):
         assert N_exp <= len(df)
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "regions, N_node_loc",
     [
@@ -168,6 +170,7 @@ def test_ldv_capacity_factor(test_context, regions, N_node_loc, years="B"):
     assert N_node_loc == len(df["node_loc"].unique())
 
 
+@build.get_computer.minimum_version
 @pytest.mark.parametrize(
     "source, regions, years",
     [

--- a/message_ix_models/tests/model/transport/test_migrate.py
+++ b/message_ix_models/tests/model/transport/test_migrate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from message_data.model.transport.migrate import import_all
+from message_ix_models.model.transport.migrate import import_all
 
 
 @pytest.mark.xfail(reason="Don't actually attempt to run the code.")

--- a/message_ix_models/tests/model/transport/test_operator.py
+++ b/message_ix_models/tests/model/transport/test_operator.py
@@ -2,11 +2,10 @@ import pytest
 from genno import Quantity
 from genno.testing import assert_qty_equal
 from message_ix import Scenario
-from message_ix_models.project.ssp import SSP_2024
 from numpy.testing import assert_allclose
 
-from message_data.model.transport import Config, factor
-from message_data.model.transport.operator import (
+from message_ix_models.model.transport import Config, factor
+from message_ix_models.model.transport.operator import (
     broadcast_advance,
     distance_ldv,
     distance_nonldv,
@@ -14,8 +13,9 @@ from message_data.model.transport.operator import (
     factor_ssp,
     transport_check,
 )
-from message_data.model.transport.structure import get_technology_groups
-from message_data.projects.navigate import T35_POLICY
+from message_ix_models.model.transport.structure import get_technology_groups
+from message_ix_models.project.navigate import T35_POLICY
+from message_ix_models.project.ssp import SSP_2024
 
 
 @pytest.mark.xfail(reason="Incomplete")

--- a/message_ix_models/tests/model/transport/test_report.py
+++ b/message_ix_models/tests/model/transport/test_report.py
@@ -51,6 +51,7 @@ def test_configure_legacy():
         assert expected.get(k, 0) + len(TECHS[k]) == len(v), k
 
 
+@MARK[7]
 @build.get_computer.minimum_version
 @pytest.mark.usefixtures("preserve_report_callbacks")
 @pytest.mark.parametrize(
@@ -102,6 +103,7 @@ def quiet_genno(caplog):
     caplog.set_level(logging.WARNING, logger="genno.compat.pyam")
 
 
+@MARK[7]
 @build.get_computer.minimum_version
 @mark.usefixtures("quiet_genno", "preserve_report_callbacks")
 def test_simulated_solution(request, test_context, regions="R12", years="B"):

--- a/message_ix_models/tests/model/transport/test_report.py
+++ b/message_ix_models/tests/model/transport/test_report.py
@@ -4,16 +4,19 @@ from typing import TYPE_CHECKING
 
 import genno
 import pytest
-from message_ix_models import ScenarioInfo
-from message_ix_models.report import prepare_reporter, register
 from pytest import mark, param
 
-from message_data.model.transport.report import callback, configure_legacy_reporting
-from message_data.model.transport.testing import (
+from message_ix_models import ScenarioInfo
+from message_ix_models.model.transport.report import (
+    callback,
+    configure_legacy_reporting,
+)
+from message_ix_models.model.transport.testing import (
     MARK,
     built_transport,
     simulated_solution,
 )
+from message_ix_models.report import prepare_reporter, register
 
 if TYPE_CHECKING:
     import message_ix
@@ -22,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 def test_configure_legacy():
-    from message_data.tools.post_processing.default_tables import TECHS
+    from message_ix_models.report.legacy.default_tables import TECHS
 
     config = deepcopy(TECHS)
 

--- a/message_ix_models/tests/model/transport/test_report.py
+++ b/message_ix_models/tests/model/transport/test_report.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+@MARK[6]
 def test_configure_legacy():
     from message_ix_models.report.legacy.default_tables import TECHS
 

--- a/message_ix_models/tests/model/transport/test_util.py
+++ b/message_ix_models/tests/model/transport/test_util.py
@@ -4,10 +4,10 @@ import pytest
 import xarray as xr
 from genno.testing import assert_qty_equal
 from iam_units import registry
-from message_ix_models.report.util import as_quantity
 
-from message_data.model.transport.config import Config, DataSourceConfig
-from message_data.model.transport.util import input_commodity_level
+from message_ix_models.model.transport.config import Config, DataSourceConfig
+from message_ix_models.model.transport.util import input_commodity_level
+from message_ix_models.report.util import as_quantity
 
 
 def test_add_cl(test_context):

--- a/message_ix_models/tools/messagev.py
+++ b/message_ix_models/tools/messagev.py
@@ -1,0 +1,194 @@
+"""Tools for extracting data from MESSAGE V."""
+
+import re
+from functools import lru_cache
+
+import numpy as np
+import pandas as pd
+
+
+class CHNFile:
+    """Reader for MESSAGE V ``.chn`` files."""
+
+    index = {}
+
+    # FIXME reduce complexity from 15 to ≤14
+    def __init__(self, path):  # noqa: C901
+        """Parse .chn file."""
+
+        def _depth(str):
+            return (len(str.replace("\t", "    ")) - len(str.lstrip())) // 2
+
+        stack = []
+        self.data = {}
+        for line in open(path):
+            if line.startswith("#"):  # Comment
+                pass
+            elif len(stack) == 0:  # New level
+                name, level = line.split()
+                stack.append((name, level.rstrip(":")))
+            elif len(stack) == 1:  # New commodity
+                stack.append(tuple(line.split()))
+            elif len(stack) == 2:
+                if _depth(line) == 0 and line.strip() == "*":  # End of level
+                    stack = []
+                elif _depth(line) == 1:  # New commodity
+                    stack[-1] = tuple(line.split())
+                else:
+                    p_c = line.strip().rstrip(":")
+                    if p_c in ("Producers", "Consumers"):  # Start of P/C block
+                        stack.append(p_c)
+                        pc_data = []
+                    elif p_c == "*":  # Consecutive '*'
+                        pass
+            elif len(stack) == 3:
+                if _depth(line) == 2 and line.strip() == "*":  # End of block
+                    # Store data
+                    if len(pc_data):
+                        key = tuple([stack[0][0], stack[1][0], stack[2]])
+                        self.data[key] = pc_data
+                    stack.pop(-1)
+                else:  # Data line
+                    # TODO parse: tec, level, code, commodity, {ts,c}, [data]
+                    pc_data.append(line.split())
+            elif line == "*\n":
+                stack.pop(-1)
+
+
+class DICFile:
+    """Reader for MESSAGE V ``.dic`` files."""
+
+    tec_code = {}
+    code_tec = {}
+
+    def __init__(self, path=None):
+        if path is None:
+            return
+
+        for line in open(path):
+            if line.startswith("#"):
+                continue
+
+            tec, code = line.split()
+            self.tec_code[tec] = code
+            self.code_tec[code] = tec
+
+    def __getitem__(self, key):
+        try:
+            return self.code_tec[key]
+        except KeyError:
+            return self.tec_code[key]
+
+
+class INPFile:
+    """Reader for MESSAGE V ``.inp`` files."""
+
+    index = {}
+    file = None
+    years_re = re.compile(r"^timesteps:(( \d*)*)", re.MULTILINE)
+
+    def __init__(self, path):
+        self.file = open(path)
+
+        # Index the file
+        section = "_info"
+        pos = self.file.tell()
+        while True:
+            line = self.file.readline()
+            if line == "":
+                break
+            elif line == "*\n":
+                self.index[section] = (pos, self.file.tell() - pos)
+                section = None
+                pos = self.file.tell()
+            elif section is None:
+                section = line.split()[0]
+
+    def get_section(self, name):
+        start, len = self.index[name]
+        self.file.seek(start)
+        return self.file.read(len)
+
+    @lru_cache(1)
+    def get_years(self):
+        """Return timesteps."""
+        sec = self.get_section("_info")
+        match = self.years_re.search(sec)
+        return list(map(int, match.groups()[0].strip().split()))
+
+    params_with_source = "con1a con1c con2a inp minp moutp"
+    ts_params = "ctime fom inv plf pll vom" + params_with_source
+    scalar_params = {
+        "annualize": int,
+        "display": str,
+        "fyear": int,
+        "lyear": int,
+        "hisc": float,
+        "minp": float,
+    }
+
+    def const_or_ts(self, line):
+        param = line.pop(0)
+        source = line.pop(0) if param in self.params_with_source else None
+
+        if param == "minp":
+            line = ["c" if len(line) == 1 else "ts"] + line
+
+        kind = line.pop(0)
+        if kind == "ts":
+            elem = list(zip(self.get_years(), line))
+        elif kind == "c":
+            assert len(line) == 1
+
+            # # This line implements a fill-forward:
+            # elem = [(year, line[0]) for year in self.get_years()]
+
+            # Single element
+            elem = [(self.get_years()[0], line[0])]
+        else:
+            raise ValueError(param, source, kind, line)
+
+        # 'free' is a special value for bounds/constraints
+        df = (
+            pd.DataFrame(elem, columns=["year", "value"])
+            .replace("free", np.nan)
+            .astype({"value": float})
+        )
+
+        # Add parameter name and source
+        df["param"] = param
+        df["source"] = source
+
+        return df
+
+    def parse_section(self, name):
+        result = {}
+        params = []
+
+        # Parse each line
+        for line in map(str.split, self.get_section(name).split("\n")):
+            if line in ([], ["*"]) or line[0].startswith("#"):
+                # End of section, comment, or blank line
+                continue
+
+            param = line[0]
+            if param == name:
+                # Start of the section
+                result["extra"] = line[1:]
+            elif param in "bda bdc":
+                result["type"] = line.pop(1)  # 'lo' or 'hi'
+                params.append(self.const_or_ts(line))
+            # elif param in 'mpa mpc':
+            #     # TODO implement this
+            #     continue
+            elif param in self.ts_params:
+                params.append(self.const_or_ts(line))
+            elif param in self.scalar_params:
+                assert len(line) == 2, line
+                result[param] = self.scalar_params[param](line[1])
+
+        # Concatenate accumulated params to a single DataFrame
+        if len(params):
+            result["params"] = pd.concat(params, sort=False)
+
+        return result

--- a/message_ix_models/util/__init__.py
+++ b/message_ix_models/util/__init__.py
@@ -546,6 +546,14 @@ def merge_data(
 def minimum_version(expr: str) -> Callable:
     """Decorator for functions that require a minimum version of some upstream package.
 
+    If the decorated function is called and the condition in `expr` is not met,
+    :class:`.NotImplementedError` is raised with an informative message.
+
+    The decorated function gains an attribute :py:`.minimum_version`, another decorator
+    that can be used on associated test code. This marks the test as XFAIL, raising
+    :class:`.NotImplementedError` or :class:`.RuntimeError` (e.g. for :mod:`.click`
+    testing).
+
     See :func:`.prepare_reporter` / :func:`.test_prepare_reporter` for a usage example.
 
     Parameters
@@ -582,7 +590,7 @@ def minimum_version(expr: str) -> Callable:
             # Create the mark
             mark = pytest.mark.xfail(
                 condition=condition,
-                raises=NotImplementedError,
+                raises=(NotImplementedError, RuntimeError),
                 reason=f"Not supported{message}",
             )
 

--- a/message_ix_models/util/graphviz.py
+++ b/message_ix_models/util/graphviz.py
@@ -1,0 +1,15 @@
+from subprocess import DEVNULL, check_call
+
+try:
+    from graphviz import DOT_BINARY
+except ImportError:
+    DOT_BINARY = "dot"
+
+try:
+    check_call([DOT_BINARY, "-V"], stdout=DEVNULL, stderr=DEVNULL)
+except FileNotFoundError:
+    #: :any:`.True` if the :program:`graphviz` programs are installed, as required by
+    #: :mod:`.graphviz` and :meth:`genno.Computer.visualize`.
+    HAS_GRAPHVIZ = False
+else:
+    HAS_GRAPHVIZ = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,16 @@ report = ["plotnine", "xlsxwriter"]
 tests = [
   # For nbclient, thus nbformat
   "ixmp[tests]",
-  "message_ix_models[report]",
+  "message_ix_models[report,transport]",
   "pytest",
   "pytest-cov",
   "pytest-xdist",
+]
+transport = [
+  "message-ix-models[iea-web,report]",
+  "requests-cache",
+  "transport-energy",
+  "xarray",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,10 +130,18 @@ module = ["ixmp.*"]
 no_implicit_optional = false
 
 [tool.pytest.ini_options]
-# Disable faulthandler plugin on Windows to prevent spurious console noise
-addopts = "-p no:faulthandler --cov=message_ix_models --cov-report="
+# Default options for invoking pytest
+# - Skip tests with the "ece_db" marker
+# - Disable faulthandler plugin on Windows to prevent spurious console noise
+# - No coverage report
+addopts = """
+  -m "not ece_db"
+  -p no:faulthandler
+  --cov=message_ix_models --cov-report="""
 filterwarnings = "ignore:distutils Version classes.*:DeprecationWarning"
 markers = [
+  "ece_db: Tests requiring access to IIASA ECE internal databases",
+  "slow: Tests that typically take more than ~45 seconds wall time",
   "snapshot: Slow tests using the public MESSAGEix-GLOBIOM baseline snapshot",
 ]
 


### PR DESCRIPTION
This branch makes additional adjustments to the branch for #207 after the semi-automated migration process.

1. Adjust imports.
2. Migrate additional bits of code not picked up in the base PR:
   - `message_data.testing.assert_units` —just this one function from the larger file.
   - `message_data.tools.messagev`.
3. Adjust `.model.transport` code to locate data and config files in their new location in `message_ix_models/data/`, rather than `data/` in the message_data repo; use appropriate utility functions to construct paths.
4. Add pytest configuration and markers used by transport tests.
5. Add `.model.transport` dependencies as a new group in pyproject.toml.
6. Add `.model.transport.cli` to `message_ix_models.cli.submodules`.
7. Update test marks.
   - Tests that fail without certain data files that are non-public and were not migrated.
   - Tests that require minimum versions of certain dependencies. This is necessary because message_data is tested only on a single (most recent) version of message_ix and other dependencies.
8. Adjust internal references in docs; docs references to code.

## How to review

For @glatterf42:
- Note the CI checks all pass.
- Skim the diff.

For @ravitby:
- Read the [“MESSAGEix-Transport” docs page](https://iiasa-energy-program-message-ix--208.com.readthedocs.build/projects/models/en/208/transport/index.html) (preview, built automatically from the files on this branch).

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.