### PR TITLE
Release v2025.10.31

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-Next release
-============
+.. Next release
+.. ============
+
+v2025.10.31
+===========
 
 - :mod:`message_ix_models` is tested and compatible with `Python 3.14 <https://www.python.org/downloads/release/python-3140/>`__ (:pull:`443`).
 - Support for Python 3.9 is dropped (:pull:`443`), as it has reached end-of-life.


### PR DESCRIPTION
We did not make a release for the [2025-10 milestone](https://github.com/iiasa/message-ix-models/milestone/7) (I was on leave), so this release includes items from both that and the [2025-11 milestone](https://github.com/iiasa/message-ix-models/milestone/8).

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- [x] Update doc/whatsnew.
