### PR TITLE
Add fix costs on bialteralized gas pipe trade

### DIFF
--- a/message_ix_models/tools/bilateralize/historical_calibration.py
+++ b/message_ix_models/tools/bilateralize/historical_calibration.py
@@ -848,6 +848,13 @@ def build_historical_price(
     )
     bacidf["YEAR"] = "broadcast"
 
+    # Add costs for piped gas based on LNG prices
+    bacidf_pg = bacidf[bacidf['MESSAGE COMMODITY'] == 'LNG_shipped'].copy()
+    bacidf_pg['MESSAGE COMMODITY'] = 'gas_piped'
+    print(bacidf_pg)
+    
+    bacidf = pd.concat([bacidf, bacidf_pg])
+    
     outdf = reformat_to_parameter(
         indf=bacidf,
         message_regions=message_regions,
@@ -860,7 +867,8 @@ def build_historical_price(
 
     outdf["value"] = outdf["value"] * 0.50  # TODO: Fix this deflator (2024-2005?)
     outdf["value"] = round(outdf["value"], 0)
-
+    print(outdf)
+    
     return outdf
 
 

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -1342,10 +1342,10 @@ def prepare_edit_files(
         costdf["technology"] = costdf["technology"].str.replace("ethanol_", "eth_")
         costdf["technology"] = costdf["technology"].str.replace("fueloil_", "foil_")
 
-        for tec in [i for i in covered_tec if i != "gas_piped"]:
+        for tec in covered_tec: #[i for i in covered_tec if i != "gas_piped"]:
             log.info("Add fix cost for " + tec)
 
-            if "piped" in tec:
+            if "piped" in tec and tec != 'gas_piped':
                 tec_shipped = tec.replace("piped", "shipped")
                 add_df = costdf[costdf["technology"].str.contains(tec_shipped)].copy()
                 add_df["technology"] = add_df["technology"].str.replace(
@@ -1383,7 +1383,7 @@ def prepare_edit_files(
             add_df["value"] = np.where(
                 add_df["value"].isnull(), mean_cost, add_df["value"]
             )
-            add_df["value"] = round(add_df["value"] / 5, 0)
+            add_df["value"] = round(add_df["value"], 0)
 
             add_df["unit"] = "USD/GWa"
 


### PR DESCRIPTION
This PR ensures that by default, fixed costs are added to the piped gas trade technology.

Fixed costs in the bilateralize tool represent existing trade proclivities, and exist primarily to differentiate among different trade relations. For example, if WEU>MEA fix_cost is 100 and WEU>CHN fix_cost is 50 for the same commodity (e.g., piped gas) then this will be part of the "decision" for whether and how much WEU/MEA and WEU/CHN trade with one another. This is in combination with distance and other infrastructural costs (e.g., costs associated with building and operating the pipelines) 

## How to review

**Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
If no review is required, write “No review:” and describe why.

<!--
- Read the diff and note that the CI checks all pass.
-->

## PR checklist
- [ ] Continuous integration checks all ✅
- [ ] Update doc/whatsnew.
