### PR TITLE
Fix naming of GDP and population columns in SSP data aggregation within `tools.costs`

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Fix and update :doc:`/api/tools-costs`
+  - Fix naming of GDP and population columns in SSP data aggregation (:pull:`219`).
 
 v2024.8.6
 =========

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,7 +4,7 @@ What's new
 Next release
 ============
 
-- Fix and update :doc:`/api/tools-costs`
+- Fix and update :doc:`/api/tools-costs` (:pull:`219`)
   - Fix naming of GDP and population columns in SSP data aggregation (:pull:`219`).
 
 v2024.8.6

--- a/message_ix_models/tools/costs/gdp.py
+++ b/message_ix_models/tools/costs/gdp.py
@@ -97,8 +97,8 @@ def process_raw_ssp_data(context: Context, config: Config) -> pd.DataFrame:
         return (
             pd.concat(
                 [
-                    dfs[0].to_series().rename("total_gdp"),
-                    dfs[1].to_series().rename("total_population"),
+                    dfs[0].to_series().rename("total_population"),
+                    dfs[1].to_series().rename("total_gdp"),
                     dfs[2].to_series().rename("gdp_ppp_per_capita"),
                     dfs[3].to_series().rename("gdp_ratio_reg_to_reference"),
                 ],

--- a/message_ix_models/tools/costs/gdp.py
+++ b/message_ix_models/tools/costs/gdp.py
@@ -22,14 +22,15 @@ def process_raw_ssp_data(context: Context, config: Config) -> pd.DataFrame:
     pandas.DataFrame
         with the columns:
 
-        - scenario_version
-        - scenario
-        - region
-        - year
-        - total_gdp
-        - total_population
-        - gdp_ppp_per_capita
-        - gdp_ratio_reg_to_reference
+        - scenario_version: version of SSP scenario data
+        - scenario: scenario (SSP1-5, LED)
+        - region: region name
+        - year: year of data
+        - total_population: total population aggregated to the regional level
+        - total_gdp: total GDP aggregated to the regional level
+        - gdp_ppp_per_capita: regional GDP per capita in PPP
+        - gdp_ratio_reg_to_reference: ratio of regional GDP per capita to \
+            reference region's GDP per capita
     """
     from collections import defaultdict
 

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -67,8 +67,12 @@ def assign_income_groups(  # noqa: C901
             return 1.0
 
     elif method == "population":
+        # Work around khaeru/sdmx#191: ensure the HTTPS URL is used
+        client = sdmx.Client("WB_WDI")
+        client.source.url = client.source.url.replace("http://", "https://")
+
         # Retrieve WB_WDI data for SERIES=SP_POP_TOTAL (Population, total)
-        dm = sdmx.Client("WB_WDI").data(
+        dm = client.data(
             "WDI", key="A.SP_POP_TOTL.", params=dict(startPeriod=2020, endPeriod=2020)
         )
 
@@ -154,7 +158,7 @@ def fetch_codelist(id: str) -> "sdmx.model.common.Codelist":
     import sdmx
 
     file = pooch.retrieve(
-        url="http://api.worldbank.org/v2/sdmx/rest/codelist/WB/", known_hash=None
+        url="https://api.worldbank.org/v2/sdmx/rest/codelist/WB/", known_hash=None
     )
     # Read the retrieved SDMX StructureMessage and extract the code list
     sm = sdmx.read_sdmx(file)


### PR DESCRIPTION
Small fix to `total_gdp` and `total_population` columns being switched in `message_ix_models.tools.costs.gdp.process_raw_ssp_data()`

In the `message_ix_models.tools.costs.gdp.process_raw_ssp_data()` function that pulls and combines SSP data in `tools.costs`, there is a block of code that converts the data in the `Computer()` into a `pandas` DataFrame, with each computer key being a column. However, the naming of the columns are switched (`total_population` and `total_gdp`). So, I just swapped them.

From what I can tell, this has zero impact on the actual costs calculations, as these DataFrames columns are not used anywhere (and are later even dropped). The calculation of GDP per capita happens before this DataFrame is created, here:

https://github.com/iiasa/message-ix-models/blob/9bb0037be15c4e76a00f12ab4c71a386ef20f6b7/message_ix_models/tools/costs/gdp.py#L87-L88

And these values seem to be correct.

I picked up on this because I am calling using the output of `message_ix_models.tools.costs.gdp.process_raw_ssp_data()` function on its own elsewhere.

## How to review

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [ ] Continuous integration checks all ✅
- [x] Update doc/whatsnew.