### PR TITLE
Change decay to reach cost reduction specified by 2100 (instead of 2110) `tools.costs`

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -17,6 +17,7 @@ Next release
   - Replace solar and wind technologies with new ones (:pull:`206`).
   - Reorganize input files and incorporate `first_year.csv` data into `tech_map.csv` (:pull:`221`).
   - Reconfigure use and implementation of technology variants/modules to be more agnostic (:pull:`221`).
+  - Change cost decay to reach reduction percentage specified on the year 2100 (:pull:`227`).
 - Improve and extend :doc:`/material/index` (:pull:`218`).
 
   - Release of MESSAGEix-Materials 1.1.0 (:doc:`/material/v1.1.0`).

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -323,7 +323,7 @@ def project_ref_region_inv_costs_using_reduction_rates(
             cost_region_2100=lambda x: x.reg_cost_base_year
             - (x.reg_cost_base_year * x.cost_reduction),
             b=lambda x: (1 - config.pre_last_year_rate) * x.cost_region_2100,
-            r=lambda x: (1 / (config.final_year - config.base_year))
+            r=lambda x: (1 / (2100 - config.base_year))
             * np.log((x.cost_region_2100 - x.b) / (x.reg_cost_base_year - x.b)),
             reference_region=config.ref_region,
         )

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -278,6 +278,12 @@ def project_ref_region_inv_costs_using_reduction_rates(
     This function uses the cost reduction rates for each technology under each scenario
     to project the capital costs for each technology in the reference region.
 
+    The changing of costs is projected until the year 2100
+    (hard-coded in this function), which might not be the same
+    as :attr:`.Config.final_year` (:attr:`.Config.final_year` represents the final
+    projection year instead). 2100 is hard coded because the cost reduction values are
+    assumed to be reached by 2100.
+
     The returned data have the list of periods given by :attr:`.Config.seq_years`.
 
     Parameters


### PR DESCRIPTION
Small fix to the cost decay in `tools.costs` to reach the reduction rate specified by 2100

Currently, the decay is applied so that the cost reduction rate is reached by `Config.final_year`, which is 2110 -- but this should really be 2100. So if the cost reduction rate is 10%, that 10% reduction (relative to the base year) is reached in 2110, not 2100. Therefore the 2100 value is maybe around 9% less than the base year value (or something like that).

Further down the line, the tool also takes the 2100 value and repeats it until `Config.final_year` (since 2110 isn't really a model year), so essentially the cost projections never officially reach the cost reduction rate specified (it gets very close).

This branch is derived off of the `costs/reconfigure-modules` branch, so PR #221 should be merged before this one goes through review.

## How to review

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Update doc/whatsnew.