### PR TITLE
Fix envvar name in snapshot CI

### DIFF
--- a/.github/workflows/pytest-snapshots.yaml
+++ b/.github/workflows/pytest-snapshots.yaml
@@ -39,7 +39,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         cache-dependency-glob: "**/pyproject.toml"
-        python-version: ${{ env.python }}
+        python-version: ${{ env.python-version }}
 
     - uses: iiasa/actions/setup-gams@main
       with:


### PR DESCRIPTION
#281 renamed the environment variable for the python version of our snapshot CI test from `python` to `python-version`. The uv action could not find `env.python` and thus saw no input for `python-version`, which it needs to create a venv. And without a venv, we get [the error we see in today's snapshot CI test](https://github.com/iiasa/message-ix-models/actions/runs/12922591067/job/36038523512).

This PR adjust the name of the environment variable used for the uv action.


## How to review


- Read the diff and note that the variable name used now is correct.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update doc/whatsnew.~ Just CI.

