### PR TITLE
Adjust "pytest" CI workflow for gamsapi 53

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -184,6 +184,9 @@ jobs:
                 (version < V("3.9"), "pytest < 8.1"),
                 # https://github.com/iiasa/message-ix-models/issues/366
                 (V("3.8") < version < V("3.11"), "ixmp4 < 0.11"),
+                # ixmp.util.ixmp4 contains compatibility code that only
+                # works with pandas < 3.
+                (version == V("3.11"), "pandas < 3"),
             ):
                 result += f' "{dependency}"' if condition else ""
  


### PR DESCRIPTION
Force pandas < 3 when testing ixmp/message-ix 3.11.0.

Related to https://github.com/iiasa/message-ix-models/issues/469#issuecomment-4011332645 / pandas 3 compatibility.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI changes only
- ~Update doc/whatsnew.~