### PR TITLE
Add functionality in `tools.costs` to specify cost reduction scenarios and values

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -15,7 +15,7 @@ Next release
 - Expand :doc:`repro` with sections on :ref:`repro-doc` and :ref:`versioning`, including :ref:`a list of external model names and ‘versions’ <model-names>` like “MESSAGEix-GLOBIOM 2.0” (:issue:`224`, :pull:`226`).
 - Update :doc:`/transport/index` (:pull:`213`).
 - Add "LED", "SSP4", and "SSP5" as values for the :program:`--ssp=…` option in :func:`.common_params` (:pull:`233`).
-- Fix and update :doc:`/api/tools-costs` (:pull:`219`, :pull:`206`, :pull:`221`, :pull:`227`, :pull:`222`)
+- Fix and update :doc:`/api/tools-costs` (:pull:`219`, :pull:`206`, :pull:`221`, :pull:`227`, :pull:`222`, :pull:`255`)
 
   - Fix naming of GDP and population columns in SSP data aggregation (:pull:`219`).
   - Edit inputs for storage, CSP, hydrogen, and industry technologies (:pull:`206`).
@@ -24,6 +24,7 @@ Next release
   - Reconfigure use and implementation of technology variants/modules to be more agnostic (:pull:`221`).
   - Change cost decay to reach reduction percentage specified on the year 2100 (:pull:`227`).
   - Add `cooling` technology variant/module (:pull:`222`).
+  - Add functionality to specify cost reduction values and cost reduction scenarios in a module (:pull:`255`).
 - Improve and extend :doc:`/material/index` (:pull:`218`, :pull:`253`).
 
   - Release of MESSAGEix-Materials 1.1.0 (:doc:`/material/v1.1.0`).

--- a/message_ix_models/data/costs/materials/cost_reduction.csv
+++ b/message_ix_models/data/costs/materials/cost_reduction.csv
@@ -1,0 +1,7 @@
+# Cost reduction in 2100,,,,,,
+# ,,,,,,
+# Units: %  ,,,,,,
+message_technology,technology_type,very_low,low,medium,high,very_high
+furnace_coal_cement,Materials,0.23,0.24,0.25,0.26,0.27
+gas_ct,Gas/Oil,0.99,0.99,0.99,0.99,0.99
+bio_hpl,Materials,0.77,0.77,0.77,0.77,0.77

--- a/message_ix_models/data/costs/materials/cost_reduction.csv
+++ b/message_ix_models/data/costs/materials/cost_reduction.csv
@@ -2,6 +2,3 @@
 # ,,,,,,
 # Units: %  ,,,,,,
 message_technology,technology_type,very_low,low,medium,high,very_high
-furnace_coal_cement,Materials,0.23,0.24,0.25,0.26,0.27
-gas_ct,Gas/Oil,0.99,0.99,0.99,0.99,0.99
-bio_hpl,Materials,0.77,0.77,0.77,0.77,0.77

--- a/message_ix_models/data/costs/materials/scenarios_reduction.csv
+++ b/message_ix_models/data/costs/materials/scenarios_reduction.csv
@@ -1,5 +1,1 @@
 message_technology,SSP1,SSP2,SSP3,SSP4,SSP5,LED
-furnace_coal_cement,low,low,low,low,low,low
-manuf_steel,medium,medium,medium,medium,medium,medium
-hp_elec_refining,high,high,high,high,high,high
-bio_hpl,very_low,very_low,very_low,very_low,very_low,very_low

--- a/message_ix_models/data/costs/materials/scenarios_reduction.csv
+++ b/message_ix_models/data/costs/materials/scenarios_reduction.csv
@@ -1,0 +1,5 @@
+message_technology,SSP1,SSP2,SSP3,SSP4,SSP5,LED
+furnace_coal_cement,low,low,low,low,low,low
+manuf_steel,medium,medium,medium,medium,medium,medium
+hp_elec_refining,high,high,high,high,high,high
+bio_hpl,very_low,very_low,very_low,very_low,very_low,very_low

--- a/message_ix_models/tests/tools/costs/test_decay.py
+++ b/message_ix_models/tests/tools/costs/test_decay.py
@@ -1,19 +1,89 @@
 from typing import Literal
 
+import pandas as pd
 import pytest
 
 from message_ix_models.tools.costs import Config
 from message_ix_models.tools.costs.decay import (
+    _get_module_cost_reduction,
+    _get_module_scenarios_reduction,
     get_technology_reduction_scenarios_data,
     project_ref_region_inv_costs_using_reduction_rates,
 )
 from message_ix_models.tools.costs.regional_differentiation import (
     apply_regional_differentiation,
+    get_raw_technology_mapping,
+    subset_module_map,
 )
 
 
