### PR TITLE
Add function entrypoint to `.ssp.transport`

### DIFF
--- a/doc/project/ssp.rst
+++ b/doc/project/ssp.rst
@@ -58,7 +58,7 @@ Transport
 .. automodule:: message_ix_models.project.ssp.transport
    :members:
 
-   Use :program:`mix-models ssp transport --help in.xlsx out.xlsx` to invoke :func:`.main`.
+   Use :program:`mix-models ssp transport --help in.xlsx out.xlsx` to invoke :func:`.process_file`.
    Data are read from PATH_IN, in :file:`.xlsx` or :file:`.csv` format.
    If :file:`.xlsx`, the data are first temporarily converted to :file:`.csv`.
    Data are written to PATH_OUT; if not given, this defaults to the same path and suffix as PATH_IN, with "_out" added to the stem.

--- a/doc/project/ssp.rst
+++ b/doc/project/ssp.rst
@@ -47,8 +47,12 @@ Data
       SSPOriginal
       SSPUpdate
 
-2024 update
-===========
+.. _ssp-2024:
+
+2023–2025 update
+================
+
+This update is related to the `Scenario Model Intercomparison Project (ScenarioMIP) for CMIP7 <https://wcrp-cmip.org/mips/scenariomip>`_.
 
 Transport
 ---------
@@ -58,19 +62,23 @@ Transport
 .. automodule:: message_ix_models.project.ssp.transport
    :members:
 
-   Use :program:`mix-models ssp transport --help in.xlsx out.xlsx` to invoke :func:`.process_file`.
-   Data are read from PATH_IN, in :file:`.xlsx` or :file:`.csv` format.
-   If :file:`.xlsx`, the data are first temporarily converted to :file:`.csv`.
-   Data are written to PATH_OUT; if not given, this defaults to the same path and suffix as PATH_IN, with "_out" added to the stem.
+   There are two ways to invoke this code:
 
-   For example:
+   1. To process data from file, use :program:`mix-models ssp transport --help in.xlsx out.xlsx` to invoke :func:`.process_file`.
+      Data are read from PATH_IN, in :file:`.xlsx` or :file:`.csv` format.
+      If :file:`.xlsx`, the data are first temporarily converted to :file:`.csv`.
+      Data are written to PATH_OUT; if not given, this defaults to the same path and suffix as PATH_IN, with "_out" added to the stem.
 
-   .. code-block:: shell
+      For example:
 
-      mix-models ssp transport --method=B \
-        SSP_SSP2_v2.1_baseline.xlsx
+      .. code-block:: shell
 
-   …produces a file :file:`SSP_SSP2_v2.1_baseline_out.xlsx` in the same directory.
+         mix-models ssp transport --method=B \
+           SSP_SSP2_v2.1_baseline.xlsx
+
+      …produces a file :file:`SSP_SSP2_v2.1_baseline_out.xlsx` in the same directory.
+
+   2. To process an existing :class:`pandas.DataFrame` from other code, call :func:`.process_df`, passing the input dataframe and the `method` parameter.
 
    As of 2025-01-25:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,7 +11,7 @@ Next release
     The minimum supported version of both packages is 3.7.0.
 
 - Update :class:`.IEA_EWEB` to support :py:`transform="B"` / :func:`.transform_B` (:issue:`230`, :pull:`259`).
-- Add :func:`.prepare_method_B` to :mod:`.ssp.transport` (:pull:`259`).
+
 - New utility :class:`.sdmx.AnnotationsMixIn` (:pull:`259`).
 - Drop obsolete :py:`series_of_pint_quantity()` (:pull:`289`).
 
@@ -20,6 +20,14 @@ By topic:
 .. contents::
    :local:
    :backlinks: none
+
+SSP :ref:`ssp-2024`/ScenarioMIP
+-------------------------------
+
+Improve :mod:`.ssp.transport`:
+
+- Add :func:`.prepare_method_B` and make this the default1 (:pull:`259`).
+- Add :func:`~.ssp.transport.process_df` (:pull:`303`).
 
 Transport
 ---------

--- a/message_ix_models/project/ssp/cli.py
+++ b/message_ix_models/project/ssp/cli.py
@@ -43,7 +43,7 @@ def transport_cmd(context: "Context", method, path_in: Path, path_out: Optional[
     import pandas as pd
     from platformdirs import user_cache_path
 
-    from .transport import main
+    from .transport import process_file
 
     if path_in.suffix == ".xlsx":
         path_in_user = path_in
@@ -65,7 +65,7 @@ def transport_cmd(context: "Context", method, path_in: Path, path_out: Optional[
     else:
         path_out_user = path_out
 
-    main(path_in, path_out, method)
+    process_file(path_in, path_out, method)
 
     if path_out_user != path_out:
         print(f"Convert CSV output to {path_out_user}")

--- a/message_ix_models/project/ssp/cli.py
+++ b/message_ix_models/project/ssp/cli.py
@@ -65,7 +65,7 @@ def transport_cmd(context: "Context", method, path_in: Path, path_out: Optional[
     else:
         path_out_user = path_out
 
-    process_file(path_in, path_out, method)
+    process_file(path_in, path_out, method=method)
 
     if path_out_user != path_out:
         print(f"Convert CSV output to {path_out_user}")

--- a/message_ix_models/tests/project/ssp/test_transport.py
+++ b/message_ix_models/tests/project/ssp/test_transport.py
@@ -3,8 +3,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 import pytest
 
-from message_ix_models.model.transport.testing import MARK
-from message_ix_models.project.ssp.transport import main
+from message_ix_models.project.ssp.transport import prepare_computer, process_file
 from message_ix_models.tests.tools.iea.test_web import user_local_data  # noqa: F401
 from message_ix_models.util import package_data_path
 
@@ -80,18 +79,20 @@ VARIABLE = {
 }
 
 
-@MARK["gh-288"]
-@main.minimum_version
+@prepare_computer.minimum_version
 # @pytest.mark.usefixtures("user_local_data")
 @pytest.mark.parametrize("method", ("A", "B"))
-def test_main(tmp_path, test_context, input_csv_path, method) -> None:
+def test_process_file(tmp_path, test_context, input_csv_path, method) -> None:
     """Code can be called from Python."""
+    if method == "A":
+        pytest.skip("Obsolete case")
+
     # Locate a temporary data file
     path_in = input_csv_path
     path_out = tmp_path.joinpath("output.csv")
 
     # Code runs
-    main(path_in=path_in, path_out=path_out, method=method)
+    process_file(path_in=path_in, path_out=path_out, method=method)
 
     # Output path exists
     assert path_out.exists()
@@ -141,7 +142,7 @@ def test_main(tmp_path, test_context, input_csv_path, method) -> None:
         assert False, msg
 
 
-@main.minimum_version
+@prepare_computer.minimum_version
 def test_cli(tmp_path, mix_models_cli, input_xlsx_path) -> None:
     """Code can be invoked from the command-line."""
     from shutil import copyfile

--- a/message_ix_models/tests/project/ssp/test_transport.py
+++ b/message_ix_models/tests/project/ssp/test_transport.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING
 import pandas as pd
 import pytest
 
-from message_ix_models.project.ssp.transport import prepare_computer, process_file
+from message_ix_models.project.ssp.transport import (
+    prepare_computer,
+    process_df,
+    process_file,
+)
 from message_ix_models.tests.tools.iea.test_web import user_local_data  # noqa: F401
 from message_ix_models.util import package_data_path
 
@@ -79,41 +83,27 @@ VARIABLE = {
 }
 
 
-@prepare_computer.minimum_version
-# @pytest.mark.usefixtures("user_local_data")
-@pytest.mark.parametrize("method", ("A", "B"))
-def test_process_file(tmp_path, test_context, input_csv_path, method) -> None:
-    """Code can be called from Python."""
-    if method == "A":
-        pytest.skip("Obsolete case")
-
-    # Locate a temporary data file
-    path_in = input_csv_path
-    path_out = tmp_path.joinpath("output.csv")
-
-    # Code runs
-    process_file(path_in=path_in, path_out=path_out, method=method)
-
-    # Output path exists
-    assert path_out.exists()
-
-    # Read input file
-    df_in = pd.read_csv(path_in)
-
+def check(df_in: pd.DataFrame, df_out: pd.DataFrame, method: str) -> None:
+    """Common checks for :func:`test_process_df` and :func:`test_process_file`."""
     # Identify dimension columns
     dims_wide = list(df_in.columns)[:5]  # …in 'wide' layout
     dims = dims_wide + ["Year"]  # …in 'long' layout
 
     # Convert wide to long; sort
-    df_in = df_in.melt(dims_wide, var_name="Year").sort_values(dims)
+    def _to_long(df):
+        return (
+            df.melt(dims_wide, var_name=dims[-1])
+            .astype({dims[-1]: int})
+            .sort_values(dims)
+        )
+
+    df_in = _to_long(df_in)
+    df_out = _to_long(df_out)
 
     # Input data already contains the variable names to be modified
     exp = {v[1] for v in VARIABLE if IN_ & v[0]}
     assert exp <= set(df_in["Variable"].unique())
     region = set(df_in["Region"].unique())
-
-    # Read output file
-    df_out = pd.read_csv(path_out).melt(dims_wide, var_name="Year")
 
     # Data have the same length
     assert len(df_in) == len(df_out)
@@ -128,6 +118,18 @@ def test_process_file(tmp_path, test_context, input_csv_path, method) -> None:
         "abs(value_y - value_x) > 1e-16"
     )
 
+    # Possible number of modified values. In each tuple, the first is the count with
+    # the full IEA EWEB dataset, the second with the fuzzed data
+    N = {
+        "A": (2840, None),
+        "B": (2400, 1400),
+    }[method]
+
+    try:
+        full_iea_eweb_data = N.index(len(df)) == 0  # True if the full dataset
+    except IndexError:
+        assert False, f"Unexpected number of modified values: {len(df)}"
+
     # df.to_csv("debug0.csv")  # DEBUG Dump to file
     # print(df.to_string(max_rows=50))  # DEBUG Show in test output
 
@@ -139,7 +141,55 @@ def test_process_file(tmp_path, test_context, input_csv_path, method) -> None:
     if len(cond):
         msg = "Negative emissions totals after processing"
         print(f"\n{msg}:", cond.to_string(), sep="\n")
-        assert False, msg
+        assert not full_iea_eweb_data, msg
+
+
+@prepare_computer.minimum_version
+@pytest.mark.parametrize(
+    "method",
+    (
+        pytest.param("A", marks=pytest.mark.xfail(reason="Obsolete/not maintained")),
+        "B",
+    ),
+)
+def test_process_df(input_csv_path, method) -> None:
+    df_in = pd.read_csv(input_csv_path)
+
+    # Code runs
+    df_out = process_df(df_in, method=method)
+
+    # Output satisfies expectations
+    check(df_in, df_out, method)
+
+
+@prepare_computer.minimum_version
+# @pytest.mark.usefixtures("user_local_data")
+@pytest.mark.parametrize(
+    "method",
+    (
+        pytest.param("A", marks=pytest.mark.xfail(reason="Obsolete/not maintained")),
+        "B",
+    ),
+)
+def test_process_file(tmp_path, test_context, input_csv_path, method) -> None:
+    """Code can be called from Python."""
+
+    # Locate a temporary data file
+    path_in = input_csv_path
+    path_out = tmp_path.joinpath("output.csv")
+
+    # Code runs
+    process_file(path_in=path_in, path_out=path_out, method=method)
+
+    # Output path exists
+    assert path_out.exists()
+
+    # Read input and output files
+    df_in = pd.read_csv(path_in)
+    df_out = pd.read_csv(path_out)
+
+    # Output satisfies expectations
+    check(df_in, df_out, method)
 
 
 @prepare_computer.minimum_version


### PR DESCRIPTION
This PR adds the function `message_ix_models.project.ssp.transport.process_df()` as an entry point to the functionality established in #225 and #259.

cf. [Slack messages](https://iiasa-ece.slack.com/archives/CCFHDNA6P/p1740993729970499)

## How to review

- Read [the expanded docs](https://iiasa-energy-program-message-ix--303.com.readthedocs.build/projects/models/en/303/project/ssp.html#module-message_ix_models.project.ssp.transport) for the module, in particular the new function.
- Call the function with 'real' input data.
- Report any errors, with detail about the calling code and input data.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.