### PR TITLE
Adjust for click v8.2.0

### DIFF
--- a/message_ix_models/tests/model/material/test_build.py
+++ b/message_ix_models/tests/model/material/test_build.py
@@ -36,10 +36,15 @@ _MARKS = [
     # seconds (20 minutes). Always SKIP.
     pytest.mark.skipif(_C1, reason="Slow/Java heap space error"),
     # On macOS, the test occasionally times out the run (~360 minutes = 21600 seconds).
-    # When it passes, it does so in ~700 seconds. Time out after a +20% margin, and
-    # XFAIL if this timeout occurs.
-    pytest.mark.xfail(_C2, reason="Times out"),
-    pytest.mark.timeout(700 * 1.2 if _C2 else 0),
+    # When it passes, it does so in ~700 seconds.
+    #
+    # # Time out after a +20% margin, and XFAIL if this timeout occurs.
+    # pytest.mark.xfail(_C2, reason="Times out"),
+    # pytest.mark.timeout(700 * 1.2 if _C2 else 0),
+    #
+    # Skip unconditionally. See
+    # https://github.com/iiasa/message-ix-models/pull/346#issuecomment-2873056272
+    pytest.mark.skipif(_C2, reason="Times out"),
 ]
 
 

--- a/message_ix_models/tests/util/test_importlib.py
+++ b/message_ix_models/tests/util/test_importlib.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+class TestMessageDataFinder:
+    @pytest.mark.parametrize("has_message_data", (False, True))
+    def test_exception(self, monkeypatch, has_message_data: bool) -> None:
+        """:meth:`.MessageDataFinder.find_spec` fails transparently."""
+        import message_ix_models.util.common
+
+        monkeypatch.setattr(
+            message_ix_models.util.common, "HAS_MESSAGE_DATA", has_message_data
+        )
+        try:
+            import message_ix_models.model.transport.not_.a.submodule  # noqa: F401
+        except ImportError as e:
+            # The exception message mentions the original import name, not message_data
+            assert "named 'message_ix_models.model.transport" in repr(e)

--- a/message_ix_models/util/click.py
+++ b/message_ix_models/util/click.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
+from importlib.metadata import version
 from pathlib import Path
 from typing import Literal, Optional, Union, cast
 
@@ -423,10 +424,14 @@ class CliRunner:
         cp = subprocess.run(all_args, capture_output=True, env=self.env, **kwargs)
 
         # Convert to a click.testing.Result
+
+        # Mandatory argument introduced in click 8.2
+        kw = dict(output_bytes=bytes()) if version("click") >= "8.2" else {}
         return click.testing.Result(
             runner=cast(click.testing.CliRunner, self),
             stdout_bytes=cp.stdout or bytes(),
             stderr_bytes=cp.stderr or bytes(),
+            **kw,
             return_value=None,
             exit_code=cp.returncode,
             exception=None,

--- a/message_ix_models/util/common.py
+++ b/message_ix_models/util/common.py
@@ -1,6 +1,7 @@
 import logging
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
+from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
 
@@ -17,23 +18,19 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-try:
-    import message_data
-except ImportError:
-    MESSAGE_DATA_PATH: Optional[Path] = None
-    HAS_MESSAGE_DATA = False
-else:  # pragma: no cover  (needs message_data)
-    # Root directory of the message_data repository.
-    MESSAGE_DATA_PATH = Path(message_data.__file__).parents[1]
+#: :any:`True` if :mod:`message_data` is installed.
+HAS_MESSAGE_DATA = False
+
+#: Root directory of the :mod:`message_data` repository. This package is always
+#: installed from source.
+MESSAGE_DATA_PATH: Optional[Path] = None
+
+if _spec := find_spec("message_data"):  # pragma: no cover
     HAS_MESSAGE_DATA = True
+    assert _spec.origin is not None
+    MESSAGE_DATA_PATH = Path(_spec.origin).parents[1]
 
-__all__ = [
-    "HAS_MESSAGE_DATA",
-    "Adapter",
-    "MappingAdapter",
-]
-
-# Directory containing message_ix_models.__init__
+#: Directory containing message_ix_models.__init__.
 MESSAGE_MODELS_PATH = Path(__file__).parents[1]
 
 #: Package data already loaded with :func:`load_package_data`.

--- a/message_ix_models/util/importlib.py
+++ b/message_ix_models/util/importlib.py
@@ -4,40 +4,72 @@ import re
 from importlib import util
 from importlib.abc import MetaPathFinder
 from importlib.machinery import ModuleSpec, SourceFileLoader
+from logging import INFO, getLogger
+
+from ._logging import once
 
 
 class MessageDataFinder(MetaPathFinder):
-    """Load model and project code from :mod:`message_data`."""
+    """Load model and project code from :mod:`message_data`.
 
-    # Expression for supported module names
+    This class allows for future-proof import statements. For example, if there is a
+    module :py:`message_data.project.foo.bar`, code can be written like:
+
+    .. code-block:: python
+
+       from message_ix_models.project.foo import bar
+
+    The :meth:`find_spec` method locates the corresponding submodule in
+    :mod:`message_data` and imports it as if it were in :mod:`message_ix_models`. Later,
+    if the module is migrated to :py:`message_ix_models.project.foo.bar`, the import
+    statement will work directly, without changes or use of MessageDataFinder.
+
+    Where the *same* module names exist within both packages, the submodule of
+    :mod:`message_ix_models` will be found directly and MessageDataFinder will not be
+    invoked.
+
+    This behaviour also allows to mix model and project code in the two packages,
+    although this **should** be avoided where possible.
+    """
+
+    #: Expression for supported module names.
     expr = re.compile(r"message_ix_models\.(?P<name>(model|project)\..*)")
 
-    # NB coverage is excluded, because the message-ix-models test suite does not
-    #    install/use message-data.
     @classmethod
-    def find_spec(cls, name, path, target=None):  # pragma: no cover
-        match = cls.expr.match(name)
-        try:
+    def find_spec(cls, name: str, path, target=None):
+        from .common import HAS_MESSAGE_DATA
+
+        if not HAS_MESSAGE_DATA:
+            return None
+
+        if match := cls.expr.match(name):
             # Construct the name for the actual module to load
             new_name = f"message_data.{match.group('name')}"
-        except AttributeError:
-            # `match` was None; unsupported. Let the importlib defaults take over.
+        else:
             return None
 
-        # Get an import spec for the message_data submodule
-        spec = util.find_spec(new_name)
-        if not spec:
+        try:
+            # Get an import spec for the message_data submodule
+            spec = util.find_spec(new_name)
+        except ImportError:
+            # `new_name` does not exist as a submodule of message_data
             return None
+        else:  # pragma: no cover
+            # NB Coverage ignored because message_data is not installed on GHA
+            assert spec is not None and spec.origin is not None
 
-        # Create a new spec that loads message_data.model.foo as if it were
-        # message_ix_models.model.foo
-        new_spec = ModuleSpec(
-            name=name,
-            # Create a new loader that loads from the actual file with the desired name
-            loader=SourceFileLoader(fullname=name, path=spec.origin),
-            origin=spec.origin,
-        )
-        # These can't be passed through the constructor
-        new_spec.submodule_search_locations = spec.submodule_search_locations
+            once(getLogger(__name__), INFO, f"Import {new_name!r} as {name!r}")
 
-        return new_spec
+            # - Create a new spec that loads message_data.model.foo as if it were
+            #   message_ix_models.model.foo
+            # - Create a new loader that loads from the actual file with the desired
+            #   name
+            new_spec = ModuleSpec(
+                name=name,
+                loader=SourceFileLoader(fullname=name, path=spec.origin),
+                origin=spec.origin,
+            )
+            # These can't be passed through the constructor
+            new_spec.submodule_search_locations = spec.submodule_search_locations
+
+            return new_spec


### PR DESCRIPTION
Closes #344, thus fixes the "Code quality" check for the `main` branch and other PRs.

Also: a small adjustment to .util.importlib.MessageDataFinder. This is to avoid error messages like [this one](https://github.com/iiasa/message-ix-models/actions/runs/14972200595/job/42055631634#step:11:18):
```
Traceback (most recent call last):
  File "/home/runner/work/message-ix-models/message-ix-models/.venv/bin/mix-models", line 4, in <module>
    from message_ix_models.cli import main
  File "/home/runner/work/message-ix-models/message-ix-models/.venv/lib/python3.13/site-packages/message_ix_models/cli.py", line 204, in <module>
    __import__(name)
    ~~~~~~~~~~^^^^^^
  File "/home/runner/work/message-ix-models/message-ix-models/.venv/lib/python3.13/site-packages/message_ix_models/model/material/cli.py", line 29, in <module>
    from .build import build
  File "/home/runner/work/message-ix-models/message-ix-models/.venv/lib/python3.13/site-packages/message_ix_models/model/material/build.py", line 14, in <module>
    from message_ix_models.model.material.data_other_industry import (
    ...<3 lines>...
    )
  File "/home/runner/work/message-ix-models/message-ix-models/.venv/lib/python3.13/site-packages/message_ix_models/util/importlib.py", line 28, in find_spec
    spec = util.find_spec(new_name)
  File "<frozen importlib.util>", line 91, in find_spec
ModuleNotFoundError: No module named 'message_data'
```

Here the actual error is that the module `message_ix_models.model.material.data_other_industry` is not found, nor is there an aliased `message_data.model.material.data_other_industry`. The new exception raised from within MessageDataFinder.find_spec() makes this hard to see. The commit results in the exception being raised with the original name.

## How to review

- Read the diff.
- Note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update doc/whatsnew.~ Internal changes only.