### PR TITLE
Raise error in `tools.costs` when a technology is assigned a reduction rate for which it does not have value 

### DIFF
--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -314,8 +314,6 @@ def get_technology_reduction_scenarios_data(
     scenarios_reduction = _get_module_scenarios_reduction(module, energy_map, tech_map)
     cost_reduction = _get_module_cost_reduction(module, energy_map, tech_map)
 
-    cost_reduction.query("message_technology == 'bio_hpl'")
-
     # get first year values
     adj_first_year = (
         tech_map[["message_technology", "first_year_original"]]

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -365,8 +365,10 @@ def get_technology_reduction_scenarios_data(
         )
 
         raise ValueError(
-            f"The following technology + scenario + reduction rate combinations are missing data. Please check the reduction rate exists for the technology.\n\
-                {check_nan.print.unique().tolist()}."
+            "The following technology + scenario + reduction rate combinations "
+            "are missing data. "
+            "Please check that the reduction rate exists for the technology.\n"
+            f"{check_nan.print.unique().tolist()}."
         )
 
     # if reduction_rate is "none", then set cost_reduction to 0

--- a/message_ix_models/tools/costs/decay.py
+++ b/message_ix_models/tools/costs/decay.py
@@ -350,6 +350,27 @@ def get_technology_reduction_scenarios_data(
         cost_reduction_long, on=["message_technology", "reduction_rate"], how="left"
     ).merge(adj_first_year, on="message_technology", how="left")
 
+    # filter for rows where cost_reduction is NaN and reduction rate is not "none"
+    # these are instances where a technology has a reduction_rate that
+    # does not have a cost_reduction value
+    check_nan = df.query("cost_reduction.isnull() and reduction_rate != 'none'")[
+        ["message_technology", "scenario", "reduction_rate"]
+    ]
+
+    if not check_nan.empty:
+        check_nan["print"] = (
+            check_nan.message_technology
+            + " + "
+            + check_nan.scenario
+            + " + "
+            + check_nan.reduction_rate
+        )
+
+        raise ValueError(
+            f"The following technology + scenario + reduction rate combinations are missing data. Please check the reduction rate exists for the technology.\n\
+                {check_nan.print.unique().tolist()}."
+        )
+
     # if reduction_rate is "none", then set cost_reduction to 0
     df["cost_reduction"] = np.where(df.reduction_rate == "none", 0, df.cost_reduction)
 


### PR DESCRIPTION
Small PR to add an error in the costs tool in instances where a technology has a reduction category that is missing data

This issue came up in #235 (see @khaeru's comment [here](https://github.com/iiasa/message-ix-models/pull/235#issuecomment-2546330758)), where a technology was missing a reduction rate category in `cost_reduction.csv` that other technologies had. In this case, it didn't matter too much as that missing cost reduction category was never specified for that technology in the `scenarios_reduction.csv`. However, a hypothetical was brought up: what happens if a technology is assigned a reduction category for a scenario, but said reduction category does not exist for said technology?

I have added a few lines to check for these instances and if they exist, the tool should raise an error. 

## How to review

For @khaeru and/or @glatterf42 : Read the diff and note that the CI checks all pass.

## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.