### PR TITLE
Fix CI for `message_ix` v3.10.0

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -129,17 +129,20 @@ jobs:
       id: dependencies
       run : |
         from os import environ
+        from packaging.version import Version, parse
         from pathlib import Path
 
-        v, result = "${{ matrix.version.upstream }}".replace("main", "vmain"), []
-        for condition, dependency in (
-            (v >= "v3.7.0", "dask[dataframe] < 2024.11.0"),  # dask >= 2024.11.0 changes handling of dict (will be addressed in #225)
-            (v <= "v3.7.0", "genno < 1.25"),  # Upstream versions < 3.8.0 import genno.computations, removed in 1.25.0 (#156)
-            (v < "v3.9.0", "pytest == 8.0.0"),  # Upstream versions < 3.9.0 use a hook argument removed in pytest 8.1.0 (#155)
-        ):
-            result.extend([f'"{dependency}"'] if condition else [])
+        version_string = "${{ matrix.version.upstream }}"
 
-        Path(environ["GITHUB_OUTPUT"]).write_text(f"value={' '.join(result)}\n")
+        if version_string != "main": 
+            v, result = parse(version_string), []
+            for condition, dependency in (
+                (v <= Version("v3.7.0"), "genno < 1.25"),  # Upstream versions < 3.8.0 import genno.computations, removed in 1.25.0 (#156)
+                (v < Version("v3.9.0"), "pytest == 8.0.0"),  # Upstream versions < 3.9.0 use a hook argument removed in pytest 8.1.0 (#155)
+            ):
+                result.extend([f'"{dependency}"'] if condition else [])
+
+            Path(environ["GITHUB_OUTPUT"]).write_text(f"value={' '.join(result)}\n")
       shell: python
 
     - name: Install packages and dependencies

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -125,6 +125,9 @@ jobs:
       # Work around ts-graphviz/setup-graphviz#630
       if: matrix.os != 'macos-13'
 
+    - name: Install packaging
+      run: uv pip install packaging
+
     - name: Determine extra dependencies
       id: dependencies
       run : |


### PR DESCRIPTION
The recent release v3.10.0 of message_ix and ixmp and #299 broke our CI by exposing that we don't properly handle version comparisons for extra comparisons at the moment. This PR fixes that.

In our `pytest` CI workflow, we add extra dependency requirement for specific versions. At the moment, this is done based on string comparison, but with `"v3.10.0"` coming into play, these begin to fail: 

```python
>>> "v3.10.0" < "v3.1.0"
False
>>> "v3.10.0" < "v3.7.0"
True
``` 

This results in incompatible dependencies being installed, causing the CI to fail.
@khaeru suggested to use [packaging.version](https://packaging.pypa.io/en/latest/version.html) instead of string comparisons, which I tried to add now. There's just one catch: these versions can't parse `"main"`. 
I thought about using an arbitrary number in that case that's high enough to always trigger the checks for the latest version, e.g. `99.99.99`. However, I don't really like such magic numbers and eventually we might reach that version. Also, there's part two of this PR:

One of the checks we have targets the latest versions of this repo. This should have been handled by #225, though, so this PR removes the workaround. And I generally think we want to avoid version pins for the `"main"` version, so right now, the dependency additions are hidden behind an `if version_string != "main"` check. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update doc/whatsnew.~ Just CI.

