### PR TITLE
Adjust `.ssp.transport`

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -16,6 +16,7 @@ Next release
   - Add :func:`.buildings.build.prepare_data_B`;
     rename :py:`prepare_data()` to :func:`~.buildings.build.prepare_data_A`.
 
+- Adjust :mod:`.project.ssp.transport` (:pull:`485`):
 - Add stub of :func:`.scenariomip.workflow.generate` (:pull:`394`).
 
 v2026.4.17

--- a/message_ix_models/data/transport/emi-intensity.csv
+++ b/message_ix_models/data/transport/emi-intensity.csv
@@ -30,55 +30,57 @@
 #    - https://iiasa-ece.slack.com/archives/CCFHDNA6P/p1744277852653529
 #    - https://iiasa-ece.slack.com/archives/CCFHDNA6P/p1750938340070669
 #
+#    Further updated 2026-03-13.
+#
 # Units: g / MJ
 #
 technology, commodity, emission, value
 
-AIR,        lightoil,  BC,       0.001497 # (4)
+AIR,        lightoil,  BC,       0.00193362  # (4)
 
 # (3) is used because the (4) is (nearly) zero.
-AIR,        lightoil,  CH4,      0.0005   # (3)
-# AIR,      lightoil,  CH4,      0.000000 # (4)
+AIR,        lightoil,  CH4,      0.0005      # (3)
+# AIR,      lightoil,  CH4,      0.000000    # (4)
 
 # (4) is used because (2) values are too large and yield negative totals.
 #
-# AIR,      lightoil,  CO,      13.95     # (2)  600    g/kg “Calculated using Tier 2 method”
-# AIR,      lightoil,  CO,      27.90     # (2) 1200    g/kg “Calculated using Tier 2 method”
-# AIR,      lightoil,  CO,      55.81     # (2) 2400    g/kg “Calculated using Tier 2 method”
-AIR,        lightoil,  CO,       0.091096 # (4)
+# AIR,      lightoil,  CO,      13.95        # (2)  600    g/kg “Calculated using Tier 2 method”
+# AIR,      lightoil,  CO,      27.90        # (2) 1200    g/kg “Calculated using Tier 2 method”
+# AIR,      lightoil,  CO,      55.81        # (2) 2400    g/kg “Calculated using Tier 2 method”
+AIR,        lightoil,  CO,       0.132087    # (4)
 
-AIR,        lightoil,  CO2,    118.077374 # (4)
+AIR,        lightoil,  CO2,    152.705981    # (4)
 
-AIR,        lightoil,  N2O,      0.0031   # (3)
-# AIR,      lightoil,  N2O,      3.808586 # (4)
+# AIR,      lightoil,  N2O,      0.0031      # (3)
+AIR,        lightoil,  N2O,      0.00490115  # (4)
 
-AIR,        lightoil,  NH3,      0.006133 # (4)
+AIR,        lightoil,  NH3,      0.00792780  # (4)
 
 # NOx:
 # - (2) is used because (1) and (4) values are too large and yield negative totals.
 #
-# AIR,      lightoil,  NOx,      0.3284   # (1)   14.12 g/kg, lower end of confidence interval
-# AIR,      lightoil,  NOx,      0.3521   # (1)   15.14 g/kg, upper end of confidence interval
-# AIR,      lightoil,  NOx,      0.0465   # (2)    2    g/kg “Calculated using Tier 2 method”
-AIR,        lightoil,  NOx,      0.0930   # (2)    4    g/kg “Calculated using Tier 2 method”
-# AIR,      lightoil,  NOx,      0.1860   # (2)    8    g/kg “Calculated using Tier 2 method”
-# AIR,      lightoil,  NOx,      0.479172 # (4)
+# AIR,      lightoil,  NOx,      0.3284      # (1)   14.12 g/kg, lower end of confidence interval
+# AIR,      lightoil,  NOx,      0.3521      # (1)   15.14 g/kg, upper end of confidence interval
+# AIR,      lightoil,  NOx,      0.0465      # (2)    2    g/kg “Calculated using Tier 2 method”
+# AIR,      lightoil,  NOx,      0.0930      # (2)    4    g/kg “Calculated using Tier 2 method”
+# AIR,      lightoil,  NOx,      0.1860      # (2)    8    g/kg “Calculated using Tier 2 method”
+AIR,        lightoil,  NOx,      0.611969    # (4)
 
-AIR,        lightoil,  OC,       0.000743 # (4)
+AIR,        lightoil,  OC,       0.000961207 # (4)
 
