### PR TITLE
Check out correct ref in "pytest" CI job

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -60,7 +60,7 @@ jobs:
         ref: ${{ needs.check.outputs.ref }}
 
   pytest:
-    needs: warm-lfs-cache
+    needs: [ check, warm-lfs-cache ]
 
     strategy:
       matrix:


### PR DESCRIPTION
Further correction to #288 as described at https://github.com/iiasa/message-ix-models/pull/291#issuecomment-2640100989.

## How to review

Note [here](https://github.com/iiasa/message-ix-models/actions/runs/13182382902/job/36796814007#step:4:3) that the explicit 'ref:' input is given in the checkout step, using the value from the `needs.check` payload [here](https://github.com/iiasa/message-ix-models/actions/runs/13182382902/job/36796814007#step:3:17).

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Look at a certain page in the ReadTheDocs preview build of the documentation.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI changes only
- ~Update doc/whatsnew.~