### PR TITLE
Fix snapshot test environment variables

### DIFF
--- a/.github/workflows/pytest-snapshots.yaml
+++ b/.github/workflows/pytest-snapshots.yaml
@@ -14,10 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  version:
-    gams: "43.4.1"
-    python: "3.12"
-    upstream: main
+  gams: "43.4.1"
+  python: "3.12"
+  upstream: main
 
 jobs:
   snapshots:
@@ -38,13 +37,13 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ env.version.python }}
+        python-version: ${{ env.python }}
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: ${{ env.version.gams }}
+        version: ${{ env.gams }}
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v2
@@ -53,7 +52,7 @@ jobs:
 
     - name: Install packages and dependencies
       # By default, install:
-      # - ixmp, message_ix: from GitHub branches/tags per env.version.upstream (above)
+      # - ixmp, message_ix: from GitHub branches/tags per env.upstream (above)
       # - other dependencies including genno: from PyPI.
       #
       # To test against unreleased code (on `main`, or other branches
@@ -61,8 +60,8 @@ jobs:
       # as needed. DO NOT merge such changes to `main`.
       run: |
         # pip install --upgrade "genno @ git+https://github.com/khaeru/genno.git@main"
-        pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@${{ env.version.upstream }}"
-        # pip install --upgrade "message-ix @ git+https://github.com/iiasa/message_ix.git@${{ env.version.upstream }}"
+        pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@${{ env.upstream }}"
+        # pip install --upgrade "message-ix @ git+https://github.com/iiasa/message_ix.git@${{ env.upstream }}"
         pip install --upgrade "message-ix @ git+https://github.com/iiasa/message_ix.git@issue/723"
 
         pip install .[docs,tests] dask[dataframe]


### PR DESCRIPTION
Our CI `Test snapshots` failed today, complaining that `The workflow is not valid. .github/workflows/pytest-snapshots.yaml (Line: 18, Col: 5): A mapping was not expected`.
Looking at [the docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#env), a mapping is allowed, but apparently not a nested mapping. Thus, this PR removes the `version` level in the `env` mapping (and temporarily enables `Test snapshots` to see if they run now).

## How to review

- Read the diff and note that the CI checks all pass (in particular `Test snapshot`).

## PR checklist


- [x] Continuous integration checks all ✅
- [x] Update tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update doc/whatsnew.~ Just CI.
