### PR TITLE
Adjust for iam-units 2025.10.13

### DIFF
--- a/message_ix_models/__init__.py
+++ b/message_ix_models/__init__.py
@@ -1,8 +1,8 @@
 import sys
 from importlib.metadata import PackageNotFoundError, version
 
+import iam_units
 import pint
-from iam_units import registry
 
 from message_ix_models.util._logging import setup as setup_logging
 from message_ix_models.util.config import Config
@@ -24,7 +24,8 @@ except PackageNotFoundError:  # pragma: no cover
 setup_logging(console=False, file=False)
 
 # Use iam_units.registry as the default pint.UnitsRegistry
-pint.set_application_registry(registry)
+iam_units.configure_currency("EXC", "2005")
+pint.set_application_registry(iam_units.registry)
 
 # Ensure at least one Context instance is created
 Context()

--- a/message_ix_models/model/emissions.py
+++ b/message_ix_models/model/emissions.py
@@ -135,7 +135,10 @@ def get_emission_factors(units: Optional[str] = None) -> "AnyQuantity":
         # Identify a GWP factor for target `units`, if any
         to_units, to_species = split_species(units)
         gwp_factor = convert_gwp(
-            "AR5GWP100", (1.0, str(result.units)), "C", to_species
+            "AR5GWP100",
+            (1.0, str(result.units)),
+            "C",
+            to_species,  # type: ignore [arg-type]
         ).magnitude
     else:
         gwp_factor, to_units = 1.0, result.units


### PR DESCRIPTION
This PR fixes two CI job failures following the release of iam-units 2025.10.13:

1. Tests failed with `ValueError: Existing dimensionality cannot be converted`, e.g. [here](https://github.com/iiasa/message-ix-models/actions/runs/18518398916/job/52774394220#step:13:57743). This occurrs because iam_units.configure_currency() was (long) deprecated in iam-units, and is no longer called by default on import.
2. The mypy check failed, e.g. [here](https://github.com/iiasa/message-ix-models/actions/runs/18518398916/job/52773261310#step:5:33), with `message_ix_models/model/emissions.py:138: error: Argument 4 to "convert_gwp" has incompatible type "str | None"; expected "str"  [arg-type]`. This is caused by improperly narrow type hints added in IAMConsortium/units#55, and will be fixed upstream; for now, the error is ignored.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update doc/whatsnew.~ N/A