### PR TITLE
Add `.util.slurm` and CLI

### DIFF
--- a/doc/api/util.rst
+++ b/doc/api/util.rst
@@ -225,6 +225,14 @@ Commonly used:
 .. automodule:: message_ix_models.util.sdmx
    :members:
 
+:mod:`.util.slurm`
+==================
+
+.. currentmodule:: message_ix_models.util.slurm
+
+.. automodule:: message_ix_models.util.slurm
+   :members:
+
 :mod:`.types`
 =============
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,6 +211,7 @@ intersphinx_mapping = {
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "sdmx": ("https://sdmx1.readthedocs.io/en/stable/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
 # -- Options for sphinx.ext.linkcode / ixmp.util.sphinx_linkcode_github ----------------

--- a/doc/distrib.rst
+++ b/doc/distrib.rst
@@ -1,5 +1,5 @@
-Overview and tooling
-********************
+Distributed computing
+*********************
 
 This page introduces considerations, tools, and features for using **distributed** or **high-throughput computing** with MESSAGEix-GLOBIOM.
 
@@ -38,4 +38,7 @@ Tooling
   `HTCondor <https://htcondor.readthedocs.io/en/latest/>`_, etc., but rather allow :mod:`message_ix` & co. to be used with/through those.
 - The individual features, tools, utilities, etc. should each be simple, i.e. `do one thing, and do it well <https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well>`__.
 
-.. todo:: Extend.
+See:
+
+- :doc:`howto/unicc` —a guide for one particular cluster using SLURM.
+- :mod:`.util.slurm` for the :program:`mix-models sbatch` command-line utility.

--- a/doc/howto/index.rst
+++ b/doc/howto/index.rst
@@ -17,6 +17,8 @@ Each HOWTO is contained on its own page:
 
    Run a baseline model <quickstart>
    Run mix-models on UnICC <unicc>
+   migrate
+   Release message-ix-models <release>
 
 Write a HOWTO
 =============

--- a/doc/howto/index.rst
+++ b/doc/howto/index.rst
@@ -1,0 +1,43 @@
+HOWTO guides
+************
+
+This section contains some HOWTO guides.
+The name alludes to the `Linux Documentation Project <https://tldp.org/FAQ/LDP-FAQ/index.html#AEN56>`_, wherein:
+
+   A HOWTO is usually a step-by-step guide that describe[s], in detail, how to perform **a specific task**.
+
+This contrasts with the :mod:`message_ix_models` API reference documentation, which describes exactly and completely WHAT code exists and does.
+API documentation is neutral with regards to *how* a user (like you!) might choose to use/apply the code, while a HOWTO lays out a particular way to apply the code, given the task to be accomplished.
+
+Each HOWTO is contained on its own page:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: HOWTO
+
+   Run a baseline model <quickstart>
+   Run mix-models on UnICC <unicc>
+
+Write a HOWTO
+=============
+
+1. Create a new page in this directory and add it to the ``..toctree::``.
+2. Choose a title and write headings and sentences using the imperative case, the same as the MESSAGEix :ref:`message-ix:code-style` recommends for commit messages:
+
+   Bad
+      Debugging long solve times
+
+      Setting up your virtual environment
+
+   Good
+      Debug long solve times
+
+      Set up a virtual environment
+
+3. Include a section on "Prerequisite knowledge" or similar.
+   Give links to other documentation or external resources that contain information the user needs in order to successfully follow the HOWTO.
+   These can include the original documentation, manpages, etc. for other tools to be used.
+4. Throughout, if you repeat key details from those external resource
+5. Use Sphinx :doc:`admonition, message, and warning directives <sphinx:usage/restructuredtext/directives>` to highlight information for the reader.
+   **Do not** use UPPER CASE or other ad-hoc formatting for the same purpose.
+6. Use :rfc:`2119` keywords in bold-face like **must** and **should**, to distinguish optional from mandatory steps and actions.

--- a/doc/howto/migrate.rst
+++ b/doc/howto/migrate.rst
@@ -1,5 +1,5 @@
-Migrating from :mod:`message_data`
-**********************************
+Migrate code from :mod:`message_data`
+*************************************
 
 :mod:`message_ix_models` coexists with the private repository/package currently named :mod:`message_data`.
 The latter is the location for code related to new research that has not yet been completed and published, data that must remain closed-source permanently, etc.
@@ -14,8 +14,8 @@ Over time:
 .. contents::
    :local:
 
-Using both packages together
-============================
+Use both packages together
+==========================
 
 This section gives some practices and tips for using the two packages together.
 

--- a/doc/howto/quickstart.rst
+++ b/doc/howto/quickstart.rst
@@ -1,5 +1,5 @@
-Quick-start guide to running a MESSAGEix-GLOBIOM baseline model
-***************************************************************
+Run a MESSAGEix-GLOBIOM baseline model
+**************************************
 
 .. contents::
    :local:

--- a/doc/howto/release.rst
+++ b/doc/howto/release.rst
@@ -1,5 +1,5 @@
-Releasing
-*********
+Release a new version of :mod:`message_ix_models`
+*************************************************
 
 Version numbers
 ===============

--- a/doc/howto/unicc.rst
+++ b/doc/howto/unicc.rst
@@ -1,5 +1,5 @@
-Running MESSAGEix on UnICC
-**************************
+Run :program:`mix-models` on UnICC
+**********************************
 
 This is a guide on how to get set up on the Unified IIASA Computing Cluster (UnICC) and how to run MESSAGEix scenarios on the cluster.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,8 @@ Among other tasks, the tools allow modelers to:
    howto/index
    repro
    distrib
+   develop
+   whatsnew
    bibliography
 
 API reference
@@ -104,15 +106,6 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    pkg-data/year
    pkg-data/codelists
    pkg-data/iiasa-se
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Development
-
-   develop
-   whatsnew
-   migrate
-   releasing
 
 Indices and tables
 ==================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,14 +14,15 @@ Among other tasks, the tools allow modelers to:
 - report quantities computed from model outputs.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: User guide
 
    install
    data
    cli
-   quickstart
+   howto/index
    repro
+   distrib
    bibliography
 
 API reference
@@ -103,13 +104,6 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    pkg-data/year
    pkg-data/codelists
    pkg-data/iiasa-se
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Distributed computing
-
-   distrib/overview
-   distrib/unicc
 
 .. toctree::
    :maxdepth: 2

--- a/doc/repro.rst
+++ b/doc/repro.rst
@@ -182,8 +182,8 @@ Each test **should** have a docstring explaining what it checks.
 
    tests
 
-Running the test suite
-----------------------
+Run the test suite
+------------------
 
 Some notes for running the test suite.
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -16,7 +16,8 @@ Next release
   - Simplify and consolidate tests.
 
 - Add :func:`.prepare_method_B` to :mod:`.ssp.transport` (:pull:`259`).
-- New HOWTO guide :doc:`/distrib/unicc` (:pull:`279`) and supporting command :program:`mix-models sbatch` in :mod:`.util.slurm` (:pull:`291`).
+- New :doc:`/howto/index` documentation sub-tree (:pull:`291`).
+- New guide on HOWTO :doc:`/howto/unicc` (:pull:`279`) and supporting command :program:`mix-models sbatch` in :mod:`.util.slurm` (:pull:`291`).
 - New utility :class:`.sdmx.AnnotationsMixIn` (:pull:`259`).
 
 v2025.1.10

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -16,7 +16,7 @@ Next release
   - Simplify and consolidate tests.
 
 - Add :func:`.prepare_method_B` to :mod:`.ssp.transport` (:pull:`259`).
-- New HOWTO guide :doc:`/distrib/unicc` (:pull:`279`).
+- New HOWTO guide :doc:`/distrib/unicc` (:pull:`279`) and supporting command :program:`mix-models sbatch` in :mod:`.util.slurm` (:pull:`291`).
 - New utility :class:`.sdmx.AnnotationsMixIn` (:pull:`259`).
 
 v2025.1.10

--- a/message_ix_models/cli.py
+++ b/message_ix_models/cli.py
@@ -169,6 +169,7 @@ submodules = [
     "message_ix_models.model.material.cli",
     "message_ix_models.testing.cli",
     "message_ix_models.util.pooch",
+    "message_ix_models.util.slurm",
 ]
 
 try:

--- a/message_ix_models/tests/test_cli.py
+++ b/message_ix_models/tests/test_cli.py
@@ -12,6 +12,7 @@ COMMANDS = [
     ("edits", "_debug"),
     ("fetch",),
     ("report",),
+    ("sbatch",),
     ("ssp", "gen-structures"),
     ("techs",),
     ("testing",),

--- a/message_ix_models/tests/util/test_slurm.py
+++ b/message_ix_models/tests/util/test_slurm.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "sbatch_opts, env",
+    (
+        (["--username=u", "--venv=/path/to/venv"], {}),  # Use CLI options
+        ([], {"USER": "u", "VIRTUAL_ENV": "/path/to/venv"}),  # Options from env vars
+    ),
+)
+def test_cli(monkeypatch, tmp_path, mix_models_cli, sbatch_opts, env) -> None:
+    cmd = (
+        ["sbatch"]
+        + sbatch_opts
+        + ["--", "--opt0=0", "foo", "--opt1=1", "bar", "--opt2=2", "baz"]
+    )
+
+    # Set a temporary, fixed $HOME directory that exists
+    home = str(tmp_path)
+    monkeypatch.setitem(mix_models_cli.env, "HOME", home)
+
+    for k, v in env.items():
+        monkeypatch.setitem(mix_models_cli.env, k, v)
+
+    # Command completes without error
+    result = mix_models_cli.assert_exit_0(cmd)
+
+    # Template is rendered correctly
+    for line in (
+        "#SBATCH --mail-user=u@iiasa.ac.at",
+        f"#SBATCH -o {home}/out/solve_%J.out",
+        "source /path/to/venv/bin/activate",
+        "export IXMP_DATA=/path/to/venv/share/ixmp",
+        "mix-models --opt0=0 foo --opt1=1 bar --opt2=2 baz",
+    ):
+        assert f"\n{line}\n" in result.output

--- a/message_ix_models/util/slurm.py
+++ b/message_ix_models/util/slurm.py
@@ -1,4 +1,41 @@
-"""Utilities for the `SLURM Workload Manager <https://slurm.schedmd.com/>`_."""
+"""Utilities for the `SLURM Workload Manager <https://slurm.schedmd.com/>`_.
+
+To use, transform a desired, ordinary invocation of the :program:`mix-models` CLI:
+
+.. code-block:: bash
+   :caption: Command 1
+
+   mix-models --opt_a=0 -b 2 command --opt_c=2 subcommand --opt_d=3 arg0 arg1
+
+…into something like:
+
+.. code-block:: bash
+   :caption: Command 2
+
+   mix-models sbatch --go \\
+     --username=example_user \\
+     --venv=/home/example_user/venv/py3.13_demo \\
+     -- \\
+     --opt_a=0 -b 2 command --opt_c=2 subcommand --opt_d=3 arg0 arg1
+
+In particular:
+
+- The inserted ``--`` separates the command ``sbatch`` from the options and arguments to
+  be used to invoke :program:`mix-models` on the worker node.
+  This command will result in exactly Command 1 being invoked at the end of the script
+  :data:`TEMPLATE`.
+- The options :program:`--username` and  :program:`--venv` are also passed into the
+  template. As the name implies, they are optional. The values are read from the
+  ``$USER`` and ``$VIRTUAL_ENV`` environment variables, respectively, wherever Command 2
+  is invoked.
+- Without the option :program:`--go`, the batch script is only printed out.
+  Add this option to actually call sbatch.
+
+See also:
+
+- `sbatch <https://slurm.schedmd.com/sbatch.html>`_ manual page.
+- :doc:`/distrib/unicc`.
+"""
 
 import os
 from collections.abc import Sequence
@@ -12,6 +49,9 @@ if TYPE_CHECKING:
 
 #: Template for an sbatch script. Currently, the same as suggested by
 #: :doc:`/distrib/unicc`.
+#:
+#: .. todo:: Read this content in separate pieces from the user's configuration and
+#:    assemble.
 TEMPLATE = """#!/bin/bash
 #SBATCH --time=1:00:00
 #SBATCH --mem=32G

--- a/message_ix_models/util/slurm.py
+++ b/message_ix_models/util/slurm.py
@@ -1,0 +1,73 @@
+"""Utilities for the `SLURM Workload Manager <https://slurm.schedmd.com/>`_."""
+
+import os
+from collections.abc import Sequence
+from subprocess import PIPE, STDOUT, run
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    import subprocess
+
+#: Template for an sbatch script. Currently, the same as suggested by
+#: :doc:`/distrib/unicc`.
+TEMPLATE = """#!/bin/bash
+#SBATCH --time=1:00:00
+#SBATCH --mem=32G
+#SBATCH --mail-type=BEGIN,END,FAIL
+#SBATCH --mail-user={username}@iiasa.ac.at
+#SBATCH -o {home_path}/out/solve_%J.out
+#SBATCH -e {home_path}/err/solve_%J.err
+
+module purge
+source /opt/apps/lmod/8.7/init/bash
+module load Python/3.11.5-GCCcore-13.2.0
+module load Java
+
+echo "Activate environment and set IXMP_DATA"
+source {env_path}/bin/activate
+export IXMP_DATA={env_path}/share/ixmp
+
+echo "Invoke message-ix-models"
+mix-models {args}
+"""
+
+
+def invoke_sbatch(
+    username: str, venv_path: str, args: Sequence[str], *, dry_run: bool = False
+) -> "subprocess.CompletedProcess":
+    """Invoke :program:`sbatch` using :func:`subprocess.run`.
+
+    :data:`TEMPLATE` is formatted using the arguments and passed directly to
+    :program:`sbatch` on standard input.
+    """
+
+    # Prepare the script using the template and variables
+    stdin = TEMPLATE.format(
+        username=username,
+        home_path=os.environ["HOME"],
+        env_path=venv_path,
+        args=" ".join(args),
+    ).encode()
+
+    if dry_run:
+        cmd = "echo"
+        print(f"Will invoke `sbatch` with standard input:\n\n{stdin.decode()}")
+    else:
+        cmd = "sbatch"
+
+    return run(cmd, input=stdin, stdout=PIPE, stderr=STDOUT)
+
+
+@click.command("sbatch")
+@click.option("--username", "-u", envvar="USER", help="User name.")
+@click.option("--venv", "-e", envvar="VIRTUAL_ENV", help="Path to virtual environment.")
+@click.option("--go", is_flag=True, help="Actually invoke.")
+@click.argument("args", nargs=-1)
+@click.pass_obj
+def cli(context, username, venv, go, args):
+    """Submit `mix-models ARGS` to a SLURM queue."""
+    result = invoke_sbatch(username, venv, args, dry_run=not go)
+
+    assert result.returncode == 0, result

--- a/message_ix_models/util/slurm.py
+++ b/message_ix_models/util/slurm.py
@@ -54,7 +54,7 @@ def invoke_sbatch(
     if dry_run:
         cmd = "echo"
         print(f"Will invoke `sbatch` with standard input:\n\n{stdin.decode()}")
-    else:
+    else:  # pragma: no cover
         cmd = "sbatch"
 
     return run(cmd, input=stdin, stdout=PIPE, stderr=STDOUT)

--- a/message_ix_models/util/slurm.py
+++ b/message_ix_models/util/slurm.py
@@ -34,7 +34,8 @@ In particular:
 See also:
 
 - `sbatch <https://slurm.schedmd.com/sbatch.html>`_ manual page.
-- :doc:`/distrib/unicc`.
+- :doc:`/howto/unicc`.
+- :doc:`/distrib/`.
 """
 
 import os


### PR DESCRIPTION
This PR…
- Adds a `mix-models sbatch` CLI command that simplifies usage with SLURM, for instance on UnICC.
  This closes #284.
- Collects some docs pages under a 'HOWTO' section, with instructions on HOWTO Write a HOWTO.

## How to review

- Read the [added documentation](https://iiasa-energy-program-message-ix--291.com.readthedocs.build/projects/models/en/291/api/util.html#module-message_ix_models.util.slurm) via the preview build.
- Check out the branch on UnICC.
- Run a command like `mix-models sbatch -- config show`.

<!--
**Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
If no review is required, write “No review:” and describe why.

For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Look at a certain page in the ReadTheDocs preview build of the documentation.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.
