### PR TITLE
Add entries for the energy demand dynamically provided by message-ix-buildings in BMT workflows

### DIFF
--- a/doc/buildings/index.rst
+++ b/doc/buildings/index.rst
@@ -5,17 +5,19 @@ MESSAGEix-Buildings
 
 MESSAGEix-Buildings refers to a set of models including a specific configuration of MESSAGEix-GLOBIOM.
 
-Code is maintained in the `iiasa/MESSAGE_Buildings <https://github.com/iiasa/MESSAGE_Buildings>`_ repository.
+Code is maintained in the `iiasa/message-ix-buildings <https://github.com/iiasa/message-ix-buildings>`_ repository.
+Since 2023, development and installation use this public repository.
+The older `iiasa/MESSAGE_Buildings <https://github.com/iiasa/MESSAGE_Buildings>`_ repository was the predecessor; the models and workflows below still refer to it where setups for previous projects apply.
 
 Function
 ========
 
-This section briefly describes how the contents of the MESSAGE_Buildings repo and :mod:`message_data` interact, as a guide to reading the code.
+This section briefly describes how the contents of the buildings model repositories and :mod:`message_data` interact, as a guide to reading the code.
 
 ACCESS and STURM
 ----------------
 
-The MESSAGE_Buildings contains two models (collectively the **“buildings models”**):
+The buildings models (historically in MESSAGE_Buildings; now in `message-ix-buildings <https://github.com/iiasa/message-ix-buildings>`_) are:
 
 - **ACCESS**: includes cooking end-use in the residential sector.
 - **STURM**: includes some residential and other end-uses, as well as the construction and demolition of buildings.
@@ -45,7 +47,7 @@ These are handled by :func:`.buildings.build_and_solve`.
 
    These steps are handled by :func:`.buildings.pre_solve`.
 
-   When the buildings module is run as part of the :doc:`/bmt/index` workflow,
+   When the buildings module is run as part of the :doc:`BMT workflow </api/model-bmt>`,
    it calls :func:`.buildings.build.build_B`,
    which loads inputs (prices, STURM outputs, static demand) specified in :attr:`context.buildings`
    or from :file:`data/bmt/config.yaml`,
@@ -106,8 +108,9 @@ Reporting for MESSAGEix-Buildings involves the following pieces:
 Usage
 =====
 
-1. Clone the main MESSAGE_Buildings repo, linked above.
+1. Install or clone the `message-ix-buildings <https://github.com/iiasa/message-ix-buildings>`_ repository (since 2023).
 
+   For legacy setups, clone the `MESSAGE_Buildings <https://github.com/iiasa/MESSAGE_Buildings>`_ repository instead.
    Either use a directory named :file:`buildings` in the same directory containing :mod:`message_data`; or, note the path and set this in the :ref:`ixmp configuration file <ixmp:configuration>`::
 
      ixmp config set "message buildings dir" /path/to/cloned/message-buildings/repo
@@ -197,6 +200,15 @@ Values given in code or on the command line will override these.
 
 .. autoclass:: message_ix_models.model.buildings.Config
    :members:
+
+Demand-Price feedback
+=====================
+
+:func:`~.buildings.sturm.call_sturm` updates STURM price inputs in the installed ``message-ix-buildings`` package (or a legacy ``MESSAGE_Buildings`` clone) from a solved scenario's ``PRICE_COMMODITY`` results, then runs the STURM R scripts. STURM writes demand files under :file:`message_ix_buildings/sturm/temp/`.
+
+:func:`~.buildings.sturm.call_buildings_demand` reads that output and adds the filtered demand to the scenario.
+
+The two functions are used for scenarios with constraints on emissions in order to include the necessary feedback between energy commodity prices and residential and commercial energy demand. This is achieved by running ``MESSAGEix-Buildings`` with the updated energy commodity prices solved by the MESSAGEix model and feeding the updated residential and commercial energy demandback to MESSAGEix. At least one iteration is required. 
 
 Code reference
 ==============

--- a/message_ix_models/model/buildings/sturm.py
+++ b/message_ix_models/model/buildings/sturm.py
@@ -334,3 +334,33 @@ def call_sturm(context: Context, scenario: Scenario) -> Scenario:
         )
 
     return scenario
