### PR TITLE
Test against ixmp/message-ix v3.10.0

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -77,8 +77,9 @@ jobs:
         # For this job only, the oldest version of Python supported by message-ix-models
         - { upstream: v3.7.0, python: "3.9" }  # Released 2023-05-17
         - { upstream: v3.8.0, python: "3.12" }  # 2024-01-12
-        # Latest released version + latest released Python
         - { upstream: v3.9.0, python: "3.13" }  # 2024-06-04
+        # Latest released version + latest released Python
+        - { upstream: v3.10.0, python: "3.13" }  # 2025-02-21
         # Development version + latest released Python
         - { upstream: main,   python: "3.13" }
 
@@ -89,6 +90,7 @@ jobs:
         - { os: macos-latest, version: { upstream: v3.8.0 }}
         - { os: macos-latest, version: { upstream: v3.9.0 }}
         # Redundant with macos-latest
+        - { os: macos-13, version: { upstream: v3.10.0 }}
         - { os: macos-13, version: { upstream: main }}
 
       fail-fast: false

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,8 +4,12 @@ What's new
 Next release
 ============
 
-- Support for :mod:`ixmp` and :mod:`message_ix` versions 3.4, 3.5, and 3.6 is dropped in accordance with the :ref:`policy-upstream-versions` (:pull:`288`, :pull:`289`).
-  The minimum version of both packages is 3.7.0.
+- In accordance with the :ref:`policy-upstream-versions`:
+
+  - :mod:`message_ix_models` supports and is tested against :mod:`ixmp` and :mod:`message_ix_models` version 3.10.0 (:pull:`299`).
+  - Support for :mod:`ixmp` and :mod:`message_ix` versions 3.4, 3.5, and 3.6 is dropped  (:pull:`288`, :pull:`289`).
+    The minimum supported version of both packages is 3.7.0.
+
 - Update :class:`.IEA_EWEB` to support :py:`transform="B"` / :func:`.transform_B` (:issue:`230`, :pull:`259`).
 - Add :func:`.prepare_method_B` to :mod:`.ssp.transport` (:pull:`259`).
 - New utility :class:`.sdmx.AnnotationsMixIn` (:pull:`259`).


### PR DESCRIPTION
With ixmp/message-ix v3.10.0 both released, we add these to the "pytest" CI workflow matrix. This will help us ensure that message-ix-models continues to work with both these latest releases and the evolving `main` branches for those repos.

According to our [Upstream version policy](https://docs.messageix.org/projects/models/en/latest/develop.html#upstream-version-policy):
> [message-ix-models supports t]he most recent 4 minor versions [of ixmp/message-ix], or all minor versions released in the past two (2) years—whichever is greater.

- The most recent 4 minor versions = 3.7, 3.8, 3.9, 3.10.
- Versions released in the last 2 years = versions released on 2023-02-24 or later. [v3.7.0 is the oldest version released since that date (on 2023-05-17)](https://pypi.org/project/message-ix/#history).

In this case both criteria give the same minimum version. Support and CI jobs for upstream 3.6 were already dropped in #289.

## How to review

None required.

Note that because of our use of 'pull_request_trigger', the added jobs will not run until this branch is merged. However, I don't believe we need the extra effort of showing they run on this branch, since at this moment upstream `v3.10.0` and `main` are identical.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update doc/whatsnew.