### PR TITLE
Update `water` to use cost projections from `tools.costs`

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Connect the water module to the cost module for cooling technologies (:pull:`245`).
 - Make setup of constraints for cooling technologies flexible and update solar csp tech. name (:pull:`242`). 
 - Fix the nexus/cooling function and add test for checking some input data (:pull:`236`).
 - Add :doc:`/project/circeular` project code and documentation (:pull:`232`).

--- a/message_ix_models/data/costs/cooling/tech_map.csv
+++ b/message_ix_models/data/costs/cooling/tech_map.csv
@@ -91,3 +91,11 @@ solar_th_ppl__air,energy,solar_th_ppl,220,0,2015
 solar_th_ppl__cl_fresh,energy,solar_th_ppl,100,0,2015
 solar_th_ppl__ot_fresh,energy,solar_th_ppl,0.4,0,2015
 solar_th_ppl__ot_saline,energy,solar_th_ppl,0.3,0,2015
+csp_sm1_ppl__air,energy,csp_sm1_ppl,220,0,2015
+csp_sm1_ppl__cl_fresh,energy,csp_sm1_ppl,100,0,2015
+csp_sm1_ppl__ot_fresh,energy,csp_sm1_ppl,0.4,0,2015
+csp_sm1_ppl__ot_saline,energy,csp_sm1_ppl,0.3,0,2015
+csp_sm3_ppl__air,energy,csp_sm3_ppl,220,0,2015
+csp_sm3_ppl__cl_fresh,energy,csp_sm3_ppl,100,0,2015
+csp_sm3_ppl__ot_fresh,energy,csp_sm3_ppl,0.4,0,2015
+csp_sm3_ppl__ot_saline,energy,csp_sm3_ppl,0.3,0,2015

--- a/message_ix_models/model/water/cli.py
+++ b/message_ix_models/model/water/cli.py
@@ -4,7 +4,7 @@ import click
 
 from message_ix_models import Context
 from message_ix_models.model.structure import get_codes
-from message_ix_models.util.click import common_params
+from message_ix_models.util.click import common_params, scenario_param
 
 log = logging.getLogger(__name__)
 
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 # allows to activate water module
 @click.group("water-ix")
 @common_params("regions")
+@scenario_param("--ssp", default="SSP2")
 @click.option("--time", help="Manually defined time")
 @click.pass_obj
 def cli(context: "Context", regions, time):
@@ -206,6 +207,7 @@ def nexus(context: "Context", regions, rcps, sdgs, rels, macro=False):
 
 @cli.command("cooling")
 @common_params("regions")
+@scenario_param("--ssp")
 @click.option(
     "--rcps",
     default="no_climate",

--- a/message_ix_models/model/water/data/water_for_ppl.py
+++ b/message_ix_models/model/water/data/water_for_ppl.py
@@ -756,6 +756,9 @@ def cool_tech(context: "Context") -> dict[str, pd.DataFrame]:
     # Remove technologies that are not required
     inv_cost = inv_cost[~inv_cost["technology"].isin(techs_to_remove)]
 
+    # Only keep cooling module technologies by filtering for technologies with "__"
+    inv_cost = inv_cost[inv_cost["technology"].str.contains("__")]
+
     # Add the investment costs to the results
     results["inv_cost"] = inv_cost
 

--- a/message_ix_models/tests/model/water/data/test_water_for_ppl.py
+++ b/message_ix_models/tests/model/water/data/test_water_for_ppl.py
@@ -94,8 +94,11 @@ def test_cool_tec(request, test_context, RCP):
     test_context.time = "year"
     test_context.nexus_set = "nexus"
     # TODO add
-    test_context.RCP = RCP
-    test_context.REL = "med"
+    test_context.update(
+        RCP=RCP,
+        REL="med",
+        ssp="SSP2",
+    )
 
     # TODO: only leaving this in so you can see which data you might want to assert to
     # be in the result. Please remove after adapting the assertions below:


### PR DESCRIPTION
This PR changes the code in the `water` model to use the regionally-differentiated and scenario-specific cost projections created by `tools.costs`.

Currently the costs for cooling technologies are being read from an input CSV and kept constant over the time horizon. 

This PR's branch is derived from the `wat_SSP_upd2` branch, so this branch can be rebased once #242 is closed or merged into that branch.

## How to review

For @adrivinca: Check if the implementation is correct and if the outputs make sense.

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ~ not needed, no new function added
- ~[ ] Add, expand, or update documentation. ~ not needed, no new function added
- [x] Update doc/whatsnew.