### PR TITLE
Update emissions accounting for trade

### DIFF
--- a/message_ix_models/data/bilateralize/configs/LNG_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/LNG_shipped.yaml
@@ -44,6 +44,8 @@ LNG_shipped_trade:
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
+    CO2: 0.482
   bunker_technology:
     LNG_tanker_LNG:
       LNG_tobunker

--- a/message_ix_models/data/bilateralize/configs/biomass_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/biomass_shipped.yaml
@@ -40,7 +40,8 @@ biomass_shipped_trade:
     - biomass_imp
   specify_network:
     False
-  tracked_emissions: # List of tracked emission types
+  tracked_emissions: # List of tracked emission types 
+  emission_factor:
   bunker_technology:
     energy_bulk_carrier_loil:
       loil_tobunker   

--- a/message_ix_models/data/bilateralize/configs/coal_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/coal_shipped.yaml
@@ -42,6 +42,8 @@ coal_shipped_trade: # Name of covered trade technology (e.g., oil)
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
+    CO2: 0.814
   bunker_technology:
     energy_bulk_carrier_loil:
       loil_tobunker

--- a/message_ix_models/data/bilateralize/configs/crudeoil_piped.yaml
+++ b/message_ix_models/data/bilateralize/configs/crudeoil_piped.yaml
@@ -48,6 +48,8 @@ crudeoil_piped_trade:
   specify_network:
     True
   tracked_emissions:
+  emission_factor:
+    CO2: 0.631
   bunker_technology: # not applicable for pipelines
   trade_technical_lifetime:
       1

--- a/message_ix_models/data/bilateralize/configs/crudeoil_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/crudeoil_shipped.yaml
@@ -47,6 +47,8 @@ crudeoil_shipped_trade: # Name of covered trade technology (e.g., oil)
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
+    CO2: 0.631
   bunker_technology:
     crudeoil_tanker_loil:
       loil_tobunker

--- a/message_ix_models/data/bilateralize/configs/eth_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/eth_shipped.yaml
@@ -47,6 +47,7 @@ eth_shipped_trade:
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
   bunker_technology:
     oil_tanker_loil:
       loil_tobunker

--- a/message_ix_models/data/bilateralize/configs/foil_piped.yaml
+++ b/message_ix_models/data/bilateralize/configs/foil_piped.yaml
@@ -45,6 +45,8 @@ foil_piped_trade:
   specify_network:
     True
   tracked_emissions:
+  emission_factor:
+    CO2: 0.665
   bunker_technology: # not applicable for pipelines
   trade_technical_lifetime:
       1

--- a/message_ix_models/data/bilateralize/configs/foil_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/foil_shipped.yaml
@@ -47,6 +47,8 @@ foil_shipped_trade:
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
+    CO2: 0.665
   bunker_technology:
     oil_tanker_loil:
       loil_tobunker

--- a/message_ix_models/data/bilateralize/configs/gas_piped.yaml
+++ b/message_ix_models/data/bilateralize/configs/gas_piped.yaml
@@ -52,6 +52,8 @@ gas_piped_trade:
     - TCE
     - TCE_non-CO2
     - TCE_other
+  emission_factor:
+    CO2: 0.507368
   bunker_technology: # not applicable for pipelines
   trade_technical_lifetime:
       1

--- a/message_ix_models/data/bilateralize/configs/lh2_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/lh2_shipped.yaml
@@ -43,6 +43,7 @@ lh2_shipped_trade:
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
   bunker_technology:
     lh2_tanker_lh2:
       lh2_tobunker

--- a/message_ix_models/data/bilateralize/configs/loil_piped.yaml
+++ b/message_ix_models/data/bilateralize/configs/loil_piped.yaml
@@ -50,6 +50,8 @@ loil_piped_trade:
   specify_network:
     True
   tracked_emissions:
+  emission_factor:
+    CO2: 0.631
   bunker_technology: # not applicable for pipelines
   trade_technical_lifetime:
       1

--- a/message_ix_models/data/bilateralize/configs/loil_shipped.yaml
+++ b/message_ix_models/data/bilateralize/configs/loil_shipped.yaml
@@ -49,6 +49,8 @@ loil_shipped_trade:
   specify_network:
     False
   tracked_emissions: # List of tracked emission types
+  emission_factor:
+    CO2: 0.631
   bunker_technology:
     oil_tanker_loil:
       loil_tobunker

--- a/message_ix_models/data/bilateralize/configs/template.yaml
+++ b/message_ix_models/data/bilateralize/configs/template.yaml
@@ -22,7 +22,7 @@ template_trade_technology: # Name of covered trade technology (e.g., oil)
   supply_technologies: # Technologies the supply the traded commodity
   # Do you want to specify the pipeline pairs? (instead of using all possible pairs) 
   specify_network: # If true, produces sheet of all mapped pipe technologies and regions, to be used to delete to desirable pairs. 
-  tracked_emissions: # List of tracked emission types
+  tracked_emissions: # List of tracked emission types and emission factors
   bunker_technology: # [DICT] Bunker technology for the traded fuel if it exists (e.g., LNG_tobunker)
   trade_technical_lifetime: # Technical lifetime of trade decision (default should be 1y)
   flow_technical_lifetime: # Technical lifetime of flow technology (default is 20y)

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -1098,6 +1098,7 @@ def export_edit_files(
             os.path.join(
                 "relation_activity_regional_exp.csv"
             ),  # necessary for legacy reporting
+            os.path.join("relation_activity_CO2_Emission.csv"),
             os.path.join("flow_technology", "capacity_factor.csv"),
             os.path.join("flow_technology", "input.csv"),
             os.path.join("flow_technology", "output.csv"),

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -491,9 +491,24 @@ def build_accounting_relations(
         **common_years,
         **common_cols,
     )
-    df_rel = df_rel.drop_duplicates()
+    df_rel_exports = df_rel.copy().drop_duplicates()
 
-    parameter_outputs[tec]["trade"]["relation_activity_CO2_Emission"] = df_rel
+    df_rel_imports = df_rel.copy().drop_duplicates()
+    df_rel_imports["technology"] = tec + "_imp"
+    df_rel_imports = df_rel_imports.drop_duplicates()
+
+    if config_dict["emission_factor"][tec] is not None:
+        emission_factor = config_dict["emission_factor"][tec]["CO2"]
+        if emission_factor is not None:
+            df_rel_exports["value"] = emission_factor*-1
+            df_rel_imports["value"] = emission_factor
+        else:
+            df_rel_exports["value"] = 0
+            df_rel_imports["value"] = 0
+
+    df_rel = pd.concat([df_rel_exports, df_rel_imports])
+
+    parameter_outputs[tec]["trade"]["relation_activity_CO2_Emission"] = df_rel.drop_duplicates()
 
     # Primary energy total
     df_rel = message_ix.make_df(


### PR DESCRIPTION
CO2 emissions were not properly tracked for bilateralized trade flows through relation activity. This ensures that relation activity has proper emissions factors associated with them (negative for exports, positive for imports)

## How to review
Relation activity for CO2 emissions tracking in trade should be transferred from edit to bare

## PR checklist
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.