### PR TITLE
Update steel diffusion constraints

### DIFF
--- a/message_ix_models/data/material/steel/Global_steel_MESSAGE.xlsx
+++ b/message_ix_models/data/material/steel/Global_steel_MESSAGE.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bdfbc1ea15b443308f38ed49426e435127e91f6a5b6338b6fef6d4acef96c16
-size 105283
+oid sha256:cda24624f0d8d9fdc1b8724ff8059f357f311444bf89e71d923ed6976afb06c6
+size 106597


### PR DESCRIPTION
Update steel diffusion constraints as follows: 
- removed growth_activity_lo and initial_activity_lo for bof_steel from 2030 onwards
- changed the growth_activity_up for dri_gas_steel, dri_h2_steel, and eaf_steel to 0.075 from 2030 onwards
- changed the initial_activity_up for dri_gas_steel and dri_h2_steel to 1.0 from 2030 onwards

## How to review

No review is needed, just changing the parameters in Excel data file as agreed before. 

## PR checklist

- [x] Continuous integration checks all ✅