### PR TITLE
Adjust code owners for `.tools.costs`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,10 +22,10 @@
 /message_ix_models/tests/tools/costs  @adrivinca @macflo8 @OFR-IIASA @ywpratama
 /message_ix_models/tools/costs        @adrivinca @macflo8 @OFR-IIASA @ywpratama
 
-/doc/material                            @GamzeUnlu95 @macflo8
-/message_ix_models/data/material         @GamzeUnlu95 @macflo8
-/message_ix_models/model/material        @GamzeUnlu95 @macflo8
-/message_ix_models/tests/model/material  @GamzeUnlu95 @macflo8
+/doc/material                            @macflo8
+/message_ix_models/data/material         @macflo8
+/message_ix_models/model/material        @macflo8
+/message_ix_models/tests/model/material  @macflo8
 
 /doc/transport
 /message_ix_models/data/transport         @khaeru @r-aneeque

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,11 +10,17 @@
 /message_ix_models/workflow.py             @khaeru @glatterf42
 /message_ix_models/tests/test_workflow.py  @khaeru @glatterf42
 
-/doc/api/tools-costs.rst              @measrainsey
-/message_ix_models/data/costs         @measrainsey
-/message_ix_models/data/intratec      @measrainsey
-/message_ix_models/tests/tools/costs  @measrainsey
-/message_ix_models/tools/costs        @measrainsey
+# Colleagues responsible for module-specific cost data
+/message_ix_models/data/costs/cooling   @adrivinca
+/message_ix_models/data/costs/dac       @ywpratama
+/message_ix_models/data/costs/material  @macflo8
+
+# All of the above + others
+/doc/api/tools-costs.rst              @adrivinca @macflo8 @OFR-IIASA @ywpratama
+/message_ix_models/data/costs         @adrivinca @macflo8 @OFR-IIASA @ywpratama
+/message_ix_models/data/intratec      @adrivinca @macflo8 @OFR-IIASA @ywpratama
+/message_ix_models/tests/tools/costs  @adrivinca @macflo8 @OFR-IIASA @ywpratama
+/message_ix_models/tools/costs        @adrivinca @macflo8 @OFR-IIASA @ywpratama
 
 /doc/material                            @GamzeUnlu95 @macflo8
 /message_ix_models/data/material         @GamzeUnlu95 @macflo8


### PR DESCRIPTION
As discussed and agreed at the 2025-02-20 MESSAGE team meeting, this PR updates the CODEOWNERS file to keep it current with the actual team and practice:

- Add @adrivinca @macflo8 @ywpratama as sole owners of input data files for particular cost 'modules'.
- Add all 3 of the above plus @OFR-IIASA as joint owners of all other costs-related files, replacing @measrainsey.

Also:
- Remove @GamzeUnlu95 from co-ownership of some `.model.material` files, to indicate that @macflo8 is now the only person who can be asked for review.

## How to review

- Anyone tagged in the issue or added as an owner should mention if these changes do not match their recollection or current capabilities.
- Approve if no objection is heard.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update doc/whatsnew.~