+@pytest.mark.parametrize(
+    "module, t_exp",
+    (
+        ("energy", {"coal_ppl", "gas_ppl", "gas_cc", "solar_res1"}),
+        ("materials", {"biomass_NH3", "MTO_petro", "furnace_foil_steel"}),
+        ("cooling", {"coal_ppl__cl_fresh", "gas_cc__air", "nuc_lc__ot_fresh"}),
+    ),
+)
+def test_get_module_scenarios_reduction(
+    module: Literal["energy", "materials", "cooling"], t_exp
+) -> None:
+    tech_map = energy_map = get_raw_technology_mapping("energy")
+
+    # if module is not energy, run subset_module_map
+    if module != "energy":
+        module_map = get_raw_technology_mapping(module)
+        module_sub = subset_module_map(module_map)
+
+        # Remove energy technologies that exist in module mapping
+        energy_map = energy_map.query(
+            "message_technology not in @module_sub.message_technology"
+        )
+
+        tech_map = pd.concat([energy_map, module_sub], ignore_index=True)
+
+    result = _get_module_scenarios_reduction(module, energy_map, tech_map)
+
+    # Expected MESSAGEix-GLOBIOM technologies are present in the data
+    assert t_exp <= set(result.message_technology.unique())
+
+
+@pytest.mark.parametrize(
+    "module, t_exp",
+    (
+        ("energy", {"coal_ppl", "gas_ppl", "gas_cc", "solar_res1"}),
+        ("materials", {"biomass_NH3", "MTO_petro", "furnace_foil_steel"}),
+        ("cooling", {"coal_ppl__cl_fresh", "gas_cc__air", "nuc_lc__ot_fresh"}),
+    ),
+)
+def test_get_module_cost_reduction(
+    module: Literal["energy", "materials", "cooling"], t_exp
+) -> None:
+    tech_map = energy_map = get_raw_technology_mapping("energy")
+
+    # if module is not energy, run subset_module_map
+    if module != "energy":
+        module_map = get_raw_technology_mapping(module)
+        module_sub = subset_module_map(module_map)
+
+        # Remove energy technologies that exist in module mapping
+        energy_map = energy_map.query(
+            "message_technology not in @module_sub.message_technology"
+        )
+
+        tech_map = pd.concat([energy_map, module_sub], ignore_index=True)
+
+    # The function runs without error
+    result = _get_module_cost_reduction(module, energy_map, tech_map)
+
+    # Expected MESSAGEix-GLOBIOM technologies are present in the data
+    assert t_exp <= set(result.message_technology.unique())
+
+
 @pytest.mark.parametrize("module", ("energy", "materials", "cooling"))
-def test_get_technology_reduction_scenarios_data(module: str) -> None:
+def test_get_technology_reduction_scenarios_data(
+    module: Literal["energy", "materials", "cooling"],
+) -> None:
     config = Config()
     # The function runs without error
     result = get_technology_reduction_scenarios_data(config.y0, module=module)

--- a/message_ix_models/tests/tools/costs/test_decay.py
+++ b/message_ix_models/tests/tools/costs/test_decay.py
@@ -12,14 +12,6 @@ from message_ix_models.tools.costs.regional_differentiation import (
 )
 
 
-@pytest.mark.parametrize(
-    "module, t_exp",
-    (
-        ("energy", {"coal_ppl", "gas_ppl", "gas_cc", "solar_res1"}),
-        ("materials", {"biomass_NH3", "MTO_petro", "furnace_foil_steel"}),
-        ("cooling", {"coal_ppl__cl_fresh", "gas_cc__air", "nuc_lc__ot_fresh"}),
-    ),
-)
 @pytest.mark.parametrize("module", ("energy", "materials", "cooling"))
 def test_get_technology_reduction_scenarios_data(module: str) -> None:
     config = Config()

--- a/message_ix_models/tests/tools/costs/test_decay.py
+++ b/message_ix_models/tests/tools/costs/test_decay.py
@@ -26,7 +26,7 @@ from message_ix_models.tools.costs.regional_differentiation import (
     ),
 )
 def test_get_module_scenarios_reduction(
-    module: Literal["energy", "materials", "cooling"], t_exp
+    module: Literal["energy", "materials", "cooling"], t_exp: set[str]
 ) -> None:
     tech_map = energy_map = get_raw_technology_mapping("energy")
 
@@ -57,7 +57,7 @@ def test_get_module_scenarios_reduction(
     ),
 )
 def test_get_module_cost_reduction(
-    module: Literal["energy", "materials", "cooling"], t_exp
+    module: Literal["energy", "materials", "cooling"], t_exp: set[str]
 ) -> None:
     tech_map = energy_map = get_raw_technology_mapping("energy")
 
@@ -111,7 +111,9 @@ def test_get_technology_reduction_scenarios_data(
     ),
 )
 def test_project_ref_region_inv_costs_using_reduction_rates(
-    module: Literal["energy", "materials", "cooling"], t_exp, t_excluded
+    module: Literal["energy", "materials", "cooling"],
+    t_exp: set[str],
+    t_excluded: set[str],
 ) -> None:
     # Set up
     config = Config(module=module)

