### PR TITLE
Quick check in for inf numbers in the share data in material reporting

### DIFF
--- a/message_ix_models/model/material/report/run_reporting.py
+++ b/message_ix_models/model/material/report/run_reporting.py
@@ -566,6 +566,8 @@ def split_mto_feedstock(
                 variable=f"Share|{c}-methanol-fs",
             )
         )
+        # in case in::methanol-final is zero in sepcific year/node
+        to_append = pyam.IamDataFrame(to_append.data.replace([np.inf, -np.inf], 0))
         py_df_all = pyam.concat([py_df_all, to_append])
         updated_rows = []
 


### PR DESCRIPTION
A draft PR to help confirm if in::methanol-final can be zero in specific regions/years. 

## How to review

- @macflo8 is it possible that in::methanol-final can be zero in a regular scenario run?
- If no, then ignore this PR. 
- If yes, read the diff, check if it is ok to replace inf with zero in the shares. 
- The CI checks all pass.