### PR TITLE
Replace resolved numpy workaround with dask workaround

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -111,7 +111,7 @@ jobs:
 
         # TEMPORARY Work around dask v2024.11.0;
         # see https://github.com/khaeru/genno/issues/149
-        pip install "dask < 2024.11.0"
+        pip install "dask < 2024.11.0" "dask-expr < 1.1.17"
 
     - name: Configure local data path
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -109,9 +109,9 @@ jobs:
 
         pip install .[docs,tests] ${{ matrix.upstream.extra-deps }}
 
-        # TEMPORARY Work around hgrecco/pint#2007, unionai-oss/pandera#1685;
-        # see https://github.com/khaeru/genno/issues/140
-        pip install "pint != 0.24.0" "numpy < 2"
+        # TEMPORARY Work around dask v2024.11.0;
+        # see https://github.com/khaeru/genno/issues/149
+        pip install "dask < 2024.11.0"
 
     - name: Configure local data path
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -46,23 +46,29 @@ jobs:
         - version: v3.4.0
           python-version: "3.11"
           extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"' #
+          dask-dataframe: false
         - version: v3.5.0
           python-version: "3.11"
           extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"' #
+          dask-dataframe: false
         - version: v3.6.0
           python-version: "3.11"
           extra-deps: '"dask < 2024.3.0" "genno < 1.25" "pandas < 2.0" "pytest == 8.0.0"' #
+          dask-dataframe: false
         - version: v3.7.0
           python-version: "3.11"
-          extra-deps: 'dask[dataframe]   "genno < 1.25"                "pytest == 8.0.0"' #
+          extra-deps: '                  "genno < 1.25"                "pytest == 8.0.0"' #
+          dask-dataframe: true
         # Latest released version
         - version: v3.8.0
           python-version: "3.12"
-          extra-deps: 'dask[dataframe]                                 "pytest == 8.0.0"' #
+          extra-deps: '                                                "pytest == 8.0.0"' #
+          dask-dataframe: true
         # Development version
         - version: main
           python-version: "3.12"
-          extra-deps: 'dask[dataframe]' #
+          extra-deps: '' #
+          dask-dataframe: true
 
       fail-fast: false
 
@@ -109,9 +115,13 @@ jobs:
 
         pip install .[docs,tests] ${{ matrix.upstream.extra-deps }}
 
+
+    - name: Install specific dask versions as workaround
+      if: ${{ matrix.upstream.dask-dataframe }}
+      run: |
         # TEMPORARY Work around dask v2024.11.0;
         # see https://github.com/khaeru/genno/issues/149
-        pip install "dask < 2024.11.0" "dask-expr < 1.1.17"
+        pip install "dask[dataframe] < 2024.11.0"
 
     - name: Configure local data path
       run: |

--- a/message_ix_models/model/water/data/demands.py
+++ b/message_ix_models/model/water/data/demands.py
@@ -644,7 +644,7 @@ def add_sectoral_demands(context: "Context") -> dict[str, pd.DataFrame]:
     ]
     # create a new column and use np.select to assign
     # values to it using our lists as arguments
-    h_act["commodity"] = np.select(conditions, values)
+    h_act["commodity"] = np.select(conditions, values, "Unknown technology")
     h_act["value"] = h_act["value"].abs()
 
     hist_act = make_df(

--- a/message_ix_models/model/water/data/demands.py
+++ b/message_ix_models/model/water/data/demands.py
@@ -644,7 +644,7 @@ def add_sectoral_demands(context: "Context") -> dict[str, pd.DataFrame]:
     ]
     # create a new column and use np.select to assign
     # values to it using our lists as arguments
-    h_act["commodity"] = np.select(conditions, values, "Unknown technology")
+    h_act["commodity"] = np.select(conditions, values, "Unknown commodity")
     h_act["value"] = h_act["value"].abs()
 
     hist_act = make_df(


### PR DESCRIPTION
This is a twin of https://github.com/iiasa/message_ix/pull/887, fixing the CI test suite by pinning dask until genno is compatible with the latest versions of it.


- Read the diff and note that the CI checks all pass.


## PR checklist


- [x] Continuous integration checks all ✅
- [x] Update CI tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update doc/whatsnew.~ Just CI.
