### PR TITLE
Fix dividing by zero in methanol feedstock share computation

### DIFF
--- a/message_ix_models/model/material/report/reporter_utils.py
+++ b/message_ix_models/model/material/report/reporter_utils.py
@@ -1,5 +1,12 @@
+import numpy as np
 import message_ix
 from genno import Key
+
+def _safe_div(num, denom):
+    """Division that returns 0 where the denominator is zero."""
+    result = num / denom
+    return result.where(np.isfinite(result), 0).fillna(0)
+
 
 comm_tec_map = {
     "coal": ["meth_coal", "meth_coal_ccs"],
@@ -183,7 +190,7 @@ def add_biometh_final_share(rep: message_ix.Reporter, mode: str = "feedstock"):
         )
         rep.add(
             f"share::{comm}methanol-final",
-            "div",
+            _safe_div,
             f"out::{comm}methanol-final",
             "in::methanol-final",
         )

--- a/message_ix_models/model/material/report/run_reporting.py
+++ b/message_ix_models/model/material/report/run_reporting.py
@@ -371,7 +371,6 @@ def split_fe_other(
                 variable=f"Share|{c}-methanol",
             )
         )
-        to_append = pyam.IamDataFrame(to_append.data.replace([np.inf, -np.inf], 0))
         py_df_all = pyam.concat([py_df_all, to_append])
         updated_rows = []
 


### PR DESCRIPTION
@ZHAOSHIYA0227 first bumped into this issue. 

Within `report_materials`, we get:

ValueError: Infinite values in `data`:
               model  scenario   region            variable           unit  year
0  JUSTMIP_SSP2_v6.5  baseline  R12_WEU  Share|gas-methanol  dimensionless  2100



<details><summary>Error</summary>
<p>

``` 
/home/kikstra/message_data/message_data/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution
/home/kikstra/env/message/lib/python3.11/site-packages/jwt/api_jwt.py:153: InsecureKeyLengthWarning: The HMAC key is 20 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  return self._jws.encode(
/home/kikstra/env/message/lib/python3.11/site-packages/jwt/api_jwt.py:153: InsecureKeyLengthWarning: The HMAC key is 20 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  return self._jws.encode(
/home/kikstra/message_data/message_data/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution
/home/kikstra/env/message/lib/python3.11/site-packages/jwt/api_jwt.py:153: InsecureKeyLengthWarning: The HMAC key is 20 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  return self._jws.encode(
/home/kikstra/message_data/message_data/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution
/home/kikstra/env/message/lib/python3.11/site-packages/jwt/api_jwt.py:153: InsecureKeyLengthWarning: The HMAC key is 20 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  return self._jws.encode(
/home/kikstra/message_data/message_data/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution
input: mixed units ['???', 't'] discarded
output: mixed units ['GWa', '-'] discarded
output: mixed units ['GWa', 't', 'Mt', 'Mt C/yr'] discarded
input: mixed units ['GWa', 'Mt', '-'] discarded
output: mixed units ['GWa', 't', 'Mt', 'Mt C/yr'] discarded
input: mixed units ['GWa', 'Mt', '-'] discarded
output: mixed units ['GWa', 't', 'Mt', 'Mt C/yr'] discarded
input: mixed units ['GWa', 'Mt', '-'] discarded
output: mixed units ['GWa', 't', 'Mt', 'Mt C/yr'] discarded
input: mixed units ['GWa', 'Mt', '-'] discarded
input: mixed units ['GWa', 't', '???'] discarded
input: mixed units ['GWa', '-'] discarded
output: mixed units ['GWa', '-'] discarded
output: mixed units ['GWa', 't', 'Mt', 'Mt C/yr'] discarded
input: mixed units ['GWa', 'Mt', 't', '-'] discarded
output: mixed units ['GWa', 't', 'Mt', 'Mt C/yr'] discarded
input: mixed units ['GWa', 'Mt', 't', '-'] discarded
Traceback (most recent call last):
  File "/home/kikstra/message_data/message_data/projects/justmip/utils/workflow_operations.py", line 117, in report_scenario
    report_materials(scen, region="R12_GLB", upload_ts=True)
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 711, in run
    dfs = run_all_categories(rep, scenario.model, scenario.scenario)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 688, in run_all_categories
    run_fe_reporting(rep, model_name, scen_name),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 176, in run_fe_reporting
    py_df_all = split_fe_other(rep, py_df_all, model, scenario)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 366, in split_fe_other
    to_append = pyam.IamDataFrame(
                ^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/core.py", line 147, in __init__
    self._init(data, meta, index=index, **kwargs)
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/core.py", line 183, in _init
    _data = format_data(data, index=index, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/utils.py", line 457, in format_data
    df = _check_data(df, time_col)
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/utils.py", line 366, in _check_data
    raise_data_error(
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/exceptions.py", line 20, in raise_data_error
    raise ValueError(format_log_message(msg, data))
ValueError: Infinite values in `data`:
               model  scenario   region            variable           unit  year
0  JUSTMIP_SSP2_v6.5  baseline  R12_WEU  Share|gas-methanol  dimensionless  2100
Traceback (most recent call last):
  File "/home/kikstra/message_data/message_data/projects/justmip/reference/reference_workflow_runner.py", line 330, in <module>
    main()
  File "/home/kikstra/message_data/message_data/projects/justmip/reference/reference_workflow_runner.py", line 288, in main
    report_scenario_by_name(reporting_tgt_model, reporting_scenario_name, RUN_CONFIG)
  File "/home/kikstra/message_data/message_data/projects/justmip/utils/workflow_operations.py", line 152, in report_scenario_by_name
    report_scenario(scen, mp, run_config)
  File "/home/kikstra/message_data/message_data/projects/justmip/utils/workflow_operations.py", line 117, in report_scenario
    report_materials(scen, region="R12_GLB", upload_ts=True)
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 711, in run
    dfs = run_all_categories(rep, scenario.model, scenario.scenario)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 688, in run_all_categories
    run_fe_reporting(rep, model_name, scen_name),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 176, in run_fe_reporting
    py_df_all = split_fe_other(rep, py_df_all, model, scenario)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/message-ix-models/message_ix_models/model/material/report/run_reporting.py", line 366, in split_fe_other
    to_append = pyam.IamDataFrame(
                ^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/core.py", line 147, in __init__
    self._init(data, meta, index=index, **kwargs)
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/core.py", line 183, in _init
    _data = format_data(data, index=index, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/utils.py", line 457, in format_data
    df = _check_data(df, time_col)
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/utils.py", line 366, in _check_data
    raise_data_error(
  File "/home/kikstra/env/message/lib/python3.11/site-packages/pyam/exceptions.py", line 20, in raise_data_error
    raise ValueError(format_log_message(msg, data))
ValueError: Infinite values in `data`:
               model  scenario   region            variable           unit  year
0  JUSTMIP_SSP2_v6.5  baseline  R12_WEU  Share|gas-methanol  dimensionless  2100

```

</p>
</details> 

This seems to happen in `add_biometh_final_share()`, when it tries to divide by zero

**Suggested fix:**
Replace the raw "div" operation in `add_biometh_final_share()` with a safe division that returns 0 where `in::methanol-final` is zero (regions and years with no methanol use). Previously, the division produced inf, which caused pyam.IamDataFrame to raise ValueError in `split_fe_other()`. An earlier downstream `replace()` seems to have attempted to fix this but the crash happened before that was called. This `replace()` probably is now redundant and thus removed.

