### PR TITLE
Use `uv publish` for 'publish' CI workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,19 +1,30 @@
 name: Build package / publish
 
 on:
-  push:
-    branches: [ main ]
-    tags: [ "v*" ]
-  release:
-    types: [ published ]
-  # Check that package can be built even on PRs
-  pull_request:
-    branches: [ main ]
+  pull_request: { branches: [ main ] }
+  push: { tags: [ "v*" ] }
+  release: { types: [ published ] }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
-    uses: iiasa/actions/.github/workflows/publish.yaml@main
-    with:
-      lfs: true
-    secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+    environment: { name: publish }
+    permissions: { id-token: write }
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with: { python-version: "3.14" }
+    - run: uv build
+    - run: uv publish --trusted-publishing=always
+      if: >-
+        github.event_name == 'release' || (
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+        )
+      # Uncomment for testing
+      # env: { UV_PUBLISH_URL: "https://test.pypi.org/legacy/" }


### PR DESCRIPTION
Same as iiasa/ixmp#614.
## How to review
Confirm the alpha release tagged on the branch is published to test.pypi.org
## PR checklist
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI changes only
- ~Update doc/whatsnew.~
- [x] (after approval) Drop the TEMPORARY commit.
- [ ] (after merge) Remove the GitHub Actions secrets for PyPI and TestPyPI; delete the tokens on (Test)PyPI proper.