-AIR,        lightoil,  Sulfur,   0.0279   # (1)    1.2  g/kg
-# AIR,      lightoil,  Sulfur,   0.041980 # (4) “Sulfur” in upstream data with “SO2” in units
+# AIR,      lightoil,  Sulfur,   0.0279      # (1)    1.2  g/kg
+AIR,        lightoil,  Sulfur,   0.0567318   # (4) “Sulfur” in upstream data with “SO2” in units
 
-# AIR,      lightoil,  SOx,      0.0116   # (2)    0.5  g/kg “Assuming 0.05% S by mass”
-AIR,        lightoil,  SOx,      0.0233   # (2)    1    g/kg “Assuming 0.05% S by mass”
-# AIR,      lightoil,  SOx,      0.0465   # (2)    2    g/kg “Assuming 0.05% S by mass”
+# AIR,      lightoil,  SOx,      0.0116      # (2)    0.5  g/kg “Assuming 0.05% S by mass”
+AIR,        lightoil,  SOx,      0.0233      # (2)    1    g/kg “Assuming 0.05% S by mass”
+# AIR,      lightoil,  SOx,      0.0465      # (2)    2    g/kg “Assuming 0.05% S by mass”
 
 # VOC:
 # - (2) were provided with the code 'NMVOC', but we use the label 'VOC' to align with
 #   MESSAGEix-GLOBIOM, even though these are not strictly the same.
 # - (4) is used because (2) values are too large and yield negative totals.
 #
-# AIR,      lightoil,  VOC,      0.2209   # (2)    9.5  g/kg “Calculated using Tier 2 method”
-# AIR,      lightoil,  VOC,      0.4419   # (2)   19    g/kg “Calculated using Tier 2 method”
-# AIR,      lightoil,  VOC,      0.8837   # (2)   38    g/kg “Calculated using Tier 2 method”
-AIR,        lightoil,  VOC,      0.013759 # (4)
+# AIR,      lightoil,  VOC,      0.2209      # (2)    9.5  g/kg “Calculated using Tier 2 method”
+# AIR,      lightoil,  VOC,      0.4419      # (2)   19    g/kg “Calculated using Tier 2 method”
+# AIR,      lightoil,  VOC,      0.8837      # (2)   38    g/kg “Calculated using Tier 2 method”
+AIR,        lightoil,  VOC,      0.0167551   # (4)

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -8,6 +8,7 @@ from functools import cache
 from typing import TYPE_CHECKING, Any
 
 import genno
+import genno.operator
 import pandas as pd
 from genno import Key, quote
 
@@ -582,9 +583,16 @@ def method_BC_common(
     # Select only total transport consumption of lightoil from K.fe_in
     indexers = {"t": "Transportation (w/ bunkers)"}
     c.add(k.fe[0], "select", K.fe_in, indexers=indexers, drop=True)
+    # Exclude data for n=World; totals to be recomputed later
+    c.add(k.fe[1], "select", k.fe[0], indexers={"n": ["World"]}, inverse=True)
 
     # Product of aviation share and FE of total transport → FE of aviation
-    c.add(k.fe, "mul", k.fe[0], k_fe_share)
+    c.add(k.fe[2], "mul", k.fe[1], k_fe_share)
+
+    # Add global sum
+    c.add(k.fe[3], "sum", k.fe[2], dimensions="n")
+    c.add(k.fe[4], "expand_dims", k.fe[3], dim={"n": ["World"]})
+    c.add(k.fe, "concat", k.fe[2], k.fe[4])
 
     # Convert exogenous emission intensity data to Mt / EJ
     c.add(k.ei["units"], "convert_units", k.ei, units="Mt / EJ")

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -84,7 +84,23 @@ K = Keys(
     fe_in=f"fe:c-n-t-y:{L}+in",
     fe_out=f"fe:c-n-t-y:{L}+out",
     units=f"units:e-UNIT:{L}",
+    y="y::model",
 )
+
+
+ROWS = [
+    # CO2 only
+    [-1.0, "Energy|Demand", "Transportation"],
+    # All species
+    [1.0, "Energy|Demand", "Bunkers|International Aviation"],
+    [1.0, "Energy|Demand", "Bunkers"],
+    # All except CO2
+    [1.0, "_T", "_T"],
+    [1.0, "Energy", "_T"],
+    [1.0, "Energy|Combustion", "_T"],
+    [1.0, "Energy|Demand", "_T"],
+    [1.0, "Fossil Fuels and Industry", "_T"],
+]
 
 
 class METHOD(Enum):
@@ -124,24 +140,11 @@ def aviation_emi_share(ref: "TQuantity") -> "TQuantity":
 
 def broadcast_est_emi(q_ref: "TQuantity") -> "TQuantity":
     """Quantity to re-add the :math:`(s, t)` dimensions for emission data."""
-    rows = [
-        # CO2 only
-        [-1.0, "Energy|Demand", "Transportation"],
-        # All species
-        [1.0, "Energy|Demand", "Bunkers"],
-        [1.0, "Energy|Demand", "Bunkers|International Aviation"],
-        # All except CO2
-        [1.0, "_T", "_T"],
-        [1.0, "Energy", "_T"],
-        [1.0, "Energy|Combustion", "_T"],
-        [1.0, "Energy|Demand", "_T"],
-        [1.0, "Fossil Fuels and Industry", "_T"],
-    ]
     data: list[list[Any]] = []
     for e in sorted(q_ref.coords["e"].data):
         # Add only the relevant rows
         idx = slice(3) if e == "CO2" else slice(1, 99)
-        data.extend([e] + row for row in rows[idx])
+        data.extend([e] + row for row in ROWS[idx])
 
     return type(q_ref)(
         pd.DataFrame(data, columns=["e", "value", "s", "t"]).set_index(["e", "s", "t"]),
@@ -315,6 +318,11 @@ def get_computer(
 
     # Create a Context instance. Only R12 is supported.
     context = Context(model=ModelConfig(regions="R12"))
+
+    # Only years=B is supported
+    y_all = get_codelist("year/B")
+    y_model = [y for y in map(lambda c: int(c.id), y_all) if y >= 2020]
+
     # Store in `c` for reference by other operations
     c.add("context", context)
     c.graph["config"].update(regions="R12")
@@ -385,8 +393,10 @@ def get_computer(
     method_func = {METHOD.A: method_A, METHOD.B: method_B, METHOD.C: method_C}[method]
     method_func(c)
 
+    # Offset/zero out certain values so these are replaced, not incremented
+    c.add(K.emi["offset"], offset, K.emi_in, y=y_model)
     # Adjust the original data by adding the (maybe negative) prepared values at K.emi
-    c.add(K.emi["adj"], "add", K.emi_in, K.emi)
+    c.add(K.emi["adj"], "add", K.emi_in, K.emi["offset"], K.emi)
     c.add(K.fe_out["adj"], "add", K.fe_in[1], K.fe_out)
 
     # Add a key "target" to:
@@ -739,6 +749,24 @@ def process_df(
 
     # Compute and return the result
     return c.get("target")
+
+
+def offset(qty: "TQuantity", *, y: list[int]) -> "TQuantity":
+    """Compute offset to reduce/“zero out” existing data."""
+    s_bcast = (
+        pd.DataFrame(ROWS[1:], columns=["value", "s", "t"])
+        .assign(n="World")
+        .set_index(["n", "s", "t"])
+    )
+
+    # - Select certain values from `qty`; drop the (s, t) dimensions.
+    # - Re-add these dimensions, broadcasting over various combinations per ROWS.
+    # - Take the negative.
+    return (
+        qty.sel(n=["World"], s="Energy|Demand", t="Bunkers|International Aviation", y=y)
+        * type(qty)(s_bcast, units="")
+        * -1.0
+    )
 
 
 def process_file(

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -6,7 +6,7 @@ from collections.abc import Hashable
 from enum import Enum, auto
 from functools import cache
 from itertools import product
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import genno
 import pandas as pd
@@ -40,6 +40,7 @@ EXPR_EMI = re.compile(
       (\|
         (?P<s>
           Energy(\|(Combustion|Demand))?
+          | Energy.and.Industrial.Processes
           | Fossil.Fuels.and.Industry
         )
         (\|
@@ -123,9 +124,7 @@ def aviation_emi_share(ref: "TQuantity") -> "TQuantity":
     )
 
 
-def broadcast_st_emi(
-    version: Literal[1, 2], include_international: bool
-) -> "AnyQuantity":
+def broadcast_st_emi(version: int, include_international: bool) -> "AnyQuantity":
     """Quantity to re-add the :math:`(s, t)` dimensions for emission data.
 
     Parameters
@@ -133,8 +132,8 @@ def broadcast_st_emi(
     version :
         Version of ‘variable’ names supported by the current module.
     include_international :
-        If :any:`True`, include "Transportation|Aviation|International" with magnitude
-        1.0. Otherwise, omit.
+        If :any:`True` and :py`version == 1`, include
+        "Transportation|Aviation|International" with magnitude 1.0. Otherwise, omit.
 
     Return
     ------
@@ -188,6 +187,7 @@ def broadcast_est_emi_other(q_ref: "TQuantity") -> "TQuantity":
     s = [
         "_T",
         "Energy",
+        "Energy and Industrial Processes",
         "Energy|Combustion",
         "Energy|Demand",
         "Fossil Fuels and Industry",
@@ -196,7 +196,8 @@ def broadcast_est_emi_other(q_ref: "TQuantity") -> "TQuantity":
     df = (
         pd.DataFrame([list(e_s) for e_s in product(e, s)], columns=dims)
         .assign(value=1.0)
-        .query("not (s == 'Energy|Combustion' and e not in @e_combustion)")
+        .query("not (s == @s[3] and e not in @e_combustion)")
+        .query("not (s == @s[2] and e != 'CO2')")
         .set_index(dims)["value"]
     )
     del e_combustion

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -5,8 +5,7 @@ import re
 from collections.abc import Hashable
 from enum import Enum, auto
 from functools import cache
-from itertools import product
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import genno
 import pandas as pd
@@ -78,8 +77,7 @@ L = "AIR emi"
 #: - :py:`.fe`: computed final energy data.
 #: - :py:`.fe_in`: input data for transport final energy, to be adjusted or overwritten.
 K = Keys(
-    bcast=f"broadcast:s-t:{L}",
-    bcast_other=f"broadcast:e-s-t:{L}+other",
+    bcast=f"broadcast:e-s-t:{L}",
     input=f"input:n-y-VARIABLE-UNIT:{L}",
     emi=f"emission:e-n-s-t-y-UNIT:{L}",
     emi_in=f"emission:e-n-s-t-y-UNIT:{L}+in",
@@ -124,85 +122,31 @@ def aviation_emi_share(ref: "TQuantity") -> "TQuantity":
     )
 
 
-def broadcast_st_emi(version: int, include_international: bool) -> "AnyQuantity":
-    """Quantity to re-add the :math:`(s, t)` dimensions for emission data.
-
-    Parameters
-    ----------
-    version :
-        Version of ‘variable’ names supported by the current module.
-    include_international :
-        If :any:`True` and :py`version == 1`, include
-        "Transportation|Aviation|International" with magnitude 1.0. Otherwise, omit.
-
-    Return
-    ------
-    genno.Quantity
-        with dimensions :math:`(s, t)`.
-
-        If :py:`version=1`, the :math:`t`: values include:
-
-        - +1.0 for t="Transportation|Aviation", a label with missing data.
-        - -1.0 for t="Transportation|Road Rail and Domestic Shipping", a label with
-          existing data from which the aviation total must be subtracted.
-
-        If :py:`version=2`, the values include:
-
-        - +1.0 for t="Bunkers" and t="Bunkers|International Aviation", labels with zeros
-          in the input data file.
-        - -1.0 for t="Transportation" and t="Transportation|Road Rail and Domestic
-          Shipping", labels with existing data from which the aviation total must be
-          subtracted.
-    """
-    if version == 1:  # pragma: no cover
-        value = [1, -1, 1]
-        t = [
-            "Transportation|Aviation",
-            "Transportation|Road Rail and Domestic Shipping",
-            "Transportation|Aviation|International",
-        ]
-        idx = slice(None) if include_international else slice(-1)
-    elif version in (2, 3):
-        value = [1, 1, -1, -1]
-        t = [
-            "Bunkers",
-            "Bunkers|International Aviation",
-            "Transportation",
-            "Transportation|Road Rail and Domestic Shipping",
-        ]
-        idx = slice(-1 if version == 3 else None)
-
-    return genno.Quantity(value[idx], coords={"t": t[idx]}).expand_dims(
-        {"s": ["Energy|Demand"]}
-    )
-
-
-def broadcast_est_emi_other(q_ref: "TQuantity") -> "TQuantity":
-    """Quantity to broadcast values for other :math:`(e, s, t)`.
-
-    - s = "Energy|Combustion" is included only for e in ("CH4", "CO2", "N2O"), because
-      these are the only species in the input data with existing values.
-    """
-    e, e_combustion = sorted(q_ref.coords["e"].data), ("CH4", "CO2", "N2O")
-    s = [
-        "_T",
-        "Energy",
-        "Energy and Industrial Processes",
-        "Energy|Combustion",
-        "Energy|Demand",
-        "Fossil Fuels and Industry",
+def broadcast_est_emi(q_ref: "TQuantity") -> "TQuantity":
+    """Quantity to re-add the :math:`(s, t)` dimensions for emission data."""
+    rows = [
+        # CO2 only
+        [-1.0, "Energy|Demand", "Transportation"],
+        # All species
+        [1.0, "Energy|Demand", "Bunkers"],
+        [1.0, "Energy|Demand", "Bunkers|International Aviation"],
+        # All except CO2
+        [1.0, "_T", "_T"],
+        [1.0, "Energy", "_T"],
+        [1.0, "Energy|Combustion", "_T"],
+        [1.0, "Energy|Demand", "_T"],
+        [1.0, "Fossil Fuels and Industry", "_T"],
     ]
-    dims = ["e", "s"]
-    df = (
-        pd.DataFrame([list(e_s) for e_s in product(e, s)], columns=dims)
-        .assign(value=1.0)
-        .query("not (s == @s[3] and e not in @e_combustion)")
-        .query("not (s == @s[2] and e != 'CO2')")
-        .set_index(dims)["value"]
-    )
-    del e_combustion
+    data: list[list[Any]] = []
+    for e in sorted(q_ref.coords["e"].data):
+        # Add only the relevant rows
+        idx = slice(3) if e == "CO2" else slice(1, 99)
+        data.extend([e] + row for row in rows[idx])
 
-    return type(q_ref)(df, units="").expand_dims({"t": ["_T"]})
+    return type(q_ref)(
+        pd.DataFrame(data, columns=["e", "value", "s", "t"]).set_index(["e", "s", "t"]),
+        units="",
+    )
 
 
 def broadcast_t_fe() -> "AnyQuantity":
@@ -415,9 +359,8 @@ def get_computer(
     log.info(f"method 'C' will use data from {url}")
 
     # Common structure and utility quantities used by method_[ABC]
-    c.add(K.bcast, broadcast_st_emi, version=3, include_international=method == "A")
+    c.add(K.bcast, broadcast_est_emi, K.units)
     c.add(K.units, e_UNIT, "e::codelist")
-    c.add(K.bcast_other, broadcast_est_emi_other, K.units)
 
     # Placeholder for data-loading task. This is filled in later by process_df() or
     # process_file().
@@ -654,14 +597,9 @@ def method_BC_common(
     # - Drop/partial sum over dimension "c".
     c.add(K.emi[2], "mul", k.emi0[1] / "c", K.units)
     # Re-add the (s, t) dimensions with +ve and -ve signs for certain labels
-    # - This also includes a -ve sign for the label "Transportation".
+    # - This also includes a -ve sign for (t="Transportation", e="CO2").
     c.add(K.emi[3], "mul", K.emi[2], K.bcast)
     to_concat = [K.emi[3]]
-
-    # Adjust total beyond transport for all modes
-    c.add(K.emi[4], "select", K.emi[3], indexers={"t": ["Transportation"]}, sums=True)
-    c.add(K.emi[5], "mul", K.emi[4] / ("s", "t"), K.bcast_other, -1.0)
-    to_concat.append(K.emi[5])
 
     if False:  # pragma:  no cover —previously used for METHOD.C if k_emi_share given
         # Adjust total transportation emissions: multiply k_fe_share by input data

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -14,10 +14,11 @@ from genno import Key, quote
 
 from message_ix_models import Context
 from message_ix_models.model.structure import get_codelist
-from message_ix_models.model.transport import CL_SCENARIO
+from message_ix_models.model.transport import CL_SCENARIO, build
+from message_ix_models.report import prepare_reporter
 from message_ix_models.tools.iamc import iamc_like_data_for_query, to_quantity
 from message_ix_models.util import minimum_version
-from message_ix_models.util.genno import Keys
+from message_ix_models.util.genno import Keys, update_computer
 
 if TYPE_CHECKING:
     import pathlib
@@ -390,6 +391,20 @@ def get_computer(
     # Change labels e.g. "AFR" → "R12_AFR"; see get_label()
     c.add(K.fe_in, "relabel", K.fe_in[1], labels=get_labels())
 
+    # NB the following might be equivalent, and it may be sufficient to use either one
+    #    all three METHOD.
+    if method in (METHOD.A, METHOD.B):
+        # Add the same structure information and exogenous data used in the build
+        # workflow stage for MESSAGEix-Transport, in particular:
+        # - e::codelist
+        # - groups::iea to transport
+        # - energy::n-y-product-flow:iea —using .tools.iea.web.IEA_EWEB
+        build.get_computer(context, c)
+    else:
+        # - Prepare a Reporter to retrieve model solution data from `target_url`.
+        # - Transfer all its tasks to `c`
+        update_computer(c, prepare_reporter(context)[0])
+
     # Call a function to prepare the remaining calculations up to K.emi
     method_func = {METHOD.A: method_A, METHOD.B: method_B, METHOD.C: method_C}[method]
     method_func(c)
@@ -499,17 +514,6 @@ def method_B(c: "Computer") -> None:
        labels are produced). This is the share of aviation in final energy.
     4. Add the steps from :func:`.method_BC_common`.
     """
-    from message_ix_models.model.transport import build
-
-    context: Context = c.graph["context"]
-
-    # Add the same structure information and exogenous data used in the build and report
-    # workflow steps for MESSAGEix-Transport, in particular:
-    # - e::codelist
-    # - groups::iea to transport
-    # - energy::n-y-product-flow:iea —using .tools.iea.web.IEA_EWEB
-    build.get_computer(context, c)
-
     # Shorthand for keys and sequences of keys
     fe = Keys(
         cnt=f"energy:c-n-t:{L}+0",
@@ -564,7 +568,6 @@ def method_BC_common(
     k_emi_share
         A key giving the share of aviation in total transport emissions.
     """
-
     from message_ix_models.model.transport.key import exo
 
     # Check dimensions of k_fe_share
@@ -662,15 +665,6 @@ def method_C(c: "Computer") -> None:  # pragma: no cover
        energy.
     3. Apply the steps from :func:`.method_BC_common`.
     """
-    from message_ix_models.report import prepare_reporter
-    from message_ix_models.util.genno import update_computer
-
-    context: Context = c.graph["context"]
-
-    # - Prepare a Reporter to retrieve model solution data from `target_url`.
-    # - Transfer all its tasks to `c`
-    update_computer(c, prepare_reporter(context)[0])
-
     # Prepare `c` to compute the final energy share for aviation
     k = Keys(
         # Added by .transport.base.prepare_reporter()

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -637,10 +637,7 @@ def method_BC_common(
     c.add(K.fe_out[2], "rename_dims", K.fe_out[1], name_dict={"c_new": "c"})
 
     # Restore labels: "R12_AFR" → "AFR" etc. "World" is not changed.
-    c.add(K.fe_out[3], "relabel", K.fe_out[2], labels=labels)
-
-    # Drop data for y0
-    c.add(K.fe_out, "select", K.fe_out[3], indexers=dict(y=[2020]), inverse=True)
+    c.add(K.fe_out, "relabel", K.fe_out[2], labels=labels)
 
 
 def method_C(c: "Computer") -> None:  # pragma: no cover

--- a/message_ix_models/project/ssp/transport.py
+++ b/message_ix_models/project/ssp/transport.py
@@ -170,7 +170,7 @@ def broadcast_st_emi(version: int, include_international: bool) -> "AnyQuantity"
             "Transportation",
             "Transportation|Road Rail and Domestic Shipping",
         ]
-        idx = slice(-2 if version == 3 else None)
+        idx = slice(-1 if version == 3 else None)
 
     return genno.Quantity(value[idx], coords={"t": t[idx]}).expand_dims(
         {"s": ["Energy|Demand"]}
@@ -654,10 +654,16 @@ def method_BC_common(
     # - Drop/partial sum over dimension "c".
     c.add(K.emi[2], "mul", k.emi0[1] / "c", K.units)
     # Re-add the (s, t) dimensions with +ve and -ve signs for certain labels
+    # - This also includes a -ve sign for the label "Transportation".
     c.add(K.emi[3], "mul", K.emi[2], K.bcast)
     to_concat = [K.emi[3]]
 
-    if k_emi_share:  # pragma: no cover  —only for METHOD.C
+    # Adjust total beyond transport for all modes
+    c.add(K.emi[4], "select", K.emi[3], indexers={"t": ["Transportation"]}, sums=True)
+    c.add(K.emi[5], "mul", K.emi[4] / ("s", "t"), K.bcast_other, -1.0)
+    to_concat.append(K.emi[5])
+
+    if False:  # pragma:  no cover —previously used for METHOD.C if k_emi_share given
         # Adjust total transportation emissions: multiply k_fe_share by input data
         # TODO Also try k_emi_share here
         c.add(K.emi_in["all"], "select", K.emi_in, indexers={"t": ["Transportation"]})
@@ -669,8 +675,6 @@ def method_BC_common(
         c.add(K.emi[6], "select", K.emi[5], indexers={"n": ["World"]})
         c.add(K.emi[7], "mul", K.emi[6], K.bcast_other)
         to_concat.append(K.emi[7])
-    else:
-        pass
 
     # Concatenate emissions values to be modified
     c.add(K.emi[8], "concat", *to_concat)

--- a/message_ix_models/tests/project/ssp/test_transport.py
+++ b/message_ix_models/tests/project/ssp/test_transport.py
@@ -89,10 +89,21 @@ def check(df_in: pd.DataFrame, df_out: pd.DataFrame, method: METHOD) -> None:
             .sort_values(dims)
         )
 
-    # df_out.to_csv("debug-out.csv")  # DEBUG Dump to file
-
     df_in = _to_long(df_in)
     df_out = _to_long(df_out)
+
+    # Diff data:
+    # - Outer merge.
+    # - Fill NaNs resulting from insert_nans()
+    # - Compute diff and select rows where diff is larger than a certain value
+    df = (
+        df_in.merge(df_out, how="outer", on=dims, suffixes=("_in", "_out"))
+        .fillna(0)
+        .query("abs(value_out - value_in) > 1e-16")
+    )
+
+    # df_out.to_csv("debug-out.csv", index=False)  # DEBUG Dump to file
+    # df.to_csv("debug-diff.csv", index=False)  # DEBUG Dump to file
 
     # Input data already contains the variable names to be modified
     assert expected_variables(IN_, method) <= set(df_in["Variable"].unique())
@@ -121,16 +132,6 @@ def check(df_in: pd.DataFrame, df_out: pd.DataFrame, method: METHOD) -> None:
 
     # Output has the same set of region codes as input
     assert region == set(df_out["Region"].unique())
-
-    # Diff data:
-    # - Outer merge.
-    # - Fill NaNs resulting from insert_nans()
-    # - Compute diff and select rows where diff is larger than a certain value
-    df = (
-        df_in.merge(df_out, how="outer", on=dims, suffixes=("_in", "_out"))
-        .fillna(0)
-        .query("abs(value_out - value_in) > 1e-16")
-    )
 
     # All regions and "World" have modified values
     N_reg = {METHOD.A: 13, METHOD.B: 9, METHOD.C: 13}[method]
@@ -363,6 +364,10 @@ def test_track_GAINS() -> None:
         (
             "Emissions|CH4|Energy|Demand|Transportation|Foo",
             {"e": "CH4", "s": "Energy|Demand", "t": "Transportation|Foo"},
+        ),
+        (
+            "Emissions|CO2|Energy|Demand|Transportation",
+            {"e": "CO2", "s": "Energy|Demand", "t": "Transportation"},
         ),
     ),
 )

--- a/message_ix_models/tests/project/ssp/test_transport.py
+++ b/message_ix_models/tests/project/ssp/test_transport.py
@@ -39,11 +39,12 @@ METHOD_PARAM = (
 V1 = "SSP_dev_SSP2_v0.1_Blv0.18_baseline_prep_lu_bkp_solved_materials_2025_macro.csv"
 V2 = "SSP_LED_v2.3.1_baseline.csv"
 V3 = "SSP_SSP2_v6.2_SSP2_-_Low_Emissions.csv"
+V4 = "SSP_SSP5_v6.5_SSP5_-_Medium-Low_Emissions_a.csv"
 
 
 @pytest.fixture(scope="module")
 def input_csv_path() -> "pathlib.Path":
-    return package_data_path("test", "report", V3)
+    return package_data_path("test", "report", V4)
 
 
 @pytest.fixture(scope="module")

--- a/message_ix_models/tests/project/ssp/test_transport.py
+++ b/message_ix_models/tests/project/ssp/test_transport.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Callable, Hashable
 from functools import cache
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -9,6 +10,7 @@ import pytest
 from genno import Computer
 from message_ix import Scenario
 
+from message_ix_models import Context
 from message_ix_models.model.transport.testing import MARK as MARK_TRANSPORT
 from message_ix_models.project.ssp.transport import (
     METHOD,
@@ -70,9 +72,6 @@ I_O = IN_ | OUT  # Both
 #: Emissions species codes appearing in the IAMC-structured / reported data; these are
 #: *different* from those internal to the model.
 SPECIES = {"CH4", "BC", "CO", "CO2", "N2O", "NH3", "NOx", "OC", "Sulfur", "VOC"}
-
-#: Species for which no aviation-specific emission factor values are available.
-SPECIES_WITHOUT_EF: set[str] = set()
 
 
 def check(df_in: pd.DataFrame, df_out: pd.DataFrame, method: METHOD) -> None:
@@ -157,27 +156,27 @@ def check(df_in: pd.DataFrame, df_out: pd.DataFrame, method: METHOD) -> None:
 def expected_variables(flag: int, method: METHOD) -> set[str]:
     """Set of expected ‘Variable’ codes according to `flag` and `method`."""
     # Shorthand
-    edb, edt = "Energy|Demand|Bunkers", "Energy|Demand|Transportation"
+    edb = "Energy|Demand|Bunkers"
 
     result = set()
 
     # Emissions
     for e in SPECIES:
-        # Expected data flows in which these variable codes appear
-        exp = IN_ if (e in SPECIES_WITHOUT_EF and method != METHOD.A) else I_O
-        if flag & exp:
-            result |= {
-                f"Emissions|{e}|{edb}",
-                f"Emissions|{e}|{edb}|International Aviation",
-            } | (
-                {
-                    f"Emissions|{e}|{edt}",
-                    # NB Present up to input data format V2; not in V3
-                    # f"Emissions|{e}|{edt}|Road Rail and Domestic Shipping",
+        result |= {
+            f"Emissions|{e}|{edb}",
+            f"Emissions|{e}|{edb}|International Aviation",
+        }
+        if e == "CO2":
+            result.add(f"Emissions|{e}|Energy|Demand|Transportation")
+        else:
+            result.add(f"Emissions|{e}|Energy|Demand")
+            if not (method == METHOD.A and e in {"CH4", "N2O", "NH3"}):
+                result |= {
+                    f"Emissions|{e}",
+                    f"Emissions|{e}|Energy",
+                    f"Emissions|{e}|Energy|Combustion",
+                    f"Emissions|{e}|Fossil Fuels and Industry",
                 }
-                if method == METHOD.C
-                else set()
-            )
 
     # Final Energy
     if method != METHOD.A:
@@ -209,8 +208,11 @@ def insert_nans(
     )
 
 
+@MARK_TRANSPORT[10]
 @get_computer.minimum_version
-def test_cli(tmp_path, mix_models_cli, test_context, input_xlsx_path) -> None:
+def test_cli(
+    tmp_path: Path, mix_models_cli, test_context: Context, input_xlsx_path: Path
+) -> None:
     """Code can be invoked from the command-line."""
     from shutil import copyfile
 


### PR DESCRIPTION
This PR implements changes to `.ssp.transport.process_df(…, method=METHOD.C)` requested today:

- [x] Reduce `Emissions|CO2|Energy|Demand|Transportation` by the amount computed for `Emissions|CO2|Energy|Demand|Bunkers|International Aviation`.
- [x] Ensure the reduction in `Emissions|…|Transportation` for region="World" is equal to added values for `Emissions|…|Bunkers|International Aviation`.
  - This meant disabling the previously-specified method where the share/portion of AIR transport in total transport final energy consumption of fossil fuels was used to reduce the global total.
- [x] Update variables such as the following, in particular the third which was not previously included:
  ```
  Emissions|BC
  Emissions|BC|Energy
  Emissions|BC|Energy and Industrial Processes
  Emissions|BC|Energy|Demand
  ```
- [x] In contrast for the first item, hold values for `Emissions|{e}|Energy|Demand|Transportation` fixed, where e ≠ "CO2".
- [x] Overwrite, rather than increment, any existing values for `Emissions|{e}|Energy|Demand|Bunkers|International Aviation`.
  - [x] Adjust ‘higher’ aggregates for the difference between those existing values and the replacements.
- [x] Also write/adjust final energy [or all] values for year=2020.
- [x] Update implied emission factors in `data/transport/emi-intensity.csv`.
- [x] Compute final energy values (thus derived emissions values) for n=World by sum across other regions, rather than by adjusting existing n=World values.

The commits are also reproduced on [`ssp-dev`](https://github.com/iiasa/message-ix-models/commits/ssp-dev/).

## How to review

- Read the diff.
- Note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update doc/whatsnew.