### PR TITLE
Update add_AFOLU_CO2_accounting() per message_data:ssp_dev

### DIFF
--- a/message_ix_models/tests/test_tools.py
+++ b/message_ix_models/tests/test_tools.py
@@ -63,7 +63,7 @@ def test_add_AFOLU_CO2_accounting(scenario: "Scenario") -> None:
     add_AFOLU_CO2_accounting.add_AFOLU_CO2_accounting(
         scenario,
         relation_name="CO2_Emission_Global_Total",
-        reg="R12_GLB",
+        glb_reg="R12_GLB",  # NB Previously 'reg'
         constraint_value=1.0,
     )
 

--- a/message_ix_models/tools/add_AFOLU_CO2_accounting.py
+++ b/message_ix_models/tools/add_AFOLU_CO2_accounting.py
@@ -5,13 +5,6 @@
 
 from typing import TYPE_CHECKING, Optional
 
-import pandas as pd
-
-from message_ix_models import ScenarioInfo
-from message_ix_models.util import nodes_ex_world
-
-from .add_CO2_emission_constraint import main as add_CO2_emission_constraint
-
 if TYPE_CHECKING:
     from message_ix import Scenario
 
@@ -19,18 +12,23 @@ if TYPE_CHECKING:
 def add_AFOLU_CO2_accounting(
     scen: "Scenario",
     relation_name: str,
-    reg: str = "R11_GLB",
+    glb_reg: str = "R11_GLB",
     constraint_value: Optional[float] = None,
+    emission: str = "LU_CO2_orig",
+    level: str = "LU",
+    suffix=None,
 ) -> None:
     """Add regional CO2 entries from AFOLU to a generic relation in a specified region.
 
-    Specifically for the land_use sceanrios: For each land_use scenario a new commodity
+    Specifically for the land_use scenarios: For each land_use scenario a new commodity
     is created on a new `level` "LU".  Each land_use scenario has an output of "1" onto
     their commodity. For each of these commodities (which are set to = 0), there is a
     corresponding new technology which has an input of "1" and an entry into the
     relation, which corresponds to the the CO2 emissions of the land_use pathway. This
     complicated setup is required, because Land-use scenarios only have a single entry
     in the emission factor TCE, which is the sum of all land-use related emissions.
+
+    The default configuration applies to CO2.
 
     Parameters
     ----------
@@ -42,92 +40,43 @@ def add_AFOLU_CO2_accounting(
         Node in `scen` to which constraint should be applied.
     constraint_value :
         Value for which the lower constraint should be set.
+    emission : str (default="LU_CO2_orig")
+        Name of the `land_output` which should be accounted in the relation.
+    level : str (default="LU")
+        Name of the level onto which duplicate `land_output` should be parametrized for.
+    suffix : str
+        The suffix will be applied to all uses of the land-use scenario names e.g. for
+        helper technologies or commodities.
     """
-    glb_reg = reg
-
-    if relation_name not in scen.set("relation").tolist():
-        with scen.transact(
-            f"relation {relation_name!r} for limiting regional CO2 emissions at the "
-            "global level added"
-        ):
+    with scen.transact("Add relation based land-use TCE emission accounting"):
+        # Add relation to set
+        if relation_name not in scen.set("relation").tolist():
             scen.add_set("relation", relation_name)
 
-    if constraint_value:
-        add_CO2_emission_constraint(
-            scen, relation_name, constraint_value, type_rel="lower", reg=reg
+        # Add land-use level to set
+        if level not in scen.set("level"):
+            scen.add_set("level", level)
+
+        # Add commodities to set and set commodities to equal
+        ls = scen.set("land_scenario").tolist()
+        ls = [f"{s}{suffix}" for s in ls] if suffix else ls
+        scen.add_set("commodity", ls)
+        scen.add_set("technology", ls)
+
+        for commodity in ls:
+            scen.add_set("balance_equality", [commodity, level])
+
+        # - Retrieve land-use TCE emissions
+        # - Add land-use scenario `output` parameter onto new level/commodity
+        name = "land_output"
+        data = scen.par(name, filters={"commodity": [emission]}).assign(
+            commodity=lambda df: df.land_scenario + (suffix or ""),
+            level=level,
+            value=1.0,
+            unit="%",
         )
 
-    # Add entires into sets required for the generation of the constraint
-    #     new level - "LU"
-    #     new commodities (set to `equal`) - name = LU scenario
-    #     new technologies - name = LU scenario
-    scen.check_out()
-    scen.add_set("level", "LU")
-    ls = scen.set("land_scenario").tolist()
-    scen.add_set("commodity", ls)
-    for commodity in ls:
-        scen.add_set("balance_equality", [commodity, "LU"])
-    scen.add_set("technology", ls)
+        if data.empty:
+            raise ValueError(f"No {name!r} data for commodity {emission}")
 
-    # Retrieve LU_CO2 emissions
-    loutput = scen.par("land_output", filters={"commodity": ["LU_CO2"]})
-    if loutput.empty:
-        raise ValueError("'land_output' not available for commodity 'LU_CO2'")
-
-    # Add land-use scenario `output` parameter onto new level/commodity
-    df_land_output = loutput.copy()
-    df_land_output.commodity = df_land_output.land_scenario
-    df_land_output.level = "LU"
-    df_land_output.value = 1
-    df_land_output.unit = "%"
-    scen.add_par("land_output", df_land_output)
-
-    # Add technology `input` and `relation_activity` parameter
-    info = ScenarioInfo(scen)
-    for reg in nodes_ex_world(info.N):
-        if reg == glb_reg:
-            continue
-        for y in info.Y:
-            for s in ls:
-                if s.find("BIO0N") >= 0:
-                    continue
-
-                df = pd.DataFrame(
-                    {
-                        "node_loc": [reg],
-                        "technology": s,
-                        "year_vtg": y,
-                        "year_act": y,
-                        "mode": "M1",
-                        "node_origin": reg,
-                        "commodity": s,
-                        "level": "LU",
-                        "time": "year",
-                        "time_origin": "year",
-                        "value": 1,
-                        "unit": "???",
-                    }
-                )
-
-                scen.add_par("input", df)
-
-                df = pd.DataFrame(
-                    {
-                        "relation": [relation_name],
-                        "node_rel": glb_reg,
-                        "year_rel": y,
-                        "node_loc": reg,
-                        "technology": s,
-                        "year_act": y,
-                        "mode": "M1",
-                        "value": loutput[
-                            (loutput.node == reg)
-                            & (loutput.year == y)
-                            & (loutput.land_scenario == s)
-                        ].value,
-                        "unit": "???",
-                    }
-                )
-
-                scen.add_par("relation_activity", df)
-    scen.commit("Added technology to mimic land-use technologies")
+        scen.add_par(name, data)


### PR DESCRIPTION
Per [this thread]() (Slack, private), the version of add_AFOLU_CO2_accounting() on the message_data `dev` branch, migrated here in #350, no longer works with current scenarios like `ixmp://ixmp-dev/SSP_SSP1_v5.0/baseline_DEFAULT_step_13`. This manifests as breakage in the `.model.transport` workflow, with exceptions like:

```
ComputationError: computing 'SSP5 policy with tax' using:

<Task 'SSP5 policy with tax' <Step tax_emission()>(...)>

Use Computer.describe(...) to trace the computation.

Computation traceback:
  File "/home/runner/actions-runner/_work/message_data/message_data/.venv/lib/python3.13/site-packages/message_ix_models/workflow.py", line 125, in __call__
    result = self.action(context, s, **self.kwargs)
  File "/home/runner/actions-runner/_work/message_data/message_data/.venv/lib/python3.13/site-packages/message_ix_models/model/transport/workflow.py", line 161, in tax_emission
    scenario = engage_workflow.step_0(context, scenario)
  File "/home/runner/actions-runner/_work/message_data/message_data/.venv/lib/python3.13/site-packages/message_data/projects/engage/workflow.py", line 188, in step_0
    add_AFOLU_CO2_accounting(scenario, **kw)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/runner/actions-runner/_work/message_data/message_data/.venv/lib/python3.13/site-packages/message_data/tools/utilities/add_AFOLU_CO2_accounting.py", line 65, in add_AFOLU_CO2_accounting
    raise ValueError("'land_output' not available for commodity 'LU_CO2'")
ValueError: 'land_output' not available for commodity 'LU_CO2'
```

This PR updates the version here to match the version on message_data `ssp_dev` branch, thus partly addresses #275.

Some immediate observations about changes to the code:
- The previous version of the function modified set `balance_equality` and parameters `relation_activity`, `input`. The new version of the code does not.
- The function previously constructed data to be added by reference to the scenario structure. Now the added data is derived from existing scenario contents.
- The test added in #351 fails.
- Thus the docstring of the function, which has not been updated and references "relations" in the summary and body, appears to be out of date and no longer an accurate description.

The PR also tries to address these changes.

## How to review

**TBA**

<!--
**Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
If no review is required, write “No review:” and describe why.

For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Look at a certain page in the ReadTheDocs preview build of the documentation.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  doc/whatsnew.rst, where '999' is the GitHub pull request number:

  - Title or single-sentence description from above (:pull:`999`:).

  Commit with a message like “Add #999 to doc/whatsnew”
  -->
