### PR TITLE
Adjust for iam-units 2026.3.10

### DIFF
--- a/message_ix_models/tests/model/transport/test_ikarus.py
+++ b/message_ix_models/tests/model/transport/test_ikarus.py
@@ -37,9 +37,13 @@ class C1(Check):
             .query("technology == 'rail_pub' and year_vtg == 2020")
             .iloc[0, :]
         )
-        return np.allclose(
-            23.689086, row["value"]
-        ), "inv_cost(t=rail_pub, yv=2020) has expected value"
+        exp = 26.158703
+        result = np.allclose(exp, row["value"])
+        return result, (
+            f"inv_cost(t=rail_pub, yv=2020) has value {row['value']} "
+            + ("=" if result else "!")
+            + f"= {exp} expected"
+        )
 
 
 class C2(Check):

--- a/message_ix_models/tools/bilateralize/workflow.py
+++ b/message_ix_models/tools/bilateralize/workflow.py
@@ -19,17 +19,18 @@ from message_ix_models.tools.bilateralize.prepare_edit import prepare_edit_files
 project_name = None  # Name of the project (e.g., 'newpathways')
 config_name = None  # Name of the config file (e.g., 'config.yaml')
 
-# Prepare edit files for bilateralization
-prepare_edit_files(project_name=project_name, config_name=config_name)
+if __name__ == "__main__":
+    # Prepare edit files for bilateralization
+    prepare_edit_files(project_name=project_name, config_name=config_name)
 
-# Move data from bare files to a dictionary to update a MESSAGEix scenario
-trade_dict = bare_to_scenario(project_name=project_name, config_name=config_name)
+    # Move data from bare files to a dictionary to update a MESSAGEix scenario
+    trade_dict = bare_to_scenario(project_name=project_name, config_name=config_name)
 
-# Update MESSAGEix scenario(s) with bilateralized dictionary and solve scenario
-load_and_solve(
-    project_name=project_name,
-    config_name=config_name,
-    scenario=None,  # Specifies MESSAGEix scenario, or will use project yaml
-    trade_dict=trade_dict,
-    solve=True,
-)
+    # Update MESSAGEix scenario(s) with bilateralized dictionary and solve scenario
+    load_and_solve(
+        project_name=project_name,
+        config_name=config_name,
+        scenario=None,  # Specifies MESSAGEix scenario, or will use project yaml
+        trade_dict=trade_dict,
+        solve=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ Repository = "https://github.com/iiasa/message-ix-models"
 "Issue tracker" = "https://github.com/iiasa/message-ix-models/issues"
 
 [project.optional-dependencies]
-bilateralize = ["scgraph"]
+# https://github.com/iiasa/message-ix-models/issues/490
+bilateralize = [
+  "scgraph < 3",
+]
 buildings = ["jaydebeapi"]
 docs = [
   # sphinx.ext.autosummary covers the test suite, so all test requirements


### PR DESCRIPTION
IAMconsortium/units#60 was released with [v2026.3.10](https://github.com/IAMconsortium/units/releases/tag/v2026.3.10). This changed the deflators for EUR.

As a result, one exact expected value changed, leading to test failures in nightly CI jobs, e.g. [here](https://github.com/iiasa/message-ix-models/actions/runs/22938174337/job/66575253878#step:13:3518).
```
ERROR    message_ix_models.testing.check:check.py:97 inv_cost(t=rail_pub, yv=2020) has expected value

FAILED message_ix_models/tests/model/transport/test_ikarus.py::test_get_ikarus_data[options0-R11-11-A] - AssertionError: 1 or more checks failed
assert <message_ix_models.testing.check.CheckResult object at 0x7f1b9be69150>
FAILED message_ix_models/tests/model/transport/test_ikarus.py::test_get_ikarus_data[options0-R11-11-B] - AssertionError: 1 or more checks failed
assert <message_ix_models.testing.check.CheckResult object at 0x7f1b9b36d750>
FAILED message_ix_models/tests/model/transport/test_ikarus.py::test_get_ikarus_data[options0-R12-12-A] - AssertionError: 1 or more checks failed
assert <message_ix_models.testing.check.CheckResult object at 0x7f1b9afe7750>
…
```

The PR adjusts the expected value.

Also:
- Work around #490.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, test suite changes only
- ~Update doc/whatsnew.~