--- a/message_ix_models/tests/tools/costs/test_decay.py
+++ b/message_ix_models/tests/tools/costs/test_decay.py
@@ -4,7 +4,6 @@ import pytest
 
 from message_ix_models.tools.costs import Config
 from message_ix_models.tools.costs.decay import (
-    get_cost_reduction_data,
     get_technology_reduction_scenarios_data,
     project_ref_region_inv_costs_using_reduction_rates,
 )
@@ -21,18 +20,6 @@ from message_ix_models.tools.costs.regional_differentiation import (
         ("cooling", {"coal_ppl__cl_fresh", "gas_cc__air", "nuc_lc__ot_fresh"}),
     ),
 )
-def test_get_cost_reduction_data(module: str, t_exp) -> None:
-    # The function runs without error
-    result = get_cost_reduction_data(module)
-
-    # Expected MESSAGEix-GLOBIOM technologies are present in the data
-    assert t_exp <= set(result.message_technology.unique())
-
-    # Values of the "cost reduction" columns are between 0 and 1
-    stats = result.cost_reduction.describe()
-    assert 0 <= stats["min"] and stats["max"] <= 1
-
-
 @pytest.mark.parametrize("module", ("energy", "materials", "cooling"))
 def test_get_technology_reduction_scenarios_data(module: str) -> None:
     config = Config()

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -56,7 +56,7 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
 
         # In tech map, get technologies that are not in scenarios_joined
         # but are mapped to energy technologies
-        # then, use the scenarios_reduction.csv from the energy module for those technologies
+        # then use the scenarios reduction from the energy module for those technologies
         scenarios_module_map_to_energy = (
             tech_map_df.query(
                 "(message_technology not in @scenarios_joined.message_technology) and \

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -36,10 +36,12 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
     )
 
     if module != "energy":
-        if package_data_path("costs", module, "scenarios_reduction.csv"):
-            scenarios_module = pd.read_csv(
-                package_data_path("costs", module, "scenarios_reduction.csv")
-            )
+        ffile = package_data_path("costs", module, "scenarios_reduction.csv")
+
+        # if file exists, read it
+        # else, scenarios_joined is the same as scenarios_energy
+        if ffile:
+            scenarios_module = pd.read_csv(ffile)
 
             # if a technology exists in scenarios_module that exists in scen_red_energy,
             # remove it from scenarios_energy
@@ -54,7 +56,7 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
                 drop=True
             )
         else:
-            scenarios_joined = scenarios_energy
+            scenarios_joined = scenarios_energy.copy()
 
         # In tech map, get technologies that are not in scenarios_joined
         # but are mapped to energy technologies
@@ -155,10 +157,9 @@ def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
     )
 
     if module != "energy":
-        if package_data_path("costs", module, "cost_reduction.csv"):
-            reduction_module = pd.read_csv(
-                package_data_path("costs", module, "cost_reduction.csv"), comment="#"
-            )
+        ffile = package_data_path("costs", module, "cost_reduction.csv")
+        if ffile:
+            reduction_module = pd.read_csv(ffile, comment="#")
 
             # if a technology exists in scen_red_module that exists in scen_red_energy,
             # remove it from scen_red_energy
@@ -175,7 +176,7 @@ def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
                 .drop(columns=["technology_type"])
             )
         else:
-            reduction_joined = reduction_energy
+            reduction_joined = reduction_energy.copy()
 
         # In tech map, get technologies that are not in reduction_joined
         # but are mapped to energy technologies

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -9,7 +9,9 @@ from .config import Config
 from .regional_differentiation import get_raw_technology_mapping, subset_module_map
 
 
-def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
+def _get_module_scenarios_reduction(
+    module: str, energy_map_df: pd.DataFrame, tech_map_df: pd.DataFrame
+) -> pd.DataFrame:
     """Get scenarios reduction categories for a module.
 
     Parameters
@@ -154,7 +156,9 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
     return scenarios_all if module != "energy" else scenarios_energy
 
 
-def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
+def _get_module_cost_reduction(
+    module: str, energy_map_df: pd.DataFrame, tech_map_df: pd.DataFrame
+) -> pd.DataFrame:
     """Get cost reduction values for technologies in a module.
 
     Parameters
@@ -287,7 +291,9 @@ def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
 
 
 # create function to get technology reduction scenarios data
-def get_technology_reduction_scenarios_data(first_year, module):
+def get_technology_reduction_scenarios_data(
+    first_year: int, module: str
+) -> pd.DataFrame:
     # Get full list of technologies from mapping
     tech_map = energy_map = get_raw_technology_mapping("energy")
 

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -10,6 +10,29 @@ from .regional_differentiation import get_raw_technology_mapping, subset_module_
 
 
 def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