+
+
+def call_buildings_demand(context: Context, scenario: Scenario) -> Scenario:
+    """Retrieve buildings demand from message_buildings_dir and add to scenario."""
+    # Support both key spellings in local ixmp config.
+    buildings_root = _message_buildings_install_dir()
+
+    temp_dir = buildings_root.joinpath("message_ix_buildings", "sturm", "temp")
+    if not temp_dir.exists():
+        raise FileNotFoundError(f"Buildings demand directory not found: {temp_dir}")
+
+    demand = pd.concat(
+        [
+            pd.read_csv(temp_dir / name)
+            for name in ("resid_sturm.csv", "comm_sturm.csv")
+        ],
+        ignore_index=True,
+    )
+
+    exclude_expr = r"_mat_|_floor_|other_uses_|v_no_heat|_cook_|_apps_"
+    # TODO: do we need dynamic materials demand for CircEUlar too?
+    demand = demand[~demand["commodity"].str.contains(exclude_expr, na=False)].copy()
+    demand["level"] = "useful"
+    # TODO: "useful" to match build; consider unifying demand levels to "final"
+
+    with scenario.transact("Add Buildings demand from message_ix_buildings/sturm/temp"):
+        scenario.add_par("demand", demand)
+
+    log.info("Added %d Buildings demand rows from %s", len(demand), temp_dir)
+    return scenario

--- a/message_ix_models/model/buildings/sturm.py
+++ b/message_ix_models/model/buildings/sturm.py
@@ -5,8 +5,12 @@ import logging
 import re
 import subprocess
 from collections.abc import Mapping, MutableMapping
+from pathlib import Path
 
+import ixmp
+import numpy as np
 import pandas as pd
+from message_ix import Scenario
 
 from message_ix_models import Context
 
@@ -200,3 +204,133 @@ def scenario_name(name: str) -> str:
     return {
         "baseline": "SSP2",
     }.get(result, result)
+
+
+def _message_buildings_install_dir() -> Path:
+    """Return MESSAGEix-Buildings path from ixmp (``message_buildings_dir``)."""
+    message_buildings_dir = None
+    for key in ("message_buildings_dir", "message buildings dir"):
+        try:
+            value = ixmp.config.get(key)
+        except (AttributeError, KeyError):
+            continue
+        if value:
+            message_buildings_dir = value
+            break
+    if not message_buildings_dir:
+        raise ValueError(
+            "ixmp config key 'message_buildings_dir' (or 'message buildings dir') is "
+            "not set."
+        )
+    return Path(message_buildings_dir).expanduser().resolve()
+
+
+def call_sturm(context: Context, scenario: Scenario) -> Scenario:
+    """Merge scenario prices into STURM inputs, then run MESSAGEix-Buildings STURM."""
+    buildings_root = _message_buildings_install_dir()
+    sturm_dir = buildings_root.joinpath("message_ix_buildings", "sturm")
+    price_dir = sturm_dir.joinpath("data")
+
+    # Duplicate the original energy price input file in STURM
+    original_price_input_file = price_dir.joinpath("input_prices_R12.csv")
+
+    if not original_price_input_file.exists():
+        raise FileNotFoundError(
+            f"Original price input file not found: {original_price_input_file}"
+        )
+
+    original_price_input_backup = price_dir.joinpath("input_prices_R12_ori.csv")
+    df_prices_ori = pd.read_csv(original_price_input_file)
+    df_prices_ori.to_csv(original_price_input_backup, index=False)
+    log.info("Saved copy of original STURM prices to %s", original_price_input_backup)
+
+    # Retrieve new energy commodity prices from the scenario
+    df_prices = scenario.var(
+        "PRICE_COMMODITY",
+        filters={
+            "level": "final",
+            "commodity": [
+                "biomass",
+                "coal",
+                "lightoil",
+                "gas",
+                "electr",
+                "d_heat",
+            ],
+        },
+    )
+
+    # Map R12 regions to R11 regions
+    # R12_CHN -> R11_CHN
+    # R12_RCPA -> R11_CPA
+    # Other R12_* -> R11_* (replace R12_ with R11_)
+    def map_r12_to_r11(node):
+        """Map R12 region codes to R11 region codes"""
+        if node == "R12_CHN":
+            return "R11_CHN"
+        elif node == "R12_RCPA":
+            return "R11_CPA"
+        elif node.startswith("R12_"):
+            return node.replace("R12_", "R11_")
+        else:
+            return node  # Keep as is if not R12
+
+    # Apply the mapping
+    df_prices["node"] = df_prices["node"].apply(map_r12_to_r11)
+
+    # Identify key columns for merging
+    key_cols = ["node", "commodity", "level", "year", "time"]
+    # Filter to only columns that exist in both dataframes
+    key_cols = [
+        col
+        for col in key_cols
+        if col in df_prices_ori.columns and col in df_prices.columns
+    ]
+
+    # Merge the original dataframe with price data
+    df_updated = pd.merge(
+        df_prices_ori,
+        df_prices[key_cols + ["lvl"]],
+        on=key_cols,
+        how="left",
+        suffixes=("", "_new"),
+    )
+
+    rows_updated = (
+        df_updated["lvl_new"].notna().sum() if "lvl_new" in df_updated.columns else 0
+    )
+
+    lvl_original = df_updated["lvl"].copy()
+    lvl_scenario = df_updated["lvl_new"].fillna(df_updated["lvl"])
+
+    # Calculate the factor (ratio) between scenario and original values for analysis
+    # Factor = scenario / original
+    # Factor < 1 means scenario is lower than original
+    factor = np.where(lvl_original != 0, lvl_scenario / lvl_original, np.nan)
+
+    # For rows where factor < 1 (scenario < original), use original value
+    # Otherwise, use scenario value
+    df_updated["lvl"] = np.where(
+        (factor < 1) & (df_updated["lvl_new"].notna()), lvl_original, lvl_scenario
+    )
+    df_updated = df_updated.drop(columns=["lvl_new"])
+
+    # Save the updated prices to the default price input file in STURM
+    df_updated.to_csv(original_price_input_file, index=False)
+    log.info("Updated prices saved to %s", original_price_input_file)
+    log.info("Total rows: %d", len(df_updated))
+    log.info("Rows with updated prices: %d", rows_updated)
+
+    # Run STURM (via Rscript)
+    for name in ("run_STURM_bmt_resid.R", "run_STURM_bmt_comm.R"):
+        script = sturm_dir.joinpath(name)
+        if not script.is_file():
+            raise FileNotFoundError(f"STURM BMT R script not found: {script}")
+        log.info("Running Rscript %s (cwd=%s)", name, sturm_dir)
+        subprocess.run(
+            ["Rscript", name],
+            cwd=sturm_dir,
+            check=True,
+        )
+
+    return scenario

--- a/message_ix_models/tests/model/test_sturm.py
+++ b/message_ix_models/tests/model/test_sturm.py
@@ -1,0 +1,292 @@
+"""Tests for BMT STURM helpers in :mod:`message_ix_models.model.buildings.sturm`.
+
+Covers :func:`_message_buildings_install_dir`, :func:`call_sturm`, and
+:func:`call_buildings_demand`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from message_ix import make_df
+
+from message_ix_models.model.buildings import sturm
+from message_ix_models.testing import bare_res
+
+if TYPE_CHECKING:
+    from message_ix import Scenario
+
+    from message_ix_models import Context
+
+
+STURM_YEAR = 2030
+STURM_TIME = "year"
+STURM_UNIT = "GWa"
+PRICE_UNIT = "USD/kWa"
+STURM_PRICE_NODES = ["R11_AFR", "R11_CHN"]
+STURM_PRICE_COMMODITIES = ["gas", "electr"]
+STURM_SUBPROCESS = "message_ix_models.model.buildings.sturm.subprocess.run"
+STURM_INSTALL_DIR = (
+    "message_ix_models.model.buildings.sturm._message_buildings_install_dir"
+)
+
+
+def _sturm_price_input(values: list[float] | None = None) -> pd.DataFrame:
+    if values is None:
+        values = [10.0, 20.0]
+    return make_df(
+        "price_commodity",
+        node=STURM_PRICE_NODES,
+        commodity=STURM_PRICE_COMMODITIES,
+        level="final",
+        year=STURM_YEAR,
+        time=STURM_TIME,
+        unit=PRICE_UNIT,
+        value=values,
+    ).rename(columns={"value": "lvl"})
+
+
+def _scenario_price_par(
+    node: str | list[str],
+    commodity: str | list[str],
+    value: float | list[float],
+) -> pd.DataFrame:
+    return make_df(
+        "price_commodity",
+        node=node,
+        commodity=commodity,
+        level="final",
+        year=STURM_YEAR,
+        time=STURM_TIME,
+        unit=PRICE_UNIT,
+        value=value,
+    )
+
+
+def _scenario_price_var(
+    node: str | list[str],
+    commodity: str | list[str],
+    value: float | list[float],
+) -> pd.DataFrame:
+    return _scenario_price_par(node, commodity, value).rename(columns={"value": "lvl"})
+
+
+def _sturm_demand(
+    commodity: str | list[str],
+    value: float | list[float],
+    *,
+    node: str | list[str] = "R12_AFR",
+    level: str = "useful",
+) -> pd.DataFrame:
+    return make_df(
+        "demand",
+        node=node,
+        commodity=commodity,
+        level=level,
+        year=STURM_YEAR,
+        time=STURM_TIME,
+        unit=STURM_UNIT,
+        value=value,
+    )
+
+
+def _write_sturm_price_input(
+    path: Path, values: list[float] | None = None
+) -> pd.DataFrame:
+    frame = _sturm_price_input(values)
+    frame.to_csv(path, index=False)
+    return frame
+
+
+def _assert_sturm_price_file(path: Path, expected: pd.DataFrame) -> None:
+    columns = list(expected.columns)
+    actual = pd.read_csv(path)[columns].sort_values(columns).reset_index(drop=True)
+    pd.testing.assert_frame_equal(
+        actual,
+        expected[columns].sort_values(columns).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def _assert_demand_matches(
+    actual: pd.DataFrame, expected: pd.DataFrame, *, columns: list[str] | None = None
+) -> None:
+    columns = columns or list(make_df("demand").columns)
+    pd.testing.assert_frame_equal(
+        actual.loc[:, columns].sort_values(columns).reset_index(drop=True),
+        expected.loc[:, columns].sort_values(columns).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def _sturm_layout(tmp_path: Path) -> tuple[Path, Path, Path]:
+    buildings_root = tmp_path / "buildings"
+    sturm_dir = buildings_root / "message_ix_buildings" / "sturm"
+    price_dir = sturm_dir / "data"
+    temp_dir = sturm_dir / "temp"
+    price_dir.mkdir(parents=True)
+    temp_dir.mkdir(parents=True)
+    for name in ("run_STURM_bmt_resid.R", "run_STURM_bmt_comm.R"):
+        (sturm_dir / name).write_text("# stub\n")
+    return buildings_root, sturm_dir, price_dir
+
+
+def test_message_buildings_install_dir_raises_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "message_ix_models.model.buildings.sturm.ixmp.config.get",
+        MagicMock(side_effect=KeyError("missing")),
+    )
+
+    with pytest.raises(ValueError, match="message_buildings_dir"):
+        sturm._message_buildings_install_dir()
+
+
+def test_message_buildings_install_dir_reads_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    buildings_root = tmp_path / "message-buildings"
+    buildings_root.mkdir()
+
+    def _get(key: str) -> str:
+        if key == "message_buildings_dir":
+            return str(buildings_root)
+        raise KeyError(key)
+
+    monkeypatch.setattr("message_ix_models.model.buildings.sturm.ixmp.config.get", _get)
+
+    assert sturm._message_buildings_install_dir() == buildings_root.resolve()
+
+
+def test_call_sturm_raises_when_price_input_missing(
+    test_context: Context, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    buildings_root, _, _ = _sturm_layout(tmp_path)
+    monkeypatch.setattr(STURM_INSTALL_DIR, lambda: buildings_root)
+
+    with pytest.raises(FileNotFoundError, match="input_prices_R12.csv"):
+        sturm.call_sturm(test_context, MagicMock())
+
+
+def test_call_sturm_merges_prices_and_runs_rscripts(
+    request: pytest.FixtureRequest,
+    test_context: Context,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    buildings_root, _, price_dir = _sturm_layout(tmp_path)
+    price_input = price_dir / "input_prices_R12.csv"
+    _write_sturm_price_input(price_input)
+
+    monkeypatch.setattr(STURM_INSTALL_DIR, lambda: buildings_root)
+
+    scenario = bare_res(request, test_context)
+    # The scenario has to be solved to provide energy commodity prices.
+    scenario_prices = _scenario_price_var(
+        ["R12_AFR", "R12_CHN"],
+        ["gas", "electr"],
+        [15.0, 5.0],
+    )
+    original_var = scenario.var
+
+    def fake_var(name, filters=None):
+        if name != "PRICE_COMMODITY":
+            return original_var(name, filters=filters)
+        df = scenario_prices.copy()
+        if filters:
+            for key, values in filters.items():
+                if key in df.columns:
+                    df = df[df[key].isin(values)]
+        return df
+
+    monkeypatch.setattr(scenario, "var", fake_var)
+
+    run_calls: list[list[str]] = []
+
+    def _fake_run(command, cwd=None, check=None):  # noqa: ARG001
+        run_calls.append(command)
+
+    monkeypatch.setattr(STURM_SUBPROCESS, _fake_run)
+
+    result = sturm.call_sturm(test_context, scenario)
+
+    assert result is scenario
+    assert (price_dir / "input_prices_R12_ori.csv").is_file()
+    _assert_sturm_price_file(price_input, _sturm_price_input([15.0, 20.0]))
+    assert run_calls == [
+        ["Rscript", "run_STURM_bmt_resid.R"],
+        ["Rscript", "run_STURM_bmt_comm.R"],
+    ]
+
+
+# TODO: Discuss with Alessio whether flooring initial prices is desirable.
+# def test_call_sturm_keeps_original_when_scenario_price_is_lower(
+#     test_context: Context, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+# ) -> None:
+#     buildings_root, _, price_dir = _sturm_layout(tmp_path)
+#     price_input = price_dir / "input_prices_R12.csv"
+#     original = _write_sturm_price_input(price_input)
+#
+#     monkeypatch.setattr(STURM_INSTALL_DIR, lambda: buildings_root)
+#     monkeypatch.setattr(STURM_SUBPROCESS, MagicMock())
+#
+#     scenario = MagicMock()
+#     scenario.var.return_value = _scenario_price_var("R12_AFR", "gas", 4.0)
+#
+#     sturm.call_sturm(test_context, scenario)
+#
+#     _assert_sturm_price_file(price_input, original)
+
+
+def test_call_buildings_demand_filters_and_adds_useful_demand(
+    request: pytest.FixtureRequest,
+    test_context: Context,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    buildings_root, _, _ = _sturm_layout(tmp_path)
+    temp_dir = buildings_root / "message_ix_buildings" / "sturm" / "temp"
+
+    monkeypatch.setattr(STURM_INSTALL_DIR, lambda: buildings_root)
+
+    scenario: Scenario = bare_res(request, test_context)
+    node = scenario.set("node")[0]
+    _sturm_demand(
+        ["resid_heat_electr", "resid_heat_mat_steel", "comm_heat_electr"],
+        [1.0, 2.0, 0.5],
+        node=node,
+    ).to_csv(temp_dir / "resid_sturm.csv", index=False)
+    _sturm_demand("comm_heat_gas", 0.25, node=node).to_csv(
+        temp_dir / "comm_sturm.csv",
+        index=False,
+    )
+
+    sturm.call_buildings_demand(test_context, scenario)
+
+    expected = _sturm_demand(
+        ["resid_heat_electr", "comm_heat_electr", "comm_heat_gas"],
+        [1.0, 0.5, 0.25],
+        node=node,
+    )
+    actual = scenario.par("demand")
+    _assert_demand_matches(
+        actual.loc[actual["commodity"].isin(expected["commodity"])],
+        expected,
+    )
+
+
+def test_call_buildings_demand_raises_when_temp_dir_missing(
+    test_context: Context, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    buildings_root = tmp_path / "buildings"
+    buildings_root.mkdir()
+
+    monkeypatch.setattr(STURM_INSTALL_DIR, lambda: buildings_root)
+
+    with pytest.raises(FileNotFoundError, match="Buildings demand directory not found"):
+        sturm.call_buildings_demand(test_context, MagicMock())


### PR DESCRIPTION
This is a draft PR to add entries for the energy demand provided by message-ix-buildings in BMT workflows. 

In addition to being included during `Build`, it also needs to be updated when running policy scenarios to include the feedback between energy commodity prices and residential and commercial energy demand. 

For now it cuts in either in the steps of EN1 or EN2 of a policy scenario run. 

It is a part of the BMT development (issue #483) and has been split out accordingly.

## How to review

- Read the diff and note that the CI checks all pass.
- The documentation makes sense.

## PR checklist

- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.
