### PR TITLE
Fix Code Quality CI: checkout action and complex function

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -189,7 +189,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ needs.check.output.ref }}
+        ref: ${{ needs.check.outputs.ref }}
     - uses: astral-sh/setup-uv@v5
       with:
         cache-dependency-glob: "**/pyproject.toml"

--- a/message_ix_models/model/bare.py
+++ b/message_ix_models/model/bare.py
@@ -115,7 +115,7 @@ def get_spec(context) -> Spec:
     nodes = get_codes(f"node/{context.model.regions}")
 
     # Top-level "World" node
-    world = nodes[nodes.index("World")]
+    world = nodes[nodes.index(Code(id="World"))]
 
     # Set elements: World, followed by the direct children of World
     add.set["node"] = [world] + world.child

--- a/message_ix_models/model/disutility.py
+++ b/message_ix_models/model/disutility.py
@@ -7,7 +7,8 @@ from itertools import product
 
 import message_ix
 import pandas as pd
-from sdmx.model.common import Annotation, Code
+from sdmx.model.common import Code
+from sdmx.model.v21 import Annotation
 
 from message_ix_models import ScenarioInfo, Spec
 from message_ix_models.model.build import apply_spec

--- a/message_ix_models/model/material/cli.py
+++ b/message_ix_models/model/material/cli.py
@@ -484,7 +484,8 @@ def test_calib(context):
     Use the --model_name and --scenario_name option to specify the scenario to solve.
     """
     # Clone and set up
-    from sdmx.model import Annotation, Code
+    from sdmx.model.common import Code
+    from sdmx.model.v21 import Annotation
 
     from message_ix_models.model import macro
     from message_ix_models.util import identify_nodes

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -11,7 +11,8 @@ import pandas as pd
 import pycountry
 import xarray as xr
 from iam_units import registry
-from sdmx.model.v21 import Annotation, Code, Codelist
+from sdmx.model.common import Code, Codelist
+from sdmx.model.v21 import Annotation
 
 from message_ix_models.util import load_package_data, package_data_path
 from message_ix_models.util.sdmx import as_codes
@@ -95,7 +96,7 @@ def get_codes(name: str) -> list[Code]:
 @cache
 def get_codelist(name: str) -> Codelist:
     """Return a :class:`.Codelist` for `name` in MESSAGEix-GLOBIOM scenarios."""
-    cl = Codelist(id=name.replace("/", "_").upper())
+    cl: Codelist = Codelist(id=name.replace("/", "_").upper())
     cl.extend(get_codes(name))
     return cl
 

--- a/message_ix_models/model/transport/build.py
+++ b/message_ix_models/model/transport/build.py
@@ -395,7 +395,7 @@ def add_structure(c: Computer) -> None:
     # - `Static` tasks
     # - Single 'dynamic' tasks based on config, info, spec, and/or t_groups
     # - Multiple static and dynamic tasks generated in loops etc.
-    tasks = list(STRUCTURE_STATIC) + [
+    tasks: list[tuple] = list(STRUCTURE_STATIC) + [
         ("c::transport", quote(spec.add.set["commodity"])),
         ("c::transport+base", quote(spec.add.set["commodity"] + info.set["commodity"])),
         ("cg", quote(spec.add.set["consumer_group"])),

--- a/message_ix_models/project/edits/__init__.py
+++ b/message_ix_models/project/edits/__init__.py
@@ -3,9 +3,9 @@ import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional, cast
 
+import genno
 import pandas as pd
 import sdmx
-from genno import Quantity
 from genno.compat.sdmx.operator import dataset_to_quantity, quantity_to_message
 from sdmx.message import StructureMessage
 from sdmx.model.common import Codelist
@@ -57,7 +57,7 @@ def pasta_native_to_sdmx() -> "AnyQuantity":
     df = pd.read_csv(path).rename(columns={"Value": "value"}).set_index(PASTA_DIMS)
 
     # Convert to genno.Quantity
-    q = Quantity(df)
+    q = genno.Quantity(df)
 
     # Show the dimensions and codes
     print(q.coords)
@@ -207,6 +207,9 @@ def gen_demand(context: "Context") -> dict[str, "AnyQuantity"]:
             "Year": "y",
         },
     )
+
+    # Prevent a mypy warning in the next line; see https://github.com/khaeru/genno#166
+    assert isinstance(q_all, genno.Quantity)
 
     # Separate according to "Data" codes
     q = dict()

--- a/message_ix_models/project/ssp/structure.py
+++ b/message_ix_models/project/ssp/structure.py
@@ -5,8 +5,8 @@ from textwrap import wrap
 from typing import TYPE_CHECKING, Optional
 
 import sdmx
-import sdmx.model.v30 as m
 import sdmx.urn
+from sdmx.model import common, v21
 
 from message_ix_models.util.sdmx import make_enum, register_agency, write
 
@@ -135,17 +135,17 @@ including by geo-engineering if necessary.""",
 def generate(context: "Context", base_dir: Optional["PathLike"] = None):
     """Generate SDMX code lists containing the SSPs."""
     # Agency for ICONICS as the maintainer of other objects
-    ICONICS = m.Agency(
+    ICONICS = common.Agency(
         id="ICONICS",
         name="International Committee on New Integrated Climate Change Assessment "
         "Scenarios",
-        contact=[m.Contact(uri=["https://depts.washington.edu/iconics/"])],
+        contact=[common.Contact(uri=["https://depts.washington.edu/iconics/"])],
     )
     register_agency(ICONICS)
 
     for cl_info in CL_INFO:
         # Create the codelist: format the name and description
-        cl: m.Codelist = m.Codelist(
+        cl: common.Codelist = common.Codelist(
             id="SSP",
             name=f"Shared Socioeconomic Pathways ({cl_info['name_extra']})",
             description="\n".join(
@@ -161,13 +161,13 @@ def generate(context: "Context", base_dir: Optional["PathLike"] = None):
             original_id = f"SSP{info['id']}"
 
             # Format the name, description; add an annotation
-            c = m.Code(
+            c = common.Code(
                 id=info["id"],
                 name=f"{original_id}: {info['name']}",
                 description="\n".join(
                     [f"{original_id}: {info['name_long']}", "", info["description"]]
                 ),
-                annotations=[m.Annotation(id="original-id", text=original_id)],
+                annotations=[v21.Annotation(id="original-id", text=original_id)],
             )
 
             # Append to the code list

--- a/message_ix_models/report/operator.py
+++ b/message_ix_models/report/operator.py
@@ -266,6 +266,9 @@ def quantity_from_iamc(qty: "AnyQuantity", variable: str) -> "AnyQuantity":
             variables.append(match.group(0))
             replacements[match.group(0)] = match.group(1)
 
+    # Prevent a mypy warning in the next line; see https://github.com/khaeru/genno#166
+    assert isinstance(qty, genno.Quantity)
+
     subset = qty.pipe(select, {"v": variables}).pipe(relabel, {"v": replacements})
 
     unique_units = subset.coords["Unit"].data

--- a/message_ix_models/tests/model/test_disutility.py
+++ b/message_ix_models/tests/model/test_disutility.py
@@ -6,7 +6,8 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 from message_ix import make_df
-from sdmx.model.v21 import Annotation, Code
+from sdmx.model.common import Code
+from sdmx.model.v21 import Annotation
 
 from message_ix_models import ScenarioInfo, testing
 from message_ix_models.model import disutility

--- a/message_ix_models/tests/model/test_macro.py
+++ b/message_ix_models/tests/model/test_macro.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import pandas.testing as pdt
 import pytest
-from sdmx.model import Annotation, Code
+from sdmx.model.common import Code
+from sdmx.model.v21 import Annotation
 
 from message_ix_models.model.macro import generate, load
 from message_ix_models.util import package_data_path

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 from iam_units import registry
-from sdmx.model.v21 import Annotation, Code
+from sdmx.model.common import Code
+from sdmx.model.v21 import Annotation
 
 from message_ix_models.model.structure import (
     codelists,

--- a/message_ix_models/tests/tools/costs/test_gdp.py
+++ b/message_ix_models/tests/tools/costs/test_gdp.py
@@ -1,4 +1,5 @@
 import pytest
+from sdmx.model.common import Code
 
 from message_ix_models.model.structure import get_codes
 from message_ix_models.tools.costs import Config
@@ -20,7 +21,7 @@ def test_process_raw_ssp_data(test_context, node) -> None:
     # Retrieve list of node IDs
     nodes = get_codes(f"node/{node}")
     # Convert to string
-    regions = set(map(str, nodes[nodes.index("World")].child))
+    regions = set(map(str, nodes[nodes.index(Code(id="World"))].child))
 
     # Function runs
     # - context is ignored by process_raw_ssp_data
@@ -82,7 +83,7 @@ def test_adjust_cost_ratios_with_gdp(test_context, module) -> None:
     # Retrieve list of node IDs
     nodes = get_codes(f"node/{test_context.model.regions}")
     # Convert to string
-    regions = set(map(str, nodes[nodes.index("World")].child))
+    regions = set(map(str, nodes[nodes.index(Code(id="World"))].child))
 
     # Assert that all regions are present
     assert regions == set(result.region.unique())

--- a/message_ix_models/tests/util/test_sdmx.py
+++ b/message_ix_models/tests/util/test_sdmx.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 import sdmx
-from sdmx.model.common import Annotation, Code
+from sdmx.model.common import Code
+from sdmx.model.v21 import Annotation
 
 from message_ix_models.util.sdmx import eval_anno, make_dataflow, make_enum, read
 

--- a/message_ix_models/tools/iamc.py
+++ b/message_ix_models/tools/iamc.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import genno
 import pandas as pd
-import sdmx.model.v21 as m
 from sdmx.message import StructureMessage
+from sdmx.model import common, v21
 
 from message_ix_models.util import cached
 from message_ix_models.util.pycountry import iso_3166_alpha_3
@@ -43,8 +43,8 @@ def describe(data: pd.DataFrame, extra: Optional[str] = None) -> StructureMessag
 
     sm = StructureMessage()
 
-    def _cl(dim: str) -> m.Codelist:
-        result = m.Codelist(
+    def _cl(dim: str) -> common.Codelist:
+        result: common.Codelist = common.Codelist(
             id=dim,
             description=f"Codes appearing in the {dim!r} dimension of "
             + (extra or "data")
@@ -58,7 +58,7 @@ def describe(data: pd.DataFrame, extra: Optional[str] = None) -> StructureMessag
     for dim in ("MODEL", "SCENARIO", "REGION"):
         cl = _cl(dim)
         for value in sorted(data[dim].unique()):
-            cl.append(m.Code(id=value))
+            cl.append(common.Code(id=value))
 
     # Handle "VARIABLE" and "UNIT" jointly
     dims = ["VARIABLE", "UNIT"]
@@ -69,10 +69,10 @@ def describe(data: pd.DataFrame, extra: Optional[str] = None) -> StructureMessag
     ):
         group_units = group_data["UNIT"].unique()
         cl_variable.append(
-            m.Code(
+            common.Code(
                 id=variable,
                 annotations=[
-                    m.Annotation(
+                    v21.Annotation(
                         id="preferred-unit-measure", text=", ".join(group_units)
                     )
                 ],
@@ -80,7 +80,7 @@ def describe(data: pd.DataFrame, extra: Optional[str] = None) -> StructureMessag
         )
         for unit in group_units:
             try:
-                cl_unit.append(m.Code(id=unit))
+                cl_unit.append(common.Code(id=unit))
             except ValueError:
                 pass
 

--- a/message_ix_models/tools/wb.py
+++ b/message_ix_models/tools/wb.py
@@ -58,7 +58,7 @@ def assign_income_groups(  # noqa: C901
     """
 
     import sdmx
-    import sdmx.model.v21 as m
+    from sdmx.model import v21
 
     replace = replace or dict()
 
@@ -137,7 +137,7 @@ def assign_income_groups(  # noqa: C901
             pass
 
         # Annotate the node
-        node.annotations.append(m.Annotation(id="wb-income-group", text=ig))
+        node.annotations.append(v21.Annotation(id="wb-income-group", text=ig))
 
     log.debug(
         "(node, group) weights:\n"
@@ -197,7 +197,7 @@ def get_income_group_codelist() -> "sdmx.model.common.Codelist":
       <sdmx.model.common.AnnotableArtefact.get_annotation>`, and other methods.
     """
     import pooch
-    import sdmx.model.v21 as m
+    from sdmx.model import v21
 
     cl = fetch_codelist("CL_REF_AREA_WDI")
 
@@ -236,12 +236,12 @@ def get_income_group_codelist() -> "sdmx.model.common.Codelist":
 
         # Annotate wb-income-group; map a value like "Low income" to a URN
         code.annotations.append(
-            m.Annotation(id="wb-income-group", text=urn_for(row["Income group"]))
+            v21.Annotation(id="wb-income-group", text=urn_for(row["Income group"]))
         )
 
         try:
             code.annotations.append(
-                m.Annotation(id="wb-lending-category", text=row["Lending category"])
+                v21.Annotation(id="wb-lending-category", text=row["Lending category"])
             )
         except ValueError:
             pass  # text was None → no value

--- a/message_ix_models/util/sdmx.py
+++ b/message_ix_models/util/sdmx.py
@@ -48,7 +48,7 @@ class AnnotationsMixIn:
 
         Returns
         -------
-        list of :class:`Annotation <sdmx.model.common.Annotation>`
+        list of :class:`Annotation <sdmx.model.common.BaseAnnotation>`
             if `_rtype` is :class:`list`.
         dict
             if `_rtype` is :class:`dict`. The dict has the one key "annotations", mapped
@@ -58,9 +58,7 @@ class AnnotationsMixIn:
         result = []
         for f in fields(self):
             anno_id = f.name.replace("_", "-")
-            result.append(
-                common.Annotation(id=anno_id, text=repr(getattr(self, f.name)))
-            )
+            result.append(v21.Annotation(id=anno_id, text=repr(getattr(self, f.name))))
 
         if _rtype is list:
             return result
@@ -143,7 +141,7 @@ def as_codes(  # noqa: C901
         # Convert other dictionary (key, value) pairs to annotations
         for id, value in _info.items():
             code.annotations.append(
-                common.Annotation(
+                v21.Annotation(
                     id=id, text=value if isinstance(value, str) else repr(value)
                 )
             )
@@ -281,7 +279,7 @@ unique keys including (model name, scenario name, version).""",
         name="Unit of measure",
         description="Unit in which data values are expressed",
         annotations=[
-            common.Annotation(
+            v21.Annotation(
                 id="same-as-urn",
                 text="urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=SDMX:CROSS_DOMAIN_CONCEPTS(2.0).UNIT_MEASURE",
             ),


### PR DESCRIPTION
This PR intends to fix a few things about the Code Quality CI:

- It fixes a typo such that the Code Quality check will consider the changes here, not those already on `main`
- It reduces the complexity of the `cool_tech()` function to below 11, which is our accepted limit here (@adrivinca, this may serve as a template for the future, if you're interested: I have simply extracted one `if/else` clause and moved that to its own function, following the idea that every function should have one clearly defined task)
- I've also deleted the `pre-commit` cache in hopes of it now picking up the latest version of genno, which should fix the mypy errors we've been seeing in the nightly tests

Housekeeping:
- Mirror the 'fix' from khaeru/genno#166 for a mypy error.
- Adjust import of the Annotation class from sdmx1 to avoid warnings added in v2.22.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update doc/whatsnew.~ Just CI.