+    """Get scenarios reduction categories for a module.
+
+    Parameters
+    ----------
+    module : str
+        The module for which to get scenarios reduction categories.
+    energy_map_df : pandas.DataFrame
+        The technology mapping for the energy module.
+    tech_map_df : pandas.DataFrame
+        The technology mapping for the specific module.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns:
+        - message_technology: name of technology in MESSAGEix
+        - SSP1: scenario reduction category for SSP1
+        - SSP2: scenario reduction category for SSP2
+        - SSP3: scenario reduction category for SSP3
+        - SSP4: scenario reduction category for SSP4
+        - SSP5: scenario reduction category for SSP5
+        - LED: scenario reduction category for LED
+    """
     # Get reduction scenarios for energy module
     scenarios_energy = pd.read_csv(
         package_data_path("costs", "energy", "scenarios_reduction.csv")
@@ -131,9 +154,29 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
     return scenarios_all if module != "energy" else scenarios_energy
 
 
-# do similar in _get_module_scenarios_reduction but for cost_reduction.csv
-# and call it _get_module_cost_reduction
 def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
+    """Get cost reduction values for technologies in a module.
+
+    Parameters
+    ----------
+    module : str
+        The module for which to get cost reduction values.
+    energy_map_df : pandas.DataFrame
+        The technology mapping for the energy module.
+    tech_map_df : pandas.DataFrame
+        The technology mapping for the specific module.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns:
+        - message_technology: name of technology in MESSAGEix
+        - very_low: cost reduction for "none" scenario
+        - low: cost reduction for "low" scenario
+        - medium: cost reduction for "moderate" scenario
+        - high: cost reduction for "high" scenario
+        - very_high: cost reduction for "very high" scenario
+    """
     # Get cost reduction for energy module
     reduction_energy = pd.read_csv(
         package_data_path("costs", "energy", "cost_reduction.csv"), comment="#"

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -7,28 +7,236 @@ from .config import Config
 from .regional_differentiation import get_raw_technology_mapping, subset_module_map
 
 
-def get_cost_reduction_data(module) -> pd.DataFrame:
-    """Get cost reduction data from file.
+def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
+    # Get reduction scenarios for energy module
+    scenarios_energy = pd.read_csv(
+        package_data_path("costs", "energy", "scenarios_reduction.csv")
+    )
 
-    Raw data on cost reduction in 2100 for technologies are read from
-    :file:`data/[module]/cost_reduction_[module].csv`, based on GEA data.
+    # for technologies in energy_map that are not in scenarios_energy,
+    # assume scenario reduction across all scenarios is "none"
+    # add same columns as scenarios_energy
+    # and set all values to "none" except for message_technology column
+    scenarios_energy_no_reduction = energy_map_df.query(
+        "message_technology not in @scenarios_energy.message_technology"
+    )[["message_technology"]].assign(
+        **{
+            col: "none"
+            for col in scenarios_energy.columns
+            if col != "message_technology"
+        }
+    )
 
-    Parameters
-    ----------
-    module : str
-        Model module
+    # combine scenarios_energy and scenarios_energy_no_reduction into scenarios_energy
+    # order by message_technology
+    scenarios_energy = (
+        pd.concat([scenarios_energy, scenarios_energy_no_reduction], ignore_index=True)
+        .sort_values("message_technology")
+        .reset_index(drop=True)
+    )
 
-    Returns
-    -------
-    pandas.DataFrame
-        DataFrame with columns:
+    if module != "energy":
+        if package_data_path("costs", module, "scenarios_reduction.csv"):
+            scenarios_module = pd.read_csv(
+                package_data_path("costs", module, "scenarios_reduction.csv")
+            )
 
-        - message_technology: name of technology in MESSAGEix
-        - reduction_rate: the cost reduction rate (either very_low, low, medium, high,
-        or very_high)
-        - cost_reduction: cost reduction in 2100 (%)
-    """
+            # if a technology exists in scenarios_module that exists in scen_red_energy,
+            # remove it from scenarios_energy
+            scenarios_energy = scenarios_energy[
+                ~scenarios_energy["message_technology"].isin(
+                    scenarios_module["message_technology"]
+                )
+            ]
 
+            # append scen_red_module to scen_red_energy
+            scenarios_joined = scenarios_energy._append(scenarios_module).reset_index(
+                drop=True
+            )
+
+        # In tech map, get technologies that are not in scenarios_joined
+        # but are mapped to energy technologies
+        # then, use the scenarios_reduction.csv from the energy module for those technologies
+        scenarios_module_map_to_energy = (
+            tech_map_df.query(
+                "(message_technology not in @scenarios_joined.message_technology) and \
+                    (reg_diff_source == 'energy')"
+            )
+            .merge(
+                scenarios_energy.rename(
+                    columns={"message_technology": "base_message_technology"}
+                ),
+                how="left",
+                left_on="reg_diff_technology",
+                right_on="base_message_technology",
+            )
+            .drop(columns=["base_message_technology", "reg_diff_technology"])
+            .drop_duplicates()
+            .reset_index(drop=1)
+        )
+
+        scenarios_module_map_to_energy = scenarios_module_map_to_energy[
+            scenarios_joined.columns.intersection(
+                scenarios_module_map_to_energy.columns
+            )
+        ]
+
+        scenarios_module_map_to_energy.query("message_technology == 'fc_h2_aluminum'")
+        tech_map_df.query("message_technology == 'fc_h2_aluminum'")
+        scenarios_energy.query("message_technology == 'h2_fc_I'")
+
+        tech_map_df.query(
+            "(message_technology not in @scenarios_joined.message_technology) and \
+                    (reg_diff_source == 'energy')"
+        ).query("message_technology == 'fc_h2_aluminum'")
+
+        # for all technologies that are not in scenarios_module and
+        # are not mapped to energy technologies,
+        # assume scenario reduction across all scenarios is "none"
+        # add same columns as scenarios_joined
+        # and set all values to "none" except for message_technology column
+        scenarios_module_no_reduction = tech_map_df.query(
+            "message_technology not in @scenarios_joined.message_technology and \
+                reg_diff_source != 'energy'"
+        )[["message_technology"]].assign(
+            **{
+                col: "none"
+                for col in scenarios_joined.columns
+                if col != "message_technology"
+            }
+        )
+
+        # combine scenarios_joined, scenarios_module_map_to_energy,
+        # and scenarios_module_no_reduction
+        # order by message_technology
+        scenarios_all = (
+            pd.concat(
+                [
+                    scenarios_joined,
+                    scenarios_module_map_to_energy,
+                    scenarios_module_no_reduction,
+                ],
+                ignore_index=True,
+            )
+            .sort_values("message_technology")
+            .reset_index(drop=True)
+        )
+
+    return scenarios_all if module != "energy" else scenarios_energy
+
+
+# do similar in _get_module_scenarios_reduction but for cost_reduction.csv
+# and call it _get_module_cost_reduction
+def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
+    # Get cost reduction for energy module
+    reduction_energy = pd.read_csv(
+        package_data_path("costs", "energy", "cost_reduction.csv"), comment="#"
+    )
+
+    # for technologies in energy_map that are not in reduction_energy,
+    # assume scenario reduction across all scenarios is "none"
+    # add same columns as reduction_energy
+    # and set all values to "none" except for message_technology column
+    reduction_energy_no_reduction = energy_map_df.query(
+        "message_technology not in @reduction_energy.message_technology"
+    )[["message_technology"]].assign(
+        **{col: 0 for col in reduction_energy.columns if col != "message_technology"}
+    )
+
+    # combine reduction_energy and reduction_energy_no_reduction into reduction_energy
+    # order by message_technology
+    reduction_energy = (
+        pd.concat([reduction_energy, reduction_energy_no_reduction], ignore_index=True)
+        .sort_values("message_technology")
+        .reset_index(drop=True)
+        .drop(columns=["technology_type"])
+    )
+
+    if module != "energy":
+        if package_data_path("costs", module, "cost_reduction.csv"):
+            reduction_module = pd.read_csv(
+                package_data_path("costs", module, "cost_reduction.csv"), comment="#"
+            )
+
+            # if a technology exists in scen_red_module that exists in scen_red_energy,
+            # remove it from scen_red_energy
+            reduction_energy = reduction_energy[
+                ~reduction_energy["message_technology"].isin(
+                    reduction_module["message_technology"]
+                )
+            ]
+
+            # append scen_red_module to scen_red_energy
+            reduction_joined = (
+                reduction_energy._append(reduction_module)
+                .reset_index(drop=True)
+                .drop(columns=["technology_type"])
+            )
+
+        # In tech map, get technologies that are not in reduction_joined
+        # but are mapped to energy technologies
+        # then, use the reduction from the energy module for those technologies
+        reduction_module_map_to_energy = (
+            tech_map_df.query(
+                "(message_technology not in @reduction_joined.message_technology) and \
+                    (reg_diff_source == 'energy')"
+            )
+            .merge(
+                reduction_energy.rename(
+                    columns={"message_technology": "base_message_technology"}
+                ),
+                how="inner",
+                left_on="reg_diff_technology",
+                right_on="base_message_technology",
+            )
+            .drop(columns=["base_message_technology", "reg_diff_technology"])
+            .drop_duplicates()
+            .reset_index(drop=1)
+        )
+
+        reduction_module_map_to_energy = reduction_module_map_to_energy[
+            reduction_joined.columns.intersection(
+                reduction_module_map_to_energy.columns
+            )
+        ]
+
+        # for all technologies that are not in reduction_module and
+        # are not mapped to energy technologies,
+        # assume scenario reduction across all scenarios is "none"
+        # add same columns as reduction_joined
+        # and set all values to "none" except for message_technology column
+        reduction_module_no_reduction = tech_map_df.query(
+            "message_technology not in @reduction_joined.message_technology and \
+                reg_diff_source != 'energy'"
+        )[["message_technology"]].assign(
+            **{
+                col: 0
+                for col in reduction_joined.columns
+                if col != "message_technology"
+            }
+        )
+
+        # combine reduction_joined, reduction_module_map_to_energy,
+        # and reduction_module_no_reduction
+        # order by message_technology
+        reduction_all = (
+            pd.concat(
+                [
+                    reduction_joined,
+                    reduction_module_map_to_energy,
+                    reduction_module_no_reduction,
+                ],
+                ignore_index=True,
+            )
+            .sort_values("message_technology")
+            .reset_index(drop=True)
+        )
+
+    return reduction_all if module != "energy" else reduction_energy
+
+
+# create function to get technology reduction scenarios data
+def get_technology_reduction_scenarios_data(first_year, module):
     # Get full list of technologies from mapping
     tech_map = energy_map = get_raw_technology_mapping("energy")
 
@@ -44,143 +252,14 @@ def get_cost_reduction_data(module) -> pd.DataFrame:
 
         tech_map = pd.concat([energy_map, module_sub], ignore_index=True)
 
-    # Read in raw data
-    gea_file_path = package_data_path("costs", "energy", "cost_reduction.csv")
-    energy_rates = (
-        pd.read_csv(gea_file_path, header=8)
-        .melt(
-            id_vars=["message_technology", "technology_type"],
-            var_name="reduction_rate",
-            value_name="cost_reduction",
-        )
-        .assign(
-            technology_type=lambda x: x.technology_type.fillna("NA"),
-            cost_reduction=lambda x: x.cost_reduction.fillna(0),
-        )
-        .drop_duplicates()
-        .reset_index(drop=1)
-    ).reindex(["message_technology", "reduction_rate", "cost_reduction"], axis=1)
+    scenarios_reduction = _get_module_scenarios_reduction(module, energy_map, tech_map)
+    cost_reduction = _get_module_cost_reduction(module, energy_map, tech_map)
 
-    # For module technologies with map_tech == energy, map to base technologies
-    # and use cost reduction data
-    module_rates_energy = (
-        tech_map.query("reg_diff_source == 'energy'")
-        .drop(columns=["reg_diff_source", "base_year_reference_region_cost"])
-        .merge(
-            energy_rates.rename(
-                columns={"message_technology": "base_message_technology"}
-            ),
-            how="inner",
-            left_on="reg_diff_technology",
-            right_on="base_message_technology",
-        )
-        .drop(columns=["base_message_technology", "reg_diff_technology"])
-        .drop_duplicates()
-        .reset_index(drop=1)
-    ).reindex(["message_technology", "reduction_rate", "cost_reduction"], axis=1)
+    cost_reduction.query("message_technology == 'bio_hpl'")
 
-    # Combine technologies that have cost reduction rates
-    df_reduction_techs = pd.concat(
-        [energy_rates, module_rates_energy], ignore_index=True
-    )
-    df_reduction_techs = df_reduction_techs.drop_duplicates().reset_index(drop=1)
-
-    # Create unique dataframe of cost reduction rates
-    # and make all cost_reduction values 0
-    un_rates = pd.DataFrame(
-        {
-            "reduction_rate": ["none"],
-            "cost_reduction": [0],
-            "key": "z",
-        }
-    )
-    # For remaining module technologies that are not mapped to energy technologies,
-    # assume no cost reduction
-    module_rates_noreduction = (
-        tech_map.query(
-            "message_technology not in @df_reduction_techs.message_technology"
-        )
-        .assign(key="z")
-        .merge(un_rates, on="key")
-        .drop(columns=["key"])
-    ).reindex(["message_technology", "reduction_rate", "cost_reduction"], axis=1)
-
-    # Concatenate base and module rates
-    all_rates = pd.concat(
-        [energy_rates, module_rates_energy, module_rates_noreduction],
-        ignore_index=True,
-    ).reset_index(drop=1)
-
-    return all_rates
-
-
-def get_technology_reduction_scenarios_data(
-    first_year: int, module: str
-) -> pd.DataFrame:
-    """Read in technology first year and cost reduction scenarios.
-
-    Raw data on technology first year and reduction scenarios are read from
-    :file:`data/costs/[module]/first_year_[module]`. The first year the technology is
-    available in MESSAGEix is adjusted to be the base year if the original first year is
-    before the base year.
-
-    Raw data on cost reduction scenarios are read from
-    :file:`data/costs/[module]/scenarios_reduction_[module].csv`.
-
-    Assumptions are made for the non-energy module for technologies' cost reduction
-    scenarios that are not given.
-
-    Parameters
-    ----------
-    base_year : int, optional
-        The base year, by default set to global BASE_YEAR
-    module : str
-        Model module
-
-    Returns
-    -------
-    pandas.DataFrame
-        DataFrame with columns:
-
-        - message_technology: name of technology in MESSAGEix
-        - scenario: scenario (SSP1, SSP2, SSP3, SSP4, SSP5, or LED)
-        - first_technology_year: first year the technology is available in MESSAGEix.
-        - reduction_rate: the cost reduction rate (either very_low, low, medium, high,
-        or very_high)
-    """
-
-    energy_first_year_file = package_data_path("costs", "energy", "tech_map.csv")
-    df_first_year = pd.read_csv(energy_first_year_file, skiprows=4)[
-        ["message_technology", "first_year_original"]
-    ]
-
-    if module != "energy":
-        module_first_year_file = package_data_path("costs", module, "tech_map.csv")
-        module_first_year = pd.read_csv(module_first_year_file)[
-            ["message_technology", "first_year_original"]
-        ]
-        df_first_year = pd.concat(
-            [df_first_year, module_first_year], ignore_index=True
-        ).drop_duplicates()
-
-    tech_map = tech_energy = get_raw_technology_mapping("energy")
-
-    if module != "energy":
-        tech_module = subset_module_map(get_raw_technology_mapping(module))
-        tech_energy = tech_energy.query(
-            "message_technology not in @tech_module.message_technology"
-        )
-        tech_map = pd.concat([tech_energy, tech_module], ignore_index=True)
-
-    tech_map = tech_map.reindex(
-        ["message_technology", "reg_diff_source", "reg_diff_technology"], axis=1
-    ).drop_duplicates()
-
-    # Adjust first year:
-    # - if first year is missing, set to base year
-    # - if first year is after base year, then keep assigned first year
-    all_first_year = (
-        pd.merge(tech_map, df_first_year, on="message_technology", how="left")
+    # get first year values
+    adj_first_year = (
+        tech_map[["message_technology", "first_year_original"]]
         .assign(
             first_technology_year=lambda x: np.where(
                 x.first_year_original.isnull(),
@@ -196,78 +275,26 @@ def get_technology_reduction_scenarios_data(
         .drop(columns=["first_year_original"])
     )
 
-    # Create new column for scenario_technology
-    # - if reg_diff_source == weo, then scenario_technology = message_technology
-    # - if reg_diff_source == energy, then scenario_technology = reg_diff_technology
-    # - otherwise, scenario_technology = message_technology
-    adj_first_year = (
-        all_first_year.assign(
-            scenario_technology=lambda x: np.where(
-                x.reg_diff_source == "weo",
-                x.message_technology,
-                np.where(
-                    x.reg_diff_source == "energy",
-                    x.reg_diff_technology,
-                    x.message_technology,
-                ),
-            )
-        )
-        .drop(columns=["reg_diff_source", "reg_diff_technology"])
-        .drop_duplicates()
-        .reset_index(drop=1)
+    # convert scenarios_reduction and cost_reduction to long format
+    scenarios_reduction_long = scenarios_reduction.melt(
+        id_vars=["message_technology"], var_name="scenario", value_name="reduction_rate"
+    )
+    cost_reduction_long = cost_reduction.melt(
+        id_vars=["message_technology"],
+        var_name="reduction_rate",
+        value_name="cost_reduction",
     )
 
-    # Merge with energy technologies that have given scenarios
-    energy_scen_file = package_data_path("costs", "energy", "scenarios_reduction.csv")
-    df_energy_scen = pd.read_csv(energy_scen_file).rename(
-        columns={"message_technology": "scenario_technology"}
-    )
+    # merge scenarios_reduction_long and cost_reduction_long
+    # with adj_first_year
+    df = scenarios_reduction_long.merge(
+        cost_reduction_long, on=["message_technology", "reduction_rate"], how="left"
+    ).merge(adj_first_year, on="message_technology", how="left")
 
-    existing_scens = (
-        pd.merge(
-            adj_first_year,
-            df_energy_scen,
-            on=["scenario_technology"],
-            how="inner",
-        )
-        .drop(columns=["scenario_technology"])
-        .melt(
-            id_vars=[
-                "message_technology",
-                "first_technology_year",
-            ],
-            var_name="scenario",
-            value_name="reduction_rate",
-        )
-    )
+    # if reduction_rate is "none", then set cost_reduction to 0
+    df["cost_reduction"] = np.where(df.reduction_rate == "none", 0, df.cost_reduction)
 
-    # Create dataframe of SSP1-SSP5 and LED scenarios with "none" cost reduction rate
-    un_scens = pd.DataFrame(
-        {
-            "scenario": ["SSP1", "SSP2", "SSP3", "SSP4", "SSP5", "LED"],
-            "reduction_rate": "none",
-            "key": "z",
-        }
-    )
-
-    # Get remaining technologies that do not have given scenarios
-    remaining_scens = (
-        adj_first_year.query(
-            "message_technology not in @existing_scens.message_technology.unique()"
-        )
-        .assign(key="z")
-        .merge(un_scens, on="key")
-        .drop(columns=["key", "scenario_technology"])
-    )
-
-    # Concatenate all technologies
-    all_scens = (
-        pd.concat([existing_scens, remaining_scens], ignore_index=True)
-        .sort_values(by=["message_technology", "scenario"])
-        .reset_index(drop=1)
-    )
-
-    return all_scens
+    return df
 
 
 def project_ref_region_inv_costs_using_reduction_rates(
@@ -309,15 +336,9 @@ def project_ref_region_inv_costs_using_reduction_rates(
         - inv_cost_ref_region_decay: investment cost in reference region in year.
     """
 
-    # Get cost reduction data
-    df_cost_reduction = get_cost_reduction_data(config.module)
-
-    # Get scenarios data
-    df_scenarios = get_technology_reduction_scenarios_data(config.y0, config.module)
-
-    # Merge cost reduction data with cost reduction rates data
-    df_cost_reduction = df_cost_reduction.merge(
-        df_scenarios, on=["message_technology", "reduction_rate"], how="left"
+    # Get scenarios cost reduction data for technologies
+    df_cost_reduction = get_technology_reduction_scenarios_data(
+        config.y0, config.module
     )
 
     # Filter for reference region, and merge with reduction scenarios and discount rates

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -53,6 +53,8 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
             scenarios_joined = scenarios_energy._append(scenarios_module).reset_index(
                 drop=True
             )
+        else:
+            scenarios_joined = scenarios_energy
 
         # In tech map, get technologies that are not in scenarios_joined
         # but are mapped to energy technologies
@@ -172,6 +174,8 @@ def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
                 .reset_index(drop=True)
                 .drop(columns=["technology_type"])
             )
+        else:
+            reduction_joined = reduction_energy
 
         # In tech map, get technologies that are not in reduction_joined
         # but are mapped to energy technologies

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pandas as pd
 
@@ -40,7 +42,7 @@ def _get_module_scenarios_reduction(module, energy_map_df, tech_map_df):
 
         # if file exists, read it
         # else, scenarios_joined is the same as scenarios_energy
-        if ffile:
+        if os.path.exists(ffile):
             scenarios_module = pd.read_csv(ffile)
 
             # if a technology exists in scenarios_module that exists in scen_red_energy,
@@ -158,7 +160,8 @@ def _get_module_cost_reduction(module, energy_map_df, tech_map_df):
 
     if module != "energy":
         ffile = package_data_path("costs", module, "cost_reduction.csv")
-        if ffile:
+
+        if os.path.exists(ffile):
             reduction_module = pd.read_csv(ffile, comment="#")
 
             # if a technology exists in scen_red_module that exists in scen_red_energy,

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -1,4 +1,5 @@
 import os
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -10,7 +11,9 @@ from .regional_differentiation import get_raw_technology_mapping, subset_module_
 
 
 def _get_module_scenarios_reduction(
-    module: str, energy_map_df: pd.DataFrame, tech_map_df: pd.DataFrame
+    module: Literal["energy", "materials", "cooling"],
+    energy_map_df: pd.DataFrame,
+    tech_map_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """Get scenarios reduction categories for a module.
 
@@ -157,7 +160,9 @@ def _get_module_scenarios_reduction(
 
 
 def _get_module_cost_reduction(
-    module: str, energy_map_df: pd.DataFrame, tech_map_df: pd.DataFrame
+    module: Literal["energy", "materials", "cooling"],
+    energy_map_df: pd.DataFrame,
+    tech_map_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """Get cost reduction values for technologies in a module.
 
@@ -292,7 +297,7 @@ def _get_module_cost_reduction(
 
 # create function to get technology reduction scenarios data
 def get_technology_reduction_scenarios_data(
-    first_year: int, module: str
+    first_year: int, module: Literal["energy", "materials", "cooling"]
 ) -> pd.DataFrame:
     # Get full list of technologies from mapping
     tech_map = energy_map = get_raw_technology_mapping("energy")


### PR DESCRIPTION
This PR adds the functionality for a user to add specific cost reduction values and scenario assumptions in the costs tool.

This PR closes: 
- #251 


The logic is as follows (for both the cost reduction values and the reduction scenario categories):

1. If values/categories are specified in the non-energy module for a technology, then this value is used. If such values exist already in the energy module, the value in the non-energy module takes precedence (similar to how base year costs are implemented in this way) and replaces the energy module's values.
2. If no values/categories are specified in the non-energy module for a technology but that technology is mapped to an energy technology, then the mapped energy technology's values/categories are used.
3. If no values/categories are specified in the non-energy module or a mapped technology energy module for a technology, then no cost reduction is assumed.

~~For the time being, I have added some dummy examples using the `materials` module. The following cases I tested for:~~
* ~~Specifying scenario assumptions and cost reduction values for a technology that only exists in the `materials` module.~~
* ~~Specifying only scenario categories for a `materials` technology that is mapped to an `energy` technology. So while the cost reduction values associated with the categories for the `energy` technology is used, the customized scenario assumptions in the `materials` takes precedence.~~
* ~~Specifying cost reduction values that already exists in the `energy` module with its own cost reduction values (therefore replacing the original cost reduction values).~~
* ~~Specifying scenario assumptions and cost reduction values for a technology that does not have these values specified in the `energy` module. Therefore, if running `energy` module, then this technology has no cost reduction (because empty). But if running `materials` module, then the specified assumptions and values will be used.~~

I can remove the dummy examples after reviews say this methodology/PR makes sense.

## How to review

For @GamzeUnlu95: Could you check if the methodology implemented in this PR would work for the costs differentiation you want to achieve for steel and cement technologies?

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand~ Modify tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.