### PR TITLE
Adjust conceptual docs ordering

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,17 +8,17 @@ and derived models including single-country models and `variants with greater se
 All are built using the `MESSAGEix framework <https://docs.messageix.org>`_
 and underlying `ix modeling platform (ixmp) <https://docs.messageix.org/ixmp/>`_.
 
-Among other tasks, the tools allow modelers to:
+Among other tasks, these tools allow modelers to:
 
 - retrieve input data from various upstream sources,
 - process/transform upstream data into model input parameters,
 - create, populate, modify, and parametrize scenarios,
 - conduct model runs,
-- set up model *variants* with additional details or features, and
+- build model variants with additional details or features, and
 - report quantities computed from model outputs.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: User guide
 
    install
@@ -61,15 +61,15 @@ API reference
 
 Commonly used classes may be imported directly from :mod:`message_ix_models`.
 
-.. automodule:: message_ix_models
+.. autosummary::
 
-   .. autosummary::
+   message_ix_models.Config
+   message_ix_models.Context
+   message_ix_models.ScenarioInfo
+   message_ix_models.Spec
+   message_ix_models.Workflow
 
-      .Config
-      .Context
-      .ScenarioInfo
-      .Spec
-      .Workflow
+Other submodules are documented on their respective pages:
 
 - :doc:`api/model`
 - :doc:`api/model-bare`
@@ -111,7 +111,7 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
 .. _index-variants:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Model variants
 
    buildings/index
@@ -120,7 +120,7 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    water/index
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Research projects
 
    project/advance
@@ -150,7 +150,7 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    project/uptake
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Package data
 
    pkg-data/node

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,8 +1,12 @@
 Tools for MESSAGEix-GLOBIOM models
 **********************************
 
-:mod:`message_ix_models` provides tools for research using the **MESSAGEix-GLOBIOM family of models** developed by the IIASA Energy, Climate, and Environment (ECE) Program and its collaborators.
-This ‘family’ includes single-country and other models derived from the main, global model; all built in the `MESSAGEix framework <https://docs.messageix.org>`_ and on the `ix modeling platform (ixmp) <https://docs.messageix.org/ixmp/>`_.
+:mod:`message_ix_models` provides tools for research using the **MESSAGEix-GLOBIOM family of models**
+developed by the IIASA Energy, Climate, and Environment (ECE) Program and its collaborators.
+This ‘family’ includes the `‘main’ or ‘base’ global model <#index-conceptual>`_
+and derived models including single-country models and `variants with greater sectoral detail <#index-variant>`_.
+All are built using the `MESSAGEix framework <https://docs.messageix.org>`_
+and underlying `ix modeling platform (ixmp) <https://docs.messageix.org/ixmp/>`_.
 
 Among other tasks, the tools allow modelers to:
 
@@ -26,6 +30,29 @@ Among other tasks, the tools allow modelers to:
    develop
    whatsnew
    bibliography
+
+.. _index-conceptual:
+
+Conceptual documentation
+========================
+
+This section contains **conceptual and methodological** documentation
+of the ‘base’ or ‘main’ MESSAGEix-GLOBIOM global model,
+describing in detail how it represents global energy systems:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Conceptual documentation
+   :hidden:
+
+   global/index
+
+- :doc:`global/index`
+
+This is distinct from both
+the *technical* documentation in other sections and pages,
+which describe the code and data used to implement this representation,
+and the modules for various `model ‘variants’ <#index-variants>`_ that have similar, yet distinct, structure.
 
 API reference
 =============
@@ -81,12 +108,12 @@ Commonly used classes may be imported directly from :mod:`message_ix_models`.
    api/testing
    api/tests
 
+.. _index-variants:
 
 .. toctree::
    :maxdepth: 2
    :caption: Model variants
 
-   global/index
    buildings/index
    material/index
    transport/index


### PR DESCRIPTION
This PR rearranges the "toctree" (table of contents tree) in the documentation index page and left/navigation sidebar, such that the "conceptual documentation" appears in a new section, that appears second, beneath the user guide.

## How to review

- Look at [the ReadTheDocs preview build of the documentation](https://iiasa-energy-program-message-ix--416.com.readthedocs.build/projects/models/en/416/).
- Read the index page, particularly:
  - The first paragraph.
  - The new "Conceptual documentation" section.
- Look at the table of contents on the left side.
- Follow the links to the conceptual docs main page.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] ~Update doc/whatsnew.~ Docs reorg only, no removals or substantive changes.