### PR TITLE
Fix snapshot tests

### DIFF
--- a/message_ix_models/report/legacy/pp_utils.py
+++ b/message_ix_models/report/legacy/pp_utils.py
@@ -1865,7 +1865,9 @@ def _retr_crb_prc(ds, units):
     """
 
     # Retrieve VAR - PRICE_EMISSION
-    var = "PRICE_EMISSION_NEW"
+    # TODO iiasa/message_ix#726 is reworking PRICE_EMISSION_NEW to become the new PRICE_EMISSION
+    # Adjust the name here according to what you're running on
+    var = "PRICE_EMISSION"
     df = ds.var(var, {"type_tec": ["all"]})
     if df.empty:
         if var == "PRICE_EMISSION":


### PR DESCRIPTION
The snapshot tests have been failing for a while now. Initially, if I remember correctly, there was some issue with retrieving the snapshots consistently, but that seems to be resolved. Now, one test fails because it's looking for the `PRICE_EMISSION_NEW` variable: the legacy reporting we migrated is built on top of https://github.com/iiasa/message_ix/tree/issue/723, which introduced that variable name to fix `PRICE_EMISSION`. 

While we have unfortunately still not finished the corresponding PR, the branch has progressed to a point where `PRICE_EMISSION` was actually updated instead of a new helper variable introduced. This PR thus adjusts the variable name the migrated legacy reporting expects.

## How to review

- Read the diff and note that the CI checks all pass.
- Note that the `TEMPORARY` commit should be dropped before merging

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Update tests
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update doc/whatsnew.~ Just CI.
