### PR TITLE
Add `.report.legacy.compat`

### DIFF
--- a/message_ix_models/report/legacy/ENGAGE_SSP2_v417_tables.py
+++ b/message_ix_models/report/legacy/ENGAGE_SSP2_v417_tables.py
@@ -763,7 +763,7 @@ def retr_lnd_cvr(units):
     vars["Forest|Afforestation and Reforestation"] = pp.land_out(
         lu_out_filter={
             "level": ["land_use_reporting"],
-            "commodity": ["Land Cover|Forest|Afforestation and" " Reforestation"],
+            "commodity": ["Land Cover|Forest|Afforestation and Reforestation"],
         }
     )
 
@@ -897,7 +897,7 @@ def retr_frst_prd(units):
     vars["Roundwood|Industrial Roundwood"] = pp.land_out(
         lu_out_filter={
             "level": ["land_use_reporting"],
-            "commodity": ["Forestry Production|Roundwood|Industrial" " Roundwood"],
+            "commodity": ["Forestry Production|Roundwood|Industrial Roundwood"],
         }
     )
 
@@ -1412,7 +1412,7 @@ def retr_othemi(var, units):
             lu_out_filter={
                 "level": ["land_use_reporting"],
                 "commodity": [
-                    "Emissions|CH4|Land Use|Agriculture|Enteric" " Fermentation"
+                    "Emissions|CH4|Land Use|Agriculture|Enteric Fermentation"
                 ],
             }
         )
@@ -1492,21 +1492,21 @@ def retr_othemi(var, units):
         vars["AFOLU|Land|Grassland Pastures"] = pp.land_out(
             lu_out_filter={
                 "level": ["land_use_reporting"],
-                "commodity": ["Emissions|N2O|Land Use|Agriculture|" "Pasture"],
+                "commodity": ["Emissions|N2O|Land Use|Agriculture|Pasture"],
             }
         )
 
         vars["AFOLU|Agriculture|Managed Soils"] = pp.land_out(
             lu_out_filter={
                 "level": ["land_use_reporting"],
-                "commodity": ["Emissions|N2O|Land Use|Agriculture|" "Cropland Soils"],
+                "commodity": ["Emissions|N2O|Land Use|Agriculture|Cropland Soils"],
             }
         )
 
         vars["AFOLU|Agriculture|Livestock|Manure Management"] = pp.land_out(
             lu_out_filter={
                 "level": ["land_use_reporting"],
-                "commodity": ["Emissions|N2O|Land Use|Agriculture|" "AWM"],
+                "commodity": ["Emissions|N2O|Land Use|Agriculture|AWM"],
             }
         )
 
@@ -3112,12 +3112,9 @@ def retr_CO2emi(units_emi, units_ene_mdl):
 
     vars["Energy|Supply|Gases|Coal|Fugitive"] = pp_utils._make_zero()
 
