### PR TITLE
Extend SSP argument options

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,6 +12,7 @@ Next release
   - Fix naming of GDP and population columns in SSP data aggregation.
 
 - Update :doc:`/transport/index` (:pull:`213`).
+- Add "LED", "SSP4", and "SSP5" as values for the :program:`--ssp=…` option in :func:`.common_params` (:pull:`233`).
 
 v2024.8.6
 =========

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -247,7 +247,9 @@ PARAMS = {
         help="Run only reporting.",
     ),
     "ssp": Argument(
-        ["ssp"], callback=store_context, type=Choice(["SSP1", "SSP2", "SSP3"])
+        ["ssp"],
+        callback=store_context,
+        type=Choice(["LED", "SSP1", "SSP2", "SSP3", "SSP4", "SSP5"]),
     ),
     "urls_from_file": Option(
         ["--urls-from-file", "-f"],


### PR DESCRIPTION
The `mix-models --ssp=` CLI option is used in the SSP 2024/ScenarioMIP workflows, but originally had only SSP1 through SSP3 as accepted values. This adds SSP4, SSP5, and LED.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update doc/whatsnew.