### PR TITLE
Test against ixmp4

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -105,6 +105,9 @@ jobs:
         - { upstream: v3.10.0, python: "3.13" }  # 2025-02-21
         # Development version + latest released Python
         - { upstream: main,   python: "3.13" }
+        # NB Python 3.9 not supported by ixmp4
+        - { upstream: enh/ixmp4, python: "3.10"}
+        - { upstream: enh/ixmp4, python: "3.13"}
 
         exclude:
         # Specific version combinations that are invalid / not to be used
@@ -115,6 +118,7 @@ jobs:
         # Redundant with macos-latest
         - { os: macos-13, version: { upstream: v3.10.0 }}
         - { os: macos-13, version: { upstream: main }}
+        - { os: macos-13, version: { upstream: enh/ixmp4 }}
 
       fail-fast: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
   - id: mypy
     pass_filenames: false
     additional_dependencies:
-    - "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
-    - "message-ix @ git+https://github.com/iiasa/message_ix.git@main"
+    - "ixmp @ git+https://github.com/iiasa/ixmp.git@enh/ixmp4"
+    - "message-ix @ git+https://github.com/iiasa/message_ix.git@enh/ixmp4"
     - plotnine
     - pytest
     - sdmx1


### PR DESCRIPTION
This is a minimal PR to check that the message-ix-model test suite runs using ixmp4 storage (i.e. without the ixmp.JDBCBackend and underlying Java code). To do this, it:

- Installs from the branch for iiasa/ixmp#552 that:
  - Provides a minimal 'shim' layer between the behaviour of ixmp.Platform, ixmp.TimeSeries, ixmp.Scenario and the underlying ixmp4 API.
  - Ensures that all of the behaviour of those 3 classes continues to pass the ixmp test suite when using ixmp4 storage. (message-ix-models and downstream/user code rely on that behaviour.)
  - Will (but does not yet, as of 2024-11-28) [parametrize](https://docs.pytest.org/en/stable/how-to/parametrize.html) the `ixmp.testing.test_mp` fixture to yield either the current ixmp.JDBCBackend-backed test Platform, or an ixmp4-backed test Platform.
- Installs from the branch for iiasa/message_ix#894. (Technically this should not be necessary: if the shim works, then the `message_ix.tests` will pass with the code on message_ix `main` branch. However, using that branch makes for smaller adjustments to the GitHub Actions workflows here.)
- Confirms that the collective behaviour of the upstream packages continues to pass the `message_ix_models.tests` suite, with *either* storage option. (MESSAGEix-GLOBIOM workflows and downstream/user code rely on this behaviour.)

Implementation/to dos:
- As a consequence of parametrizing `ixmp.testing.test_mp`, all tests in `message_ix_models.tests` that use the `test_mp` fixture will run *twice*: once with JDBCBackend, and once with ixmp4.
- Some other tests may not be parametrized automatically by the upstream changes:
  - [ ] Identify these.
  - [ ] Parametrize them manually.
- [ ] Rebase this branch frequently.
- [ ] Debug installation of ixmp4 alongside other dependencies.

Some things not in scope for this PR:
- Changes to the behaviour/API of message_ix_models.
- Migrating code from `ixmp` or `message_ix`.

## How to review

**TBA**

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Look at a certain page in the ReadTheDocs preview build of the documentation.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  doc/whatsnew.rst, where '999' is the GitHub pull request number:

  - Title or single-sentence description from above (:pull:`999`:).

  Commit with a message like “Add #999 to doc/whatsnew”
  -->