-    vars[
-        "Energy|Supply|Gases|Extraction|Combustion"
-    ] = _Other_gases_extr_comb + _Diff1 * (
-        abs(_Other_gases_extr_comb) / _Total_wo_BECCS
-    ).fillna(
-        0
+    vars["Energy|Supply|Gases|Extraction|Combustion"] = (
+        _Other_gases_extr_comb
+        + _Diff1 * (abs(_Other_gases_extr_comb) / _Total_wo_BECCS).fillna(0)
     )
 
     # _Diff1 is not disctributed across the variable
@@ -3148,32 +3145,24 @@ def retr_CO2emi(units_emi, units_ene_mdl):
 
     vars["Energy|Supply|Gases|Transportation|Fugitive"] = pp_utils._make_zero()
 
-    vars[
-        "Energy|Supply|Liquids|Biomass|Combustion"
-    ] = _Other_liquids_biomass_comb + _Diff1 * (
-        abs(_Other_liquids_biomass_comb_woBECCS) / _Total_wo_BECCS
-    ).fillna(
-        0
+    vars["Energy|Supply|Liquids|Biomass|Combustion"] = (
+        _Other_liquids_biomass_comb
+        + _Diff1
+        * (abs(_Other_liquids_biomass_comb_woBECCS) / _Total_wo_BECCS).fillna(0)
     )
 
     vars["Energy|Supply|Liquids|Biomass|Fugitive"] = pp_utils._make_zero()
 
-    vars[
-        "Energy|Supply|Liquids|Coal|Combustion"
-    ] = _Other_liquids_coal_comb + _Diff1 * (
-        abs(_Other_liquids_coal_comb) / _Total_wo_BECCS
-    ).fillna(
-        0
+    vars["Energy|Supply|Liquids|Coal|Combustion"] = (
+        _Other_liquids_coal_comb
+        + _Diff1 * (abs(_Other_liquids_coal_comb) / _Total_wo_BECCS).fillna(0)
     )
 
     vars["Energy|Supply|Liquids|Coal|Fugitive"] = pp_utils._make_zero()
 
-    vars[
-        "Energy|Supply|Liquids|Extraction|Combustion"
-    ] = _Other_liquids_extr_comb + _Diff1 * (
-        abs(_Other_liquids_extr_comb) / _Total_wo_BECCS
-    ).fillna(
-        0
+    vars["Energy|Supply|Liquids|Extraction|Combustion"] = (
+        _Other_liquids_extr_comb
+        + _Diff1 * (abs(_Other_liquids_extr_comb) / _Total_wo_BECCS).fillna(0)
     )
 
     vars["Energy|Supply|Liquids|Extraction|Fugitive"] = pp_utils._make_zero()
@@ -3210,12 +3199,9 @@ def retr_CO2emi(units_emi, units_ene_mdl):
     vars["Energy|Supply|Solids|Coal|Combustion"] = pp_utils._make_zero()
     vars["Energy|Supply|Solids|Coal|Fugitive"] = pp_utils._make_zero()
 
-    vars[
-        "Energy|Supply|Solids|Extraction|Combustion"
-    ] = _Other_solids_coal_trans_comb + _Diff1 * (
-        abs(_Other_solids_coal_trans_comb) / _Total_wo_BECCS
-    ).fillna(
-        0
+    vars["Energy|Supply|Solids|Extraction|Combustion"] = (
+        _Other_solids_coal_trans_comb
+        + _Diff1 * (abs(_Other_solids_coal_trans_comb) / _Total_wo_BECCS).fillna(0)
     )
 
     vars["Energy|Supply|Solids|Extraction|Fugitive"] = pp_utils._make_zero()
@@ -4061,7 +4047,6 @@ def retr_pe(units, method=None):
     vars["Other"] = pp.inp("LH2_bunker", units)
 
     if method != "substitution":
-
         # ------------------------------------
         # Primary Energy Electricity from coal
         # ------------------------------------

--- a/message_ix_models/report/legacy/compat.py
+++ b/message_ix_models/report/legacy/compat.py
@@ -1,0 +1,266 @@
+"""Compatibility from legacy to :mod:`genno`-based reporting."""
+
+import logging
+from dataclasses import asdict
+from functools import partial
+from itertools import count
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from genno import Key, Keys, quote
+
+from message_ix_models.util import minimum_version, package_data_path
+
+from .config import Config, TableConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from message_ix import Reporter, Scenario
+
+    from message_ix_models import Context
+
+log = logging.getLogger(__name__)
+
+#: Keys for :class:`.Reporter` tasks added by :func:`callback`. These include:
+#:
+#: - Inputs to :func:`prepare_module_globals`:
+#:
+#:   - :py:`.mu`: :class:`dict` representation of
+#:     :attr:`.legacy.config.Config.model_units`.
+#:   - :py:`.uc`: :class:`dict`, same as :attr:`.legacy.config.Config.unit_conversion`.
+#:   - :py:`.upd`: :class:`pathlib.Path` to “urban percentage data”, a CSV file.
+#:   - :py:`.tm`:  :class:`list` of :class:`types.ModuleType`, including all modules
+#:     from which tables are used.
+#:
+#: - :py:`.prep`: Run :func:`prepare_module_globals`. Always returns :any:`True`.
+#: - :py:`.av`: load the CSV file at :attr:`.legacy.Config.config.var_def`, return
+#:   unique entries from the ‘Variable’ column as :class:`list`.
+#: - :py:`.mapping`: load the CSV file at :attr:`.legacy.Config.config.aggr_def`.
+#: - :py:`.result`: the final result as IAMC-structured :class:`pandas.DataFrame`.
+KEY = Keys(
+    av="allowed_vars::legacy",
+    mapping="mapping::legacy",
+    mu="model units::legacy",
+    prep="prepare modules::legacy",
+    result="legacy::iamc",
+    uc="unit conversion::legacy",
+    upd="urban_perc_data::legacy",
+    tm="table modules::legacy",
+)
+
+#: Table names to skip
+SKIP: set[str] = set()
+
+
+# NB with message_ix 3.10 and earlier:
+# - On GitHub Actions, all tables fail with ReferenceError: weakly-referenced object no
+#   longer exists.
+# - Locally, retr_macro() fails with RuntimeError: unhandled Java exception: There is no
+#   parameter 'gdp_calibrate'
+@minimum_version("message_ix 3.11")
+def callback(rep: "Reporter", context: "Context") -> None:
+    """Insert tasks to invoke legacy reporting tables.
+
+    This function calls :meth:`.legacy.config.Config.from_file` on
+    :file:`default_run_config.yaml` to read and prepare configuration.
+
+    It then sets up the following on `rep`:
+
+    - All of :data:`KEY`.
+    - Multiple keys like ``Enrgy_PE::table+iamc``, with tasks that call
+      :func:`run_table` with a given :class:`TableConfig` instance and return the result
+      as IAMC-structured :class:`pandas.DataFrame`.
+    - Intermediate keys in the preparation of :py:`KEY.result` or ``legacy::iamc``:
+
+      - ``legacy::iamc+0`` concatenates all the above tables together.
+      - ``legacy::iamc+1`` applies :func:`merge_ts` if :attr:`.Config.merge_ts` is
+        :any:`True`.
+      - ``legacy::iamc+2`` filters using :py:`KEY.av`.
+      - ``legacy::iamc+3`` applies :func:`merge_hist` if :attr:`.Config.merge_hist` is
+        :any:`True`. Currently ``legacy::iamc`` is an alias for this key.
+
+    These keys and tasks can then be overridden by user code before calling
+    :meth:`.Reporter.get`.
+
+    Raises
+    ------
+    NotImplementedError
+        if :attr:`~.Config.run_history` is :any:`True`.
+    """
+
+    # .report.legacy.config.Config instance. This is only used within the current
+    # function to set up `rep`; it is not preserved or available within the Reporter.
+    # TODO Allow a different file
+    cfg = Config.from_file(
+        package_data_path("report", "legacy", "default_run_config.yaml")
+    )
+
+    if cfg.run_history:
+        raise NotImplementedError
+
+    # Iterate over TableConfig instances derived from default_run_config.yaml
+    table_keys, modules = [], set()
+    for tc in filter(lambda tc: tc.name not in SKIP, cfg.table):
+        # Make a key for this task
+        key = Key(tc.name, tag="table+iamc")
+
+        # Avoid duplicates by adding to the name
+        for i in count():
+            if key in table_keys:
+                key = Key(f"{tc.name} {i}", tag="table+iamc")
+            else:
+                break
+
+        # Add a task to call run_legacy_table with this function
+        rep.add(key, run_table, KEY.prep, table_config=tc)
+        table_keys.append(key)
+        modules.add(tc.module)
+
+    # Add tasks that return the configuration information to be used by
+    # prepare_module_globals()
+    rep.add(KEY.mapping, partial(pd.read_csv, cfg.aggr_def))
+    rep.add(KEY.mu, quote(asdict(cfg.model_units)))
+    rep.add(KEY.uc, quote(cfg.unit_conversion))
+    rep.add(KEY.upd, quote(cfg.urban_perc))
+    rep.add(KEY.tm, modules)
+
+    # Keys for tasks already in `rep`
+    args_common = ("config", "scenario", "n", "y", "y::model")
+    # Keys or literal values added above
+    args_from_config = (KEY.mu, cfg.run_history, KEY.uc, KEY.upd, KEY.tm)
+
+    # Add a task to set module-level globals in pp_utils, default_tables, etc. This task
+    # 1. is required by, thus runs before, the individual run_table() tasks, and
+    # 2. runs only once.
+    rep.add(KEY.prep, prepare_module_globals, *args_common, *args_from_config)
+
+    # Add a task to concatenate all tables together
+    k = KEY.result
+    rep.add(k[0], lambda *args: pd.concat(args), *table_keys)
+
+    rep.add(k[1], merge_ts, k[0], condition=cfg.merge_ts)
+
+    # Apply allowed_vars from Config.var_def
+    rep.add(KEY.av, lambda: pd.read_csv(cfg.var_def)["Variable"].unique().tolist())
+    rep.add(k[2], lambda df, av: df[df.Variable.isin(av)], k[1], KEY.av)
+
+    rep.add(k[3], merge_hist, k[2], condition=cfg.merge_hist)
+
+    # Simple alias
+    rep.add(k, k[3])
+
+    # TODO Append to all::iamc key
+
+
+def merge_hist(data: pd.DataFrame, *, condition: bool) -> pd.DataFrame:
+    """Imitate :py:`iamc_report_hackathon(…, merge_hist=True)`."""
+    if condition:  # pragma: no cover
+        raise NotImplementedError
+    return data
+
+
+def merge_ts(data: pd.DataFrame, *, condition: bool) -> pd.DataFrame:
+    """Imitate :py:`iamc_report_hackathon(…, merge_ts=True)`."""
+    if condition:  # pragma: no cover
+        raise NotImplementedError
+    return data
+
+
+def prepare_module_globals(
+    config: dict,
+    scenario: "Scenario",
+    nodes: list[str],
+    years: list[int],
+    years_model: list[int],
+    model_units: dict,
+    run_history: bool,
+    unit_conversion: dict,
+    urban_perc_data: "Path",
+    table_modules: list["ModuleType"],
+) -> bool:
+    """Prepare global variables for :func:`run_table`.
+
+    Functions in the module :mod:`.report.legacy.pp_utils` and in `table_modules` such
+    as :mod:`.report.legacy.default_tables` reference module-global variables. When
+    :func:`.iamc_report_hackathon.main` is used, these are set directly before the table
+    function is called.
+
+    :func:`prepare_module_globals` ensures these module-global variables have the
+    necessary contents, using values passed as arguments: either from standard
+    :class:`.Reporter` contents per :meth:`message_ix_models.report.prepare_computer`,
+    or added by :func:`callback` in this module from a :class:`.legacy.config.Config`
+    instance.
+    """
+    from message_ix_models.report.legacy import pp_utils
+    from message_ix_models.report.legacy.postprocess import PostProcess
+
+    pp = PostProcess(scenario)
+
+    for module in table_modules:
+        # Set globals in each of the table_modules
+        # TODO When adding support for run_history = True, set kyoto_hist_data and
+        #      lu_hist_data
+        if getattr(module, "pp", None) is None:
+            setattr(module, "pp", pp)
+            setattr(module, "mu", model_units)
+            # NB The variable must be string "True", not bool
+            setattr(module, "run_history", str(run_history))
+            # NB Must be a path to a CSV file. Not used in default_tables.py; see
+            #    ENGAGE_SSP2_v417_tables.py.
+            setattr(module, "urban_perc_data", urban_perc_data)
+
+    if getattr(pp_utils, "regions", None) is None:
+        region_id = config["model"].regions
+        globalname = f"{region_id}_GLB"
+
+        setattr(pp_utils, "all_tecs", scenario.set("technology"))
+        setattr(pp_utils, "all_years", years)
+        setattr(pp_utils, "globalname", globalname)
+        setattr(pp_utils, "model_nm", scenario.model)
+        setattr(
+            pp_utils,
+            "regions",
+            {n: n.partition("_")[2] for n in nodes if n != "World"}
+            | {globalname: "World"},
+        )
+        setattr(pp_utils, "region_id", region_id)
+        setattr(pp_utils, "scen_nm", scenario.scenario)
+        setattr(pp_utils, "unit_conversion", unit_conversion)
+        setattr(pp_utils, "years", years_model)
+
+    return True
+
+
+def run_table(prepared: bool, table_config: "TableConfig") -> pd.DataFrame:
+    """Invoke a single function (‘table’) from legacy reporting.
+
+    1. Run the :attr:`.TableConfig.function`. No arguments are passed; if any are
+       required, they **must** be prepared using :any:`functools.partial`.
+    2. Prepend :attr:`.TableConfig.variable_prefix` to entries in the ‘Variable’ column.
+
+    If any exception is raised, a warning is logged, and an empty data frame is
+    returned.
+
+    Parameters
+    ----------
+    table_config :
+        Information about the table.
+    """
+    try:
+        # - Run the table function.
+        # - Prepend the variable_prefix to strings in the Variable column.
+        return table_config.function().assign(
+            Variable=lambda df: df.Variable.str.replace(
+                "^", table_config.variable_prefix + "|", regex=True
+            )
+        )
+    except Exception as e:
+        # Something went wrong. Show an exception message and return empty data.
+        mod = table_config.module.__name__
+        log.error(
+            f"{type(e).__name__} invoking {mod}.(retr_){table_config.name}:\n"
+            + e.args[0],
+        )
+        return pd.DataFrame()

--- a/message_ix_models/report/legacy/config.py
+++ b/message_ix_models/report/legacy/config.py
@@ -1,0 +1,248 @@
+"""Configuration for :class:`.report.legacy`.
+
+Classes and functions in this module mimic behaviour of configuration-handling code in
+:func:`.legacy.iamc_report_hackathon.main`. However, they are **not** used there. They
+are only used by :mod:`.legacy.compat` to mimic the behaviour of iamc_report_hackathon
+within a :class:`.Reporter`.
+
+Theses classes isolate config-handling logic, default, and file formats from the final
+information actually used in reporting operations.
+"""
+
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field, fields
+from functools import cache, partial
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+from message_ix_models.util import package_data_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DEFAULT = "message_ix_models.report.legacy.default_tables"
+
+
+@dataclass
+class Units:
+    """Units.
+
+    The fields exactly correspond to those found under ``model_units:`` in files like
+    :file:`default_units.yaml`. Adding, removing, or changing keys without adjusting
+    the class will result in errors.
+    """
+
+    conv_c2co2: float = 44.0 / 12.0
+    conv_co22c: float = 12.0 / 44.0
+    #: Carbon content of natural gas.
+    crbcnt_gas: float = 0.482
+    #: Carbon content of oil.
+    crbcnt_oil: float = 0.631
+    #: Carbon content of coal.
+    crbcnt_coal: float = 0.814
+    currency_unit_out: str = "US$2010"
+    currency_unit_out_conv: float = 1.10774
+    gwp_ch4: float = 25
+    gwp_n2o: float = 298
+    # comment appearing in :file:`default_units.yaml`:
+    #
+    #   HFC factors: GWP-HFC134a / HFC-Species
+    #   GWP from Guus Velders (SSPs 2015 scen: OECD-SSP2)
+    #   Email to Riahi, Fricko 20150713
+    gwp_HFC125: float = 1360.0 / 3450.0
+    gwp_HFC134a: float = 1360.0 / 1360.0
+    gwp_HFC143a: float = 1360.0 / 5080.0
+    gwp_HFC227ea: float = 1360.0 / 3140.0
+    gwp_HFC23: float = 1360.0 / 12500.0
+    gwp_HFC245fa: float = 1360.0 / 882.0
+    gwp_HFC365: float = 1360.0 / 804.0
+    gwp_HFC32: float = 1360.0 / 704.0
+    gwp_HFC4310: float = 1360.0 / 1650.0
+    gwp_HFC236fa: float = 1360.0 / 8060.0
+    gwp_HFC152a: float = 1360.0 / 148.0
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Units":
+        """Construct a Units instance from `data`, for instance from a file."""
+        return cls(**{k: _maybe_eval(e) for (k, e) in data.items()})
+
+
+@dataclass
+class Config:
+    """Configuration for :func:`.legacy.iamc_report_hackathon.main`.
+
+    The fields unify the following, which overlap in some cases:
+
+    1. Keys under the ``report_config:`` mapping in files like
+       :file:`default_run_config.yaml.
+    2. Arguments to :func:`.iamc_report_hackathon.main`.
+    """
+
+    #: Fully-qualified name of the module containing tables.
+    table_def: str = DEFAULT
+
+    #: Path to a CSV file.
+    aggr_def: Path = Path("default_aggregates.csv")
+
+    #: Path to a CSV file.
+    var_def: Path = Path("default_variable_definitions.csv")
+
+    #: Path to a YAML file.
+    unit_yaml: Path = Path("default_units.yaml")
+
+    #: Path to a CSV file.
+    urban_perc: Path = Path("default_pop_urban_rural.csv")
+
+    #: Only used when :attr:`run_history` is :any:`True`.
+    kyoto_hist: Path = Path("default_kyoto_hist.csv")
+
+    #: Only used when :attr:`run_history` is :any:`True`.
+    lu_hist: Path = Path("default_lu_co2_hist.csv")
+
+    merge_hist: bool = False
+    merge_ts: bool = False
+    run_history: bool = False
+
+    #: Same as module global :py:`mu` in :mod:`.legacy.pp_utils` and others. See
+    #: :func:`read_unit_config`.
+    model_units: Units = field(default_factory=Units)
+
+    #: Same as module global :py:`unit_conversion` in :mod:`.legacy.pp_utils` and
+    #: others. See :func:`read_unit_config`. Nested :class:`dict` in which the first-
+    #: and second-level keys are units to be converted from and to and the second-level
+    #: values are conversion factors that multiply values expressed in the ‘from’ units.
+    unit_conversion: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    #: List of :class:`.TableConfig` instances corresponding to the entries under
+    #: ``run_tables:`` in files like :file:`default_run_config.yaml`.
+    table: list["TableConfig"] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for f in filter(lambda f: f.type is Path, fields(self)):
+            # Convert str (e.g. from YAML) to Path
+            path = Path(getattr(self, f.name))
+            # Resolve a non-absolute or non-existing path within the package data
+            if not path.exists():
+                path = package_data_path("report", "legacy", path)
+                assert path.exists()
+            setattr(self, f.name, path)
+
+    @classmethod
+    def from_file(cls, path) -> "Config":
+        """Read a file like :file:`default_run_config.yaml`."""
+        import yaml
+
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+
+        cfg = cls(**data.pop("report_config"))
+
+        # Name of module containing table functions
+        module_name = cfg.table_def
+
+        # Convert tables to instances of TableConfig
+        for info in data.pop("run_tables").values():
+            # Skip items without "active: True"
+            if not info.pop("active", False):
+                continue
+
+            # Convert YAML contents to TableConfig instance
+            try:
+                tc = TableConfig.from_info(module_name=module_name, **info)
+            except AttributeError:
+                tc = TableConfig.from_info(module_name=DEFAULT, **info)
+            cfg.table.append(tc)
+
+        cfg.model_units, cfg.unit_conversion = read_unit_config(cfg.unit_yaml)
+
+        return cfg
+
+
+@dataclass(frozen=True)
+class TableConfig:
+    """Information needed by a legacy reporting table."""
+
+    #: Python code snippet to be evaluated at runtime to determine whether
+    #: :attr:`function` should run.
+    condition: str
+
+    #: Direct reference to a function from :mod:`.report.legacy.default_tables` or a
+    #: similar module. This may be a :any:`functools.partial` object that fixes certain
+    #: arguments to the function.
+    function: Callable
+
+    #: Reference to the module in which :attr:`function` appears.
+    module: ModuleType
+
+    #: Name of :func:`function` with the prefix "retr_" stripped.
+    name: str
+
+    #: Prefix for an IAMC ‘variable’ code.
+    variable_prefix: str
+
+    @classmethod
+    def from_info(
+        cls,
+        module_name: str,
+        *,
+        args,
+        condition: str | None = None,
+        function: str,
+        root,
+    ) -> "TableConfig":
+        """Construct from keys/values such as in :file:`default_run_config.yaml`."""
+        mod = import_module(module_name)
+        f = partial(getattr(mod, function), **args)
+        name = function.partition("retr_")[2]
+
+        return cls(condition or "", f, mod, name, root)
+
+    def __repr__(self) -> str:
+        return f"<TableConfig {self.module.__name__}.{self.name}>"
+
+
+def _maybe_eval(expr: str, *args) -> Any:
+    """Evaluate `expr`, or return as-is."""
+    try:
+        return eval(expr, *args)
+    except Exception:
+        return expr
+
+
+@cache
+def read_unit_config(path: "Path") -> tuple[Units, dict]:
+    """Read a file like :file:`default_units.yaml`.
+
+    Returns
+    -------
+    tuple
+       …containing:
+
+       1. :class:`Units` for :attr:`Config.model_units`.
+       2. :class:`dict` for :attr:`Config.unit_conversion`.
+    """
+    import yaml
+
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+
+    # Construct a Units instance. This validates the contents of the ``model_units:``
+    # subtree
+    model_units = Units.from_dict(data.pop("model_units"))
+
+    # Globals expected by expressions to be eval'd() in ``conversion_factors:``
+    globals = dict(mu=asdict(model_units))
+
+    # Evaluate expressions in the second-level key *and* in the value
+    conversion_factors: dict[str, dict[str, float]] = defaultdict(dict)
+    for a, data_a in data.pop("conversion_factors").items():
+        for b, expr in data_a.items():
+            conversion_factors[a][_maybe_eval(b, globals)] = _maybe_eval(expr, globals)
+
+    # File should contain only the above 2 keys
+    assert not data
+
+    return model_units, conversion_factors

--- a/message_ix_models/report/legacy/default_tables.py
+++ b/message_ix_models/report/legacy/default_tables.py
@@ -2035,7 +2035,7 @@ def retr_othemi(var, units):
             lu_out_filter={
                 "level": ["land_use_reporting"],
                 "commodity": [
-                    "Emissions|CH4|AFOLU|Agriculture|Livestock|" "Enteric Fermentation"
+                    "Emissions|CH4|AFOLU|Agriculture|Livestock|Enteric Fermentation"
                 ],
             }
         )
@@ -2044,7 +2044,7 @@ def retr_othemi(var, units):
             lu_out_filter={
                 "level": ["land_use_reporting"],
                 "commodity": [
-                    "Emissions|CH4|AFOLU|Agriculture|Livestock|" "Manure Management"
+                    "Emissions|CH4|AFOLU|Agriculture|Livestock|Manure Management"
                 ],
             }
         )
@@ -2132,7 +2132,7 @@ def retr_othemi(var, units):
             lu_out_filter={
                 "level": ["land_use_reporting"],
                 "commodity": [
-                    "Emissions|N2O|AFOLU|Agriculture|" "Livestock|Manure Management"
+                    "Emissions|N2O|AFOLU|Agriculture|Livestock|Manure Management"
                 ],
             }
         )
@@ -5866,21 +5866,21 @@ def retr_pe(units, method=None):
         vars["Biomass|1st Generation"] = pp.land_out(
             lu_out_filter={
                 "level": ["land_use_reporting"],
-                "commodity": ["Primary Energy|Biomass|" "1st Generation"],
+                "commodity": ["Primary Energy|Biomass|1st Generation"],
             }
         )
 
         vars["Biomass|1st Generation|Biodiesel"] = pp.land_out(
             lu_out_filter={
                 "level": ["land_use_reporting"],
-                "commodity": ["Primary Energy|Biomass|" "1st Generation|Biodiesel"],
+                "commodity": ["Primary Energy|Biomass|1st Generation|Biodiesel"],
             }
         )
 
         vars["Biomass|1st Generation|Bioethanol"] = pp.land_out(
             lu_out_filter={
                 "level": ["land_use_reporting"],
-                "commodity": ["Primary Energy|Biomass|" "1st Generation|Bioethanol"],
+                "commodity": ["Primary Energy|Biomass|1st Generation|Bioethanol"],
             }
         )
 

--- a/message_ix_models/report/legacy/iamc_report_hackathon.py
+++ b/message_ix_models/report/legacy/iamc_report_hackathon.py
@@ -6,9 +6,13 @@ import yaml
 from yaml.loader import SafeLoader
 from message_ix_models import Context
 from message_ix_models.util import package_data_path
-from message_ix_models.util.compat.message_data.get_historical_years import main as get_historical_years
+from message_ix_models.util.compat.message_data.get_historical_years import (
+    main as get_historical_years,
+)
 from message_ix_models.util.compat.message_data.get_nodes import get_nodes
-from message_ix_models.util.compat.message_data.get_optimization_years import main as get_optimization_years
+from message_ix_models.util.compat.message_data.get_optimization_years import (
+    main as get_optimization_years,
+)
 from message_ix_models.util.compat.message_data.utilities import retrieve_region_mapping
 
 from . import postprocess

--- a/message_ix_models/report/legacy/iamc_tree.py
+++ b/message_ix_models/report/legacy/iamc_tree.py
@@ -76,7 +76,6 @@ class Node(object):
         setattr(self, name, node)
 
     def sum_sectors(self, mode="overwrite"):
-
         if len(self.children) == 0:
             return self.df  # bottom of recursion
 

--- a/message_ix_models/report/operator.py
+++ b/message_ix_models/report/operator.py
@@ -419,7 +419,7 @@ def select_allow_empty(
     try:
         return genno.operator.select(qty, indexers=indexers, inverse=inverse, drop=drop)
     except KeyError:
-        return genno.Quantity([], coords={d: [] for d in qty.dims})
+        return type(qty)([], coords={d: [] for d in qty.dims})
 
 
 def select_expand(

--- a/message_ix_models/tests/report/legacy/test_compat.py
+++ b/message_ix_models/tests/report/legacy/test_compat.py
@@ -1,0 +1,69 @@
+from collections.abc import Iterator
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from message_ix_models import Context, testing
+from message_ix_models.report import prepare_reporter
+from message_ix_models.report.legacy import compat
+
+
+@pytest.fixture
+def skip_tables() -> Iterator[None]:
+    """Entirely skip some tables.
+
+    These call :func:`.postprocess.land_out` that in turn raises SystemExit if LAND is
+    empty—as it is in the scenario returned by :func:`.bare_res`. This exception cannot
+    be caught and handled by :func:`.run_table`.
+    """
+    pre = compat.SKIP.copy()
+
+    compat.SKIP = {
+        "agri_dem",
+        "agri_prd",
+        "fertilizer_int",
+        "fertilizer_use",
+        "food_dem",
+        "food_waste",
+        "frst_dem",
+        "frst_prd",
+        "globiom_feedback",
+        "lnd_cvr",
+        "othemi",
+        "price",
+        "yield",
+    }
+    try:
+        yield
+    finally:
+        compat.SKIP = pre
+
+
+@compat.callback.minimum_version
+@pytest.mark.usefixtures("skip_tables")
+def test_callback(
+    request: pytest.FixtureRequest, tmp_path: Path, test_context: Context
+) -> None:
+    """:func:`.report.legacy.compat.callback` prepares working Reporter."""
+    # NB This is similar to test_report.test_reporter_bare_res
+
+    # Prepare a solved, 'bare' scenario
+    test_context.model.regions = "R12"
+    scenario = testing.bare_res(request, test_context, solved=True)
+
+    # Set up report.Config
+    test_context.report.update(from_file="global.yaml", key=compat.KEY.result)
+    # Append the .report.legacy.compat callback
+    test_context.report.callback.append(compat.callback)
+
+    # Prepare the reporter and compute the result
+    rep, key = prepare_reporter(test_context, scenario)
+
+    # rep.visualize("report-legacy-compat.svg", key, rankdir="LR")  # DEBUG
+
+    # Result is computed without error
+    result = rep.get(key)
+
+    assert isinstance(result, pd.DataFrame)
+    assert 4455 == len(result)

--- a/message_ix_models/tests/report/legacy/test_config.py
+++ b/message_ix_models/tests/report/legacy/test_config.py
@@ -1,0 +1,18 @@
+import pytest
+
+from message_ix_models.report.legacy.config import Config
+from message_ix_models.util import package_data_path
+
+
+class TestConfig:
+    @pytest.mark.parametrize(
+        "filename, N_tables",
+        (
+            ("default_run_config.yaml", 53),
+            ("ENGAGE_SSP2_v417_run_config.yaml", 4),
+        ),
+    )
+    def test_from_file(self, filename: str, N_tables: int) -> None:
+        """:meth:`Config.from_file` handles known :file:`*_run_config.yaml` files."""
+        result = Config.from_file(package_data_path("report", "legacy", filename))
+        assert N_tables == len(result.table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,10 @@ exclude_also = [
 omit = [
   "message_ix_models/project/ssp/script/*",
   # The single existing test is far from enough
-  "message_ix_models/report/legacy/*",
+  "message_ix_models/report/legacy/*_tables.py",
+  "message_ix_models/report/legacy/iamc_*.py",
+  "message_ix_models/report/legacy/postprocess.py",
+  "message_ix_models/report/legacy/pp_utils.py",
   "message_ix_models/util/migrate.py",
 ]
 
@@ -129,7 +132,7 @@ module = [
   "message_ix_models.model.material.util",
   "message_ix_models.model.water.*",
   # Legacy codes that may not be type hinted
-  "message_ix_models.report.legacy.*",
+  "message_ix_models.report.legacy.iamc_report_hackathon",
   "message_ix_models.tools.messagev",
   "message_ix_models.util.compat.message_data.*",
 ]
@@ -175,10 +178,13 @@ markers = [
 ]
 
 [tool.ruff]
-exclude = [
+extend-exclude = [
   "doc/_static/png_source_files/Land-use_emulator_figures.ipynb",
   "message_ix_models/model/material/report/Historical Power Sector Stock Reporting-.ipynb",
-  "message_ix_models/report/legacy/",
+  "message_ix_models/report/legacy/*_tables.py",
+  "message_ix_models/report/legacy/iamc_*.py",
+  "message_ix_models/report/legacy/postprocess.py",
+  "message_ix_models/report/legacy/pp_utils.py",
   "message_ix_models/util/compat/message_data/",
 ]
 


### PR DESCRIPTION
This PR adds 2 new modules:
- `message_ix_models.report.legacy.compat`.
  - This allows to add tasks to a Reporter ('new-style' or 'genno-based' reporting) that individually and collectively reproduce the behaviour of `iamc_report_hackathon.main()` ('existing' or 'legacy' reporting).
  - In particular the added `run_table()` function invokes a single legacy table as a single task in a Reporter.
- `message_ix_models.report.legacy.config`:
  - This handles the input data/configuration files needed to make the above work.

This addition is a prerequisite for the following steps that were recently discussed and planned:

1. Separate certain operations (merge_ts, merge_hist) of the 'legacy' reporting, so they can be re-used, replaced, improved, configured, etc.
2. Run a mix of legacy tables and new reporting code and integrate the results.

These steps should in turn make the 'legacy' reporting tables more user-friendly, allow some desired improvements, and ease co-use/integration/reimplementation in 'new' reporting.

## Further details

- The implementation deliberately makes **zero changes** to code in iamc_report_hackathon, pp_utils, default_tables, *et al.* and the data files they read. Any compatibility code is contained in the new modules.
  - This should avoid complicating diffs as we update/merge/replace the existing files, e.g. with versions from message_data or message_single_country.
- This is **not a recommended approach** for new reporting code or features.
  - We will separately establish and document recommended approaches for writing new reporting code for new projects and model variants. The module is narrowly intended for the purposes mentioned above.
- There is an **existing, older module with a similar name** `message_ix_models.report.compat`.
  - The purpose of that module is different: it prepares a Reporter to _exactly imitate_ the internal calculation steps done by a 'table' function. The module added in this PR instead patches the existing table functions into a Reporter *as-is*, and adds configuration so that they run correctly.
  - It was prepared as an experiment; see #134.
  - We've discussed that, for our ideal/future-proof reporting, it may be *undesirable* to exactly imitate the way calculations are performed in the existing tables. Thus the approach in `message_ix_models.report.compat` may not be applied widely.

Here is a visualization of the added tasks:
![report-legacy-compat](https://github.com/user-attachments/assets/307a50b2-802a-47cf-b23e-125ea3cd5a69)

## How to review

- Read the added docs, particularly for the function `.report.legacy.compat.callback()`.
- Read the 1 added test in `.tests.report.legacy.test_compat()`.
- (Maybe) Run the code against a full-scale scenario and check the results.
  - The scope for this PR does **not** include making this output 1:1 with iamc_report_hackathon for all combinations of arguments and inputs. It is narrowly intended to establish the basic functionality. However, such a check can identify TODOs for follow-up PRs.
- Note the CI checks all pass.

## PR checklist

- [ ] Complete the 
  - [ ] Basic implementation of merge_ts.
  - [ ] Basic implementation of merge_hist.
  - [ ] Patch complete IAMC-structured data into existing target keys that (a) write to (i) CSV, (ii) XLSX, (b) store on Scenario, or (c) some combination of these.
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.