### PR TITLE
Partially migrate policy scenario workflow

### DIFF
--- a/message_ix_models/project/engage/workflow.py
+++ b/message_ix_models/project/engage/workflow.py
@@ -49,10 +49,10 @@ class PolicyConfig(model_workflow.Config):
     #: Which steps of the ENGAGE workflow to run. Empty list = don't run any steps.
     steps: list[int] = field(default_factory=lambda: [1, 2, 3])
 
-    #: In :func:`step_1`, actual quantity of the carbon budget to be imposed , or the
+    #: In :func:`step_1`, actual quantity of the carbon budget to be imposed, or the
     #: value "calc", in which case the value is calculated from :attr:`label` by
     #: :meth:`.ScenarioRunner.calc_budget`.
-    budget: int | Literal["calc"] = "calc"
+    budget: float | Literal["calc"] = "calc"
 
     #: In :func:`step_3`, optional information on a second scenario from which to copy
     #: ``tax_emission`` data.
@@ -139,7 +139,7 @@ def calc_budget(
         Literal "calc" to calculate a constraint budget based on `bdgt`; otherwise,
         budget constraint value expressed as average Mt C-eq / a.
     """
-    from message_data.tools.utilities import add_budget
+    from message_ix_models.tools.add_budget import main as add_budget
 
     if method == "calc":
         info = ScenarioInfo(scenario)
@@ -302,6 +302,8 @@ def retr_CO2_price(scen: Scenario):
 
 def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenario:
     """Step 3 of the ENGAGE climate policy workflow."""
+    from message_ix_models.tools import remove_emission_bounds
+    
     if config.tax_emission_scenario:
         # Retrieve CO2 prices from a different scenario
         source = Scenario(scenario.platform, **config.tax_emission_scenario)
@@ -309,10 +311,40 @@ def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenar
         # Retrieve CO2 prices from `scenario` itself
         source = scenario
 
-    # Retrieve a data frame with CO₂ prices, and apply specific ``type_emission``
-    df = retr_CO2_price(source).pipe(
-        broadcast, type_emission=config.step_3_type_emission
+    # Retrieve a data frame with CO₂ prices
+    price_df = retr_CO2_price(source)
+    
+    # Debug: check what retr_CO2_price returns
+    log.info(f"price_df columns after retr_CO2_price: {list(price_df.columns)}")
+    log.info(f"price_df shape: {price_df.shape}")
+    log.info(f"price_df head:\n{price_df.head()}")
+    
+    # Use type_emission list from config as-is
+    type_emission_list = list(config.step_3_type_emission)
+    
+    # Ensure type_tec column is present in price_df before broadcasting
+    if "type_tec" not in price_df.columns:
+        price_df["type_tec"] = "all"
+    
+    # Apply tax_emission to each type_emission separately and concatenate
+    import pandas as pd
+    df_list = []
+    for type_emi in type_emission_list:
+        df_emi = price_df.pipe(broadcast, type_emission=[type_emi])
+        df_list.append(df_emi)
+    
+    df = pd.concat(df_list, ignore_index=True)
+    
+    # Debug: print dataframe info
+    log.info(
+        f"Retrieved CO₂ prices: {len(df)} data points for type_emission={type_emission_list}"
     )
+    log.info(f"DataFrame columns: {list(df.columns)}")
+    log.info(f"DataFrame shape: {df.shape}")
+    log.info(f"DataFrame head:\n{df.head(10)}")
+    log.info(f"DataFrame dtypes:\n{df.dtypes}")
+    log.info(f"Unique type_emission values: {df['type_emission'].unique() if 'type_emission' in df.columns else 'MISSING'}")
+    log.info(f"Unique type_tec values: {df['type_tec'].unique() if 'type_tec' in df.columns else 'MISSING'}")
 
     del source  # No longer used → free memory
 
@@ -321,14 +353,35 @@ def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenar
     except ValueError:
         pass  # Solution did not exist
 
-    with scenario.transact(message=f"Add price for {config.step_3_type_emission}"):
-        scenario.add_par("tax_emission", df)
-
+    # Remove all emission bounds first
+    # Otherwise remove_emission_bounds will remove the tax_emission we just added
+    with scenario.transact(message="Remove all emission bounds"):
+        log.info("Removing all emission bounds")
+        remove_emission_bounds.main(scenario, remove_all=True)
+        
         # As in step_2, remove the lower bound on global CO2 emissions. This is
         # necessary if step_2 was not run (for instance, NAVIGATE T6.2 protocol)
         name = "relation_lower"
         filters = dict(relation=[context.model.relation_global_co2])
         scenario.remove_par(name, scenario.par(name, filters=filters))
+
+    # Now add tax_emission AFTER removing bounds
+    with scenario.transact(message=f"Add price for {type_emission_list}"):
+        log.info(
+            f"Adding tax_emission prices to {scenario.model}/{scenario.scenario} "
+            f"(type_emission={type_emission_list})"
+        )
+        log.info(f"About to add {len(df)} rows to tax_emission")
+        try:
+            scenario.add_par("tax_emission", df)
+            # Verify it was added
+            added_df = scenario.par("tax_emission")
+            log.info(f"Successfully added tax_emission. Scenario now has {len(added_df)} rows")
+            log.info(f"Added tax_emission head:\n{added_df.head(10)}")
+        except Exception as e:
+            log.error(f"Error adding tax_emission: {e}")
+            log.error(f"DataFrame that failed:\n{df.head(20)}")
+            raise
 
     return scenario
 

--- a/message_ix_models/project/engage/workflow.py
+++ b/message_ix_models/project/engage/workflow.py
@@ -19,6 +19,7 @@ from message_ix_models import Context, ScenarioInfo
 from message_ix_models.model import workflow as model_workflow
 from message_ix_models.util import HAS_MESSAGE_DATA, broadcast, identify_nodes
 from message_ix_models.workflow import Workflow
+from message_ix_models.tools import remove_emission_bounds, add_emission_trajectory
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -283,8 +284,8 @@ def step_2(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenar
 
     return scenario
 
-
-def retr_CO2_price(scen: Scenario):
+# TODO: each of them should have args such as type_emission and region
+def retr_CO2_price(scen: Scenario, regional_price=False):
     """Retrieve ``PRICE_EMISSION`` data and transform for use as ``tax_emission``.
 
     This is identical to :meth:`ScenarioRunner.retr_CO2_price`, except without the
@@ -292,13 +293,48 @@ def retr_CO2_price(scen: Scenario):
     :meth:`~.DataFrame.assign` or, to create data for multiple ``type_emission``, use
     :func:`message_ix_models.util.broadcast`.
     """
-    return (
-        scen.var("PRICE_EMISSION")
-        .assign(unit="USD/tC", type_emission=None)
+    df = scen.var("PRICE_EMISSION")
+    if regional_price:
+        df = df.loc[
+            (df["node"] != "World") & (~df["node"].str.contains("GLB"))
+        ]
+    df = (
+        df.assign(unit="USD/tC", type_emission=None)
         .rename(columns={"lvl": "value", "year": "type_year"})
         .drop("mrg", axis=1)
     )
+    return df
 
+def retr_CO2_trajectory(scen: Scenario, regional_emission_bound=True, emission="TCE_CO2"):
+    """Retrieves global CO2 emission trajectory.
+
+    Retrieves variable `EMISS` for `emission`: `TCE_CO2` or other types of emissions for
+    all regions.
+
+    Parameters
+    ----------
+    scen : :class:`message_ix.Scenario`
+        Scenario for which emission trajectory should be retrieved.
+    """
+    glb_nodes = ["World"] + [n for n in scen.set("node") if "GLB" in n]
+    if regional_emission_bound is True:
+        df = scen.var(
+            "EMISS",
+            filters={"emission": [emission], "type_tec": ["all"]},
+        )
+        df = df.loc[~df.node.isin(glb_nodes)]
+    else:
+        df = scen.var(
+            "EMISS",
+            filters={
+                "emission": [emission],
+                "type_tec": ["all"],
+                "node": glb_nodes,
+            },
+        )
+    df = df.pivot(index="node", values="lvl", columns="year")
+
+    return df
 
 def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenario:
     """Step 3 of the ENGAGE climate policy workflow."""
@@ -312,7 +348,7 @@ def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenar
         source = scenario
 
     # Retrieve a data frame with CO₂ prices
-    price_df = retr_CO2_price(source)
+    price_df = retr_CO2_price(source, regional_price=True)
     
     # Debug: check what retr_CO2_price returns
     log.info(f"price_df columns after retr_CO2_price: {list(price_df.columns)}")
@@ -355,15 +391,15 @@ def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenar
 
     # Remove all emission bounds first
     # Otherwise remove_emission_bounds will remove the tax_emission we just added
-    with scenario.transact(message="Remove all emission bounds"):
-        log.info("Removing all emission bounds")
-        remove_emission_bounds.main(scenario, remove_all=True)
+    # with scenario.transact(message="Remove all emission bounds"):
+    #     log.info("Removing all emission bounds")
+    #     remove_emission_bounds.main(scenario, remove_all=True)
         
-        # As in step_2, remove the lower bound on global CO2 emissions. This is
-        # necessary if step_2 was not run (for instance, NAVIGATE T6.2 protocol)
-        name = "relation_lower"
-        filters = dict(relation=[context.model.relation_global_co2])
-        scenario.remove_par(name, scenario.par(name, filters=filters))
+    #     # As in step_2, remove the lower bound on global CO2 emissions. This is
+    #     # necessary if step_2 was not run (for instance, NAVIGATE T6.2 protocol)
+    #     name = "relation_lower"
+    #     filters = dict(relation=[context.model.relation_global_co2])
+    #     scenario.remove_par(name, scenario.par(name, filters=filters))
 
     # Now add tax_emission AFTER removing bounds
     with scenario.transact(message=f"Add price for {type_emission_list}"):
@@ -385,6 +421,29 @@ def step_3(context: Context, scenario: Scenario, config: PolicyConfig) -> Scenar
 
     return scenario
 
+
+def step_4(context: Context, scenario: Scenario) -> Scenario:
+    """Step 4 of the ENGAGE climate policy workflow. 
+    Optional, locks in regional TCE emission path to deliver regional carbon prices.
+    
+    TODO: can introduce certificate trade in this step, also fix demand
+    """
+
+    df = retr_CO2_trajectory(scenario, regional_emission_bound=True, emission="TCE")
+    try:
+        scenario.remove_solution()
+    except ValueError:  
+        pass  
+
+    remove_emission_bounds.main(scenario, remove_all=True)
+    add_emission_trajectory.main(
+        scenario,
+        data=df,
+        type_emission="TCE",
+        remove_bounds_emission=False, # by default it only removes cumulative bounds
+    )
+
+    return scenario
 
 def add_steps(
     workflow: Workflow, base: str, config: PolicyConfig, name: str | None = None

--- a/message_ix_models/tools/add_emission_trajectory.py
+++ b/message_ix_models/tools/add_emission_trajectory.py
@@ -38,7 +38,7 @@ def main(
     """
 
     if remove_bounds_emission:
-        remove_emission_bounds(scen)
+        remove_emission_bounds(scen, remove_cumulative_only=True)
 
     with scen.transact("added emission trajectory"):
         for r in data.index.get_level_values(0).unique().tolist():

--- a/message_ix_models/tools/policy.py
+++ b/message_ix_models/tools/policy.py
@@ -1,13 +1,28 @@
 """Policies."""
 
+from __future__ import annotations
+
+import logging
 from abc import ABC
 from collections.abc import Collection
 from typing import TYPE_CHECKING, cast
 
+import message_ix
+import pandas as pd
+import yaml
+from message_ix import make_df
+
+from message_ix_models import ScenarioInfo
+
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import TypeVar
 
+    from message_ix_models.util.context import Context
+
     T = TypeVar("T", bound="Policy")
+
+log = logging.getLogger(__name__)
 
 
 class Policy(ABC):
@@ -39,3 +54,328 @@ def single_policy_of_type(collection: Collection[Policy], cls: type["T"]) -> "T 
         return cast("T", matches[0])
 
     return None
+
+
+def solve(
+    context: Context, scenario: message_ix.Scenario, model="MESSAGE"
+) -> message_ix.Scenario:
+    """Plain solve."""
+    solve_options = {
+        "advind": 0,
+        "lpmethod": 4,
+        "threads": 4,
+        "epopt": 1e-6,
+        "scaind": -1,
+        # "predual": 1,
+        "barcrossalg": 0,
+    }
+
+    scenario.solve(model, solve_options=solve_options)
+    scenario.set_as_default()
+
+    return scenario
+
+
+def make_scenario_runner(
+    context,
+):
+    """Create and initialize a ScenarioRunner for policy scenario generation."""
+    from message_data.model.scenario_runner import ScenarioRunner
+
+    from message_ix_models.util import private_data_path
+
+    biomass_trade = getattr(context, "biomass_trade", False)
+
+    config_path = (
+        private_data_path(*context.policy_config_path)
+        if isinstance(context.policy_config_path, tuple)
+        else private_data_path(context.policy_config_path)
+    )
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    model_name = context.dest_scenario["model"]
+    model_config = config[model_name]
+    # print(f"DEBUG model_config[{model_name!r}] = {model_config}")
+
+    slack_data = model_config["policy_slacks"][model_config["slack_scn"]][context.ssp]
+
+    sr = ScenarioRunner(
+        context,
+        slack_data=slack_data,
+        biomass_trade=biomass_trade,
+    )
+
+    # Pre-populate baseline scenario(s) if they do not exist.
+    # Use baseline_DEFAULT to match the workflow target
+    # (e.g., base cloned -> baseline_DEFAULT).
+    # policy_baseline is used by the runner's internal logic; baseline_DEFAULT is the
+    # prerequisite name passed to sr.add(..., start_scen="baseline_DEFAULT")
+    # by add_glasgow, etc.
+    if "policy_baseline" not in sr.scen:
+        base_scenario = message_ix.Scenario(
+            mp=sr.mp,
+            model=sr.model_name,
+            scenario="baseline_DEFAULT",
+            cache=False,
+        )
+        sr.scen["policy_baseline"] = base_scenario
+        sr.scen["baseline_DEFAULT"] = base_scenario
+
+    return sr
+
+
+def add_NPi2030(context: Context, scenario: message_ix.Scenario) -> message_ix.Scenario:
+    """Add NPi2030 to the scenario."""
+
+    sr = make_scenario_runner(context)
+    sr.add(
+        "NPi2030",
+        "baseline_DEFAULT",
+        # must start with this scenario name (hard-coded in the general scenario runner)
+        mk_INDC=True,
+        slice_year=2025,
+        policy_year=2030,
+        target_kind="Target",
+        run_reporting=False,
+        solve_typ="MESSAGE-MACRO",
+    )
+
+    # sr.add(
+    #     "npi_low_dem_scen",
+    #     "NPi2030",
+    #     slice_year=2025,
+    #     tax_emission=150,
+    #     run_reporting = False,
+    #     solve_typ="MESSAGE-MACRO",
+    # )
+
+    sr.run_all()
+
+    # return sr.scen["npi_low_dem_scen"]
+    return sr.scen["NPi2030"]
+
+
+def add_NDC2030(context, scenario):
+    """Add NDC policies to the scenario."""
+    sr = make_scenario_runner(context)
+
+    sr.add(
+        "INDC2030i_weak",
+        "baseline_DEFAULT",
+        mk_INDC=True,
+        slice_year=2025,
+        policy_year=2030,
+        target_kind="Target",
+        copy_demands="baseline_low_dem_scen",
+        # or other low demand scenario
+        # e.g., "npi_low_dem_scen"
+        run_reporting=False,
+        solve_typ="MESSAGE-MACRO",
+    )
+
+    sr.run_all()
+
+    return sr.scen["INDC2030i_weak"]
+
+
+def add_glasgow(context, scenario, level, start_scen, target_scen, slice_yr):
+    """Add Glasgow policies to the scenario.
+
+    Examples
+    --------
+    In a :class:`~message_ix_models.workflow.Workflow`, use this function as the step
+    action and pass the same keyword arguments that
+    :meth:`~message_ix_models.workflow.Workflow.add_step` forwards to the
+    callable::
+
+        wf.add_step(
+            "glasgow_partial_2030 solved",
+            "base reported",
+            add_glasgow,
+            target=f"{model_name}/glasgow_partial_2030",
+            target_scen="glasgow_partial_2030",
+            slice_yr=2025,
+            start_scen="baseline_DEFAULT",
+            level="Partial",
+        )
+
+        wf.add_step(
+            "glasgow_full_2030 solved",
+            "base reported",
+            add_glasgow,
+            target=f"{model_name}/glasgow_full_2030",
+            start_scen="baseline_DEFAULT",
+            target_scen="glasgow_full_2030",
+            slice_yr=2025,
+            level="Full",
+        )
+    """
+    sr = make_scenario_runner(context)
+
+    # Prepare add() arguments
+    add_kwargs = {
+        "mk_INDC": True,
+        "slice_year": slice_yr,
+        "run_reporting": False,
+        "solve_typ": "MESSAGE-MACRO",
+    }
+    if level.lower() == "full":
+        add_kwargs["copy_demands"] = "baseline_low_dem_scen"
+        # or other low demand scenario
+        # e.g., "npi_low_dem_scen"
+
+    sr.add(target_scen, start_scen, **add_kwargs)
+
+    sr.run_all()
+
+    # Return the target scenario that was created
+    return sr.scen[target_scen]
+
+
+def add_forever_constant(
+    context: Context,
+    scenario: message_ix.Scenario,
+    specified_price: Mapping[str, float] | None = None,
+    solve_type: str = "MESSAGE-MACRO",
+) -> message_ix.Scenario:
+    """Apply constant carbon prices from first model year to 2110.
+
+    - If `specified_price` is given, use those node-level constant values.
+    - Otherwise, use model-derived values from ``PRICE_EMISSION`` at
+      ``scenario.firstmodelyear`` and extend them as constants through 2110.
+
+    Example
+    -------
+    `specified_price` can be::
+
+        {
+            "R12_AFR": 7.33,
+            "R12_CHN": 7.33,
+            "R12_EEU": 91.667,...
+        }
+    or copied from a lookup run.
+    """
+    fmy = int(scenario.firstmodelyear)
+
+    info = ScenarioInfo(scenario)
+    model_years = [y for y in info.Y if fmy <= y <= 2110]
+
+    if specified_price:
+        base_prices = pd.DataFrame(
+            {"node": list(specified_price), "lvl": list(specified_price.values())}
+        )
+    else:
+        base_prices = scenario.var("PRICE_EMISSION").loc[
+            lambda df: df.year == fmy, ["node", "lvl"]
+        ]
+        missing = (set(info.N) - {"World", "R12_GLB"}) - set(base_prices.node)
+        if missing:
+            base_prices = pd.concat(
+                [base_prices, pd.DataFrame({"node": list(missing), "lvl": 0})],
+                ignore_index=True,
+            )
+
+    price_long = pd.concat(
+        [base_prices.assign(year=year) for year in model_years], ignore_index=True
+    )
+    df = make_df(
+        "tax_emission",
+        node=price_long["node"],
+        type_emission="TCE",
+        type_tec="all",
+        type_year=price_long["year"],
+        unit="USD/tC",
+        value=price_long["lvl"],
+    )
+
+    with scenario.transact("applying constant cprice"):
+        bound_df = scenario.par("bound_emission")
+        if not bound_df.empty:
+            scenario.remove_par("bound_emission", bound_df)
+        scenario.add_par("tax_emission", df)
+
+    if specified_price:
+        detail = ", ".join(
+            f"{node}={price}" for node, price in sorted(specified_price.items())
+        )
+        log.info(
+            f"Added specified constant carbon prices ({fmy}-2110) to "
+            f"{scenario.model}/{scenario.scenario}: {detail}"
+        )
+    else:
+        log.info(
+            f"Added constant carbon prices ({fmy}-2110) to "
+            f"{scenario.model}/{scenario.scenario}"
+        )
+    solve(context, scenario, model=solve_type)
+    scenario.set_as_default()
+    return scenario
+
+
+def add_forever_interpolate(
+    context: Context,
+    scenario: message_ix.Scenario,
+    price_2100: float = 200,
+    solve_type: str = "MESSAGE-MACRO",
+) -> message_ix.Scenario:
+    """Apply interpolated carbon prices from first model year to 2110.
+
+    - Base values are taken from ``PRICE_EMISSION`` at ``scenario.firstmodelyear``.
+    - Values are interpolated to reach `price_2100` in years 2100 and 2110.
+    """
+    fmy = int(scenario.firstmodelyear)
+    info = ScenarioInfo(scenario)
+    regions = set(info.N) - {"World", "R12_GLB"}
+    years = [y for y in info.Y if fmy <= y <= 2110]
+
+    base = scenario.var("PRICE_EMISSION").loc[
+        lambda df: df.year == fmy, ["node", "lvl"]
+    ]
+    missing = regions - set(base.node)
+    if missing:
+        base = pd.concat(
+            [base, pd.DataFrame({"node": list(missing), "lvl": 0})], ignore_index=True
+        )
+    base = base.assign(year=fmy)
+
+    long = (
+        pd.concat(
+            [
+                base,
+                pd.DataFrame({"node": list(regions), "lvl": price_2100, "year": 2100}),
+                pd.DataFrame({"node": list(regions), "lvl": price_2100, "year": 2110}),
+            ],
+            ignore_index=True,
+        )
+        .pivot_table(values="lvl", index="year", columns="node")
+        .reindex(sorted(set(years) | {fmy, 2100, 2110}))
+        .sort_index()
+        .interpolate(method="index")
+        .loc[years]
+        .reset_index()
+        .melt(id_vars="year", var_name="node", value_name="lvl")
+    )
+    df = make_df(
+        "tax_emission",
+        node=long["node"],
+        type_emission="TCE",
+        type_tec="all",
+        type_year=long["year"],
+        unit="USD/tC",
+        value=long["lvl"],
+    )
+
+    with scenario.transact("applying interpolated cprice"):
+        bound_df = scenario.par("bound_emission")
+        if not bound_df.empty:
+            scenario.remove_par("bound_emission", bound_df)
+        scenario.add_par("tax_emission", df)
+
+    log.info(
+        f"Added interpolated carbon prices ({fmy}-2110, {price_2100} at 2100/2110) to "
+        f"{scenario.model}/{scenario.scenario}"
+    )
+    solve(context, scenario, model=solve_type)
+    scenario.set_as_default()
+    return scenario

--- a/message_ix_models/tools/remove_emission_bounds.py
+++ b/message_ix_models/tools/remove_emission_bounds.py
@@ -12,23 +12,18 @@ if TYPE_CHECKING:
     from message_ix import Scenario
 
 
-def main(
-    scen: "Scenario",
-    remove_all: bool = False,
-    *,
-    parameters: Collection[str] = ("bound_emission", "tax_emission"),
-) -> None:
-    """Remove ``bound_emission`` and ``tax_emission`` data from `scen`.
+def main(scen: "Scenario", remove_all: bool = False, remove_cumulative_only: bool = False) -> None:
+    """Remove all ``tax_emission`` and ``bound_emission`` from a given scenario.
 
     Parameters
     ----------
     scen :
         Scenario for which the parameters should be removed.
-    remove_all :
-        If :any:`True`, remove all data in the parameters. If :any:`False` (default), do
-        not remove data where ``type_year`` is equal to or less than |y0|.
-    parameters :
-        Parameters from which to remove data.
+    remove_all : bool, optional
+        If True, remove all bounds. If False, only remove bounds with type_year > y0.
+    remove_cumulative_only : bool, optional
+        If True, only remove cumulative bounds (type_year == "cumulative").
+        If False, also remove yearly bounds according to remove_all parameter.
     """
 
     info = ScenarioInfo(scen)
@@ -43,7 +38,12 @@ def main(
             df_cum = df[df.type_year == "cumulative"]
             if not df_cum.empty:
                 scen.remove_par(par, df_cum)
-                df = df[df.type_year != "cumulative"]
+            
+            # If only removing cumulative, skip yearly bounds removal
+            if remove_cumulative_only:
+                continue
+                
+            df = df[df.type_year != "cumulative"]
 
             # Remove yearly bounds
             if not remove_all:

--- a/message_ix_models/tools/remove_emission_bounds.py
+++ b/message_ix_models/tools/remove_emission_bounds.py
@@ -12,13 +12,20 @@ if TYPE_CHECKING:
     from message_ix import Scenario
 
 
-def main(scen: "Scenario", remove_all: bool = False, remove_cumulative_only: bool = False) -> None:
+def main(
+    scen: "Scenario",
+    parameters: Collection[str] = ("bound_emission", "tax_emission"),
+    remove_all: bool = False,
+    remove_cumulative_only: bool = False,
+) -> None:
     """Remove all ``tax_emission`` and ``bound_emission`` from a given scenario.
 
     Parameters
     ----------
     scen :
         Scenario for which the parameters should be removed.
+    parameters : Collection[str], optional
+        Scenario parameters to modify.
     remove_all : bool, optional
         If True, remove all bounds. If False, only remove bounds with type_year > y0.
     remove_cumulative_only : bool, optional
@@ -38,11 +45,11 @@ def main(scen: "Scenario", remove_all: bool = False, remove_cumulative_only: boo
             df_cum = df[df.type_year == "cumulative"]
             if not df_cum.empty:
                 scen.remove_par(par, df_cum)
-            
+
             # If only removing cumulative, skip yearly bounds removal
             if remove_cumulative_only:
                 continue
-                
+
             df = df[df.type_year != "cumulative"]
 
             # Remove yearly bounds

--- a/message_ix_models/workflow.py
+++ b/message_ix_models/workflow.py
@@ -108,6 +108,7 @@ class WorkflowStep:
                 else dict(keep_solution=False)
             )
             s = s.clone(**clone_kw)
+            s.set_as_default()
 
         if not self.action:
             return s


### PR DESCRIPTION
This is a draft PR to make the review of changes in policy scenario workflows easier. 
It is a prerequisite for the BMT development (issue #483 ) and has been split out accordingly.

- budgets/emission targets (**EN steps with multiple options**)
- Calling ScenarioRunner on private branch (`NPi*`, `NDC*`, `LTS`(glasgow)) and options to add `*_forever`
- config to be stored on public branch

![image](https://github.com/user-attachments/assets/2fa9ccf0-616f-45ac-83bb-565f3a0ff88f)

## How to review

- Read the diff and note that the CI checks all pass.
- Make sure changes in the ENGAGE workflow and function in tools do not affect previous projects that call them
- The documentation makes sense.

## PR checklist

- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.
