### PR TITLE
Update refinery hydrogen level and CCS bounds

### DIFF
--- a/message_ix_models/data/material/petrochemicals/petrochemicals_techno_economic.xlsx
+++ b/message_ix_models/data/material/petrochemicals/petrochemicals_techno_economic.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6178b6975ee5444badcf33e5ce1d78eba40478eb599918b4634e29e5f18f362
-size 677733
+oid sha256:84cdd2bbf8f64e2d9efa61d765876a98c96832be7e756cbb618483b46df5d3ec
+size 672997

--- a/message_ix_models/data/material/set.yaml
+++ b/message_ix_models/data/material/set.yaml
@@ -233,6 +233,7 @@ petro_chemicals:
     - secondary_material
     - final_material
     - demand
+    - refinery
 
   balance_equality:
     add:


### PR DESCRIPTION
**Required:** This PR changes the `level` dimension of hydrogen flows in the refinery sector and fixes the activity of ammonia CCS technologies in 2025 to 0.

<!-- Optional: write a longer description to help a reviewer understand the PR in ~3 minutes. -->

## How to review

**Required:** no review required for merge to ssp-dev.

## PR checklist

<!-- This item is always required. -->
~~- [ ] Continuous integration checks all ✅~~
~~- [ ] Add or expand tests; coverage checks both ✅~~
~~- [ ] Add, expand, or update documentation.~~
~~- [ ] Update doc/whatsnew.~~