### PR TITLE
Use Java 21 on Windows GHA runners

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -156,6 +156,13 @@ jobs:
       # Work around ts-graphviz/setup-graphviz#630
       if: matrix.os != 'macos-13'
 
+    - name: Set Java version on Windows
+      if: startsWith(matrix.os, 'windows-')
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
     - name: Install packaging
       run: uv pip install packaging
 


### PR DESCRIPTION
Parallel to iiasa/ixmp#586 and iiasa/message_ix#962, use a version of Java compatible with JPype1 v1.6.0. This version was released 2025-07-07 and triggered failures of the `windows-latest-py3.13-upstream-*` scheduled testing jobs, for instance [here](https://github.com/iiasa/message-ix-models/actions/runs/16134476513).

## How to review

Note that the CI checks all pass on the jobs labeled "(pull_request)" (not pull_request_target). → [run #3827](https://github.com/iiasa/message-ix-models/actions/runs/16262060072?pr=370)

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only.
- ~Update doc/whatsnew.~