### PR TITLE
Add `.tools.newclimate`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,3 +74,6 @@
 /doc/project/sparccle.rst @adrivinca
 /doc/project/ssp.rst      @OFR-IIASA
 /doc/project/uptake.rst   @ywpratama
+
+/message_ix_models/tools/newclimate                @khaeru
+/message_ix_models/tests/tools/test_newclimate.py  @khaeru

--- a/doc/api/data-sources.rst
+++ b/doc/api/data-sources.rst
@@ -180,3 +180,11 @@ These files were characterized by:
    .. [1] the column is sometimes labelled "UNIT", but the contents appear to be the same.
 
 This source is discontinued and will not publish subsequent editions of the data.
+
+.. _tools-newclimate:
+
+NewClimate Institute (:mod:`.tools.newclimate`)
+===============================================
+
+.. automodule:: message_ix_models.tools.newclimate
+   :members:

--- a/doc/api/tools.rst
+++ b/doc/api/tools.rst
@@ -119,6 +119,8 @@ Policies (:mod:`.tools.policy`)
 .. automodule:: message_ix_models.tools.policy
    :members:
 
+   See also :ref:`tools-newclimate`.
+
 .. _tools-wb:
 
 World Bank structures (:mod:`.tools.wb`)
@@ -126,7 +128,6 @@ World Bank structures (:mod:`.tools.wb`)
 
 .. automodule:: message_ix_models.tools.wb
    :members:
-
 
 Tools for scenario manipulation
 ===============================

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -5,6 +5,7 @@ Next release
 ============
 
 - Add IAMC code list :class:`~.iamc.structure.CL_SCENARIO_DIAGNOSTIC` (:pull:`501`).
+- New module :ref:`tools-newclimate` (:pull:`499`).
 - Add :doc:`/api/model-bmt` (:pull:`433`).
 
   - Add

--- a/message_ix_models/tests/tools/test_newclimate.py
+++ b/message_ix_models/tests/tools/test_newclimate.py
@@ -1,0 +1,89 @@
+import pytest
+
+from message_ix_models.testing import KEY as STASH_KEY
+from message_ix_models.tools.newclimate import SECTOR, fetch, get, read
+from message_ix_models.tools.newclimate.structure import STRINGENCY
+
+
+class TestSTRINGENCY:
+    def test_int(self) -> None:
+        """Lookup of str containing only digits gives an enumeration member."""
+        assert STRINGENCY["1"] == STRINGENCY._1
+
+
+@pytest.mark.parametrize(
+    "version",
+    ("2024", "2023", "2022", "2021", "2020", "2019"),
+)
+def test_fetch(version: str) -> None:
+    # File can be fetched
+    p = fetch(version)
+
+    assert p.exists()
+
+
+@pytest.mark.parametrize(
+    "version, N_total, N_transport",
+    (
+        ("2024", 6507, 1298),
+        ("2023", 6273, 1246),
+        ("2022", 5883, 1203),
+        pytest.param("2021", 1, 1, marks=pytest.mark.xfail(raises=NotImplementedError)),
+        pytest.param("2020", 1, 1, marks=pytest.mark.xfail(raises=NotImplementedError)),
+        pytest.param("2019", 1, 1, marks=pytest.mark.xfail(raises=NotImplementedError)),
+    ),
+)
+def test_get(version: str, N_total: int, N_transport: int) -> None:
+    # Data can be fetched and read
+    result = get(version)
+
+    # Expected number of records
+    N = len(result)
+    assert N_total == N
+
+    # Objects can be filtered using enumerations
+    subset = {k: p for k, p in result.items() if SECTOR.Transport in p.sector}
+
+    N = len(subset)
+    assert N_transport == N
+
+
+def test_read0() -> None:
+    result = get("2024")
+
+    # Retrieve one entry
+    p = result["211000001"]
+
+    # Enumerated field is parsed to a list of enum items
+    assert [SECTOR.Electricity_and_heat, SECTOR.Renewables] == p.sector
+
+    # Geo field contains a pycountry object
+    assert 1 == len(p.geo)
+    # …that can be used to access various fields, as needed
+    assert "ITA" == p.country.alpha_3
+    assert "Italy" == p.country.name
+
+
+@pytest.mark.parametrize(
+    "filename, N_total",
+    (
+        ("Canada_edits_additions0.csv", 18),
+        ("Canada_edits_additions1.csv", 1),
+        ("climate_policy_database_policies_2025.csv", 6507),
+    ),
+)
+def test_read_local_data(
+    pytestconfig: pytest.Config, filename: str, N_total: int
+) -> None:
+    """Test files in user's local data path."""
+    path = pytestconfig.stash[STASH_KEY["user-local-data"]].joinpath(
+        "newclimate", filename
+    )
+
+    if path.exists():
+        # Function runs
+        result = read(path)
+
+        # Expected number of records
+        N = len(result)
+        assert N_total == N

--- a/message_ix_models/tools/newclimate/__init__.py
+++ b/message_ix_models/tools/newclimate/__init__.py
@@ -1,0 +1,215 @@
+"""Handle data from the NewClimate Institute's Climate Policy Database (CPDB).
+
+This module provides:
+
+- :class:`.NewClimatePolicy`, a concrete subclass of the abstract/generic
+  :class:`.Policy`, that reflects the data model appearing in the CPDB.
+
+  - Enumerations that reflect values appearing in fields of the database which appear to
+    be enumerated (as opposed to free text):
+    :class:`HIGH_IMPACT`,
+    :class:`JURISDICTION`,
+    :class:`OBJECTIVE`,
+    :class:`SECTOR`,
+    :class:`STATUS`,
+    :class:`STRINGENCY`,
+    :class:`TYPE`, and
+    :class:`UPDATE`.
+
+  - A method :meth:`.NewClimatePolicy.from_csv_dict` that interprets the CSV data
+    format in which the database is expressed.
+
+- Functions to :func:`fetch` versions of the database from Zenodo, :func:`read` into
+  collections of Python objects, or do both (:func:`get`).
+
+These enable programmatic use of the information in the database. For example:
+
+.. code-block:: python
+
+   from message_ix_models.tools.newclimate import SECTOR, get
+   from pycountry import countries
+
+   # Fetch and parse the 2024 edition of the database
+   policies = get("2024")
+   print(len(policies))  # 6507 objects
+
+   # Filter the dict to a list of policy objects matching a certain sector
+   p_transport = list(filter(lambda p: SECTOR.Transport in p.sector, policies.values()))
+   print(len(p_transport))  # 1298 objects
+
+   # Filter for any policies concerning the country of Austria, or the EU
+   match = {pycountry.lookup("Austria"), "European Union"}
+   p_AUT = list(filter(lambda p: set(p.geo) & match, policies.values()))
+   print(len(p_AUT)))  # 259 objects
+
+.. todo:: Extend the module:
+
+   - Serialize :class:`.NewClimatePolicy` objects in 1 or more formats, preferably
+     standards-based.
+   - :func:`fetch` versions of the database more recent than the latest Zenodo record,
+     using the `cpdb_api package
+     <https://github.com/https-github-com-NewClimateInstitute/CPDB-API>`_ or other code.
+   - Convert to/from other data models.
+"""
+
+import csv
+import logging
+from functools import cache
+from typing import TYPE_CHECKING
+
+from .structure import (
+    HIGH_IMPACT,
+    JURISDICTION,
+    OBJECTIVE,
+    SECTOR,
+    STATUS,
+    STRINGENCY,
+    TYPE,
+    UPDATE,
+    NewClimatePolicy,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "HIGH_IMPACT",
+    "JURISDICTION",
+    "NewClimatePolicy",
+    "OBJECTIVE",
+    "SECTOR",
+    "STATUS",
+    "STRINGENCY",
+    "TYPE",
+    "UPDATE",
+    "read",
+    "get",
+    "fetch",
+]
+
+log = logging.getLogger(__name__)
+
+#: Pooch information for fetching files from the static version of the database.
+SOURCE = {  # noqa: E501
+    "newclimate-2024": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.15432946",
+            registry={
+                "ClimatePolicyDatabase_v2024.csv": (
+                    "sha256:e893745bc26d225d8e91d063eb1fdbcbb5da4a51ce05d28ce5b9f51f6ef4408f"
+                ),
+            },
+        ),
+    ),
+    "newclimate-2023": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.10869734",
+            registry={
+                "ClimatePolicyDatabase_v2023.xlsx": (
+                    "sha256:bdce700c6b0c2eeb7fa06584cb8523793b64ec5799d91ae65818209aaf9de682"
+                ),
+            },
+        ),
+    ),
+    "newclimate-2022": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.7774473",
+            registry={
+                "ClimatePolicyDatabase_v2022.csv": (
+                    "sha256:fe431e41c4c2fb8513d6718fba6ba3bc0a1fd2c5b9016256a106b998f5f48946"
+                ),
+            },
+        ),
+    ),
+    "newclimate-2021": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.7774471",
+            registry={
+                "ClimatePolicyDatabase_v2021.xlsx": (
+                    "sha256:d880c2c94c7d8da84bb9cf8d315faf7230e4965cbc679ac1783222ecfe84062a"
+                ),
+            },
+        ),
+    ),
+    "newclimate-2020": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.7774462",
+            registry={
+                "ClimatePolicyDatabase_v2020.xlsx": (
+                    "sha256:08818156401200ec094985c34250ef65cea6ff5246cbbeb1d0ade317f8fdaa0c"
+                ),
+            },
+        ),
+    ),
+    "newclimate-2019": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.7774110",
+            registry={
+                "ClimatePolicyDatabase _v2019.xlsx": (
+                    "sha256:c28cdd613496d503ae00bacf637fc052128e04361580110829843b4bf0235368"
+                ),
+            },
+        )
+    ),
+}
+
+
+def fetch(version: str) -> "Path":
+    """Retrieve data for `version` of the Climate Policy Database from Zenodo."""
+    from message_ix_models.util import pooch
+
+    # Ensure sources for this module are registered
+    pooch.SOURCE.update(SOURCE)
+
+    # Construct the key
+    source_id = f"newclimate-{version}"
+
+    return pooch.fetch(**pooch.SOURCE[source_id], extra_cache_path="newclimate")[0]
+
+
+def get(version: str) -> dict[str, NewClimatePolicy]:
+    """:func:`fetch` and then :func:`read` data for `version` of the database."""
+    f_source = fetch(version)
+
+    if f_source.suffix == ".xlsx":
+        # Convert Excel to CSV
+        import pandas as pd
+
+        f_read = f_source.with_suffix(".csv")
+        if not f_read.exists():
+            log.info(f"Unpack {f_source} to {f_read}")
+            pd.read_excel(f_source).to_csv(f_read, index=False)
+    else:
+        f_read = f_source
+
+    # - Force use of UTF-8 on macOS and Windows.
+    # - The 2022 CSV file is not in UTF-8 format; use a different encoding.
+    kwargs = dict(encoding="latin-1" if version == "2022" else "utf-8")
+
+    try:
+        return read(f_read, **kwargs)
+    except Exception as e:
+        if version in ("2021", "2020", "2019"):
+            raise NotImplementedError("Read 2021 and earlier data format") from e
+        else:  # pragma: no cover
+            raise
+
+
+@cache
+def read(path: "Path", **kwargs) -> dict[str, NewClimatePolicy]:
+    """Read a CSV file into a :class:`dict` of Policy objects.
+
+    Returns
+    -------
+    dict
+        Keys are :attr:`.NewClimatePolicy.id`. If the file contains records with the
+        same IDs, only the last appears, and a warning is logged.
+    """
+    with open(path, **kwargs) as f:
+        policies = [NewClimatePolicy.from_csv_dict(row) for row in csv.DictReader(f)]
+
+    result = {p.id: p for p in policies}
+    if len(result) < len(policies):
+        log.warning(f"{len(policies) - len(result)} duplicate IDs in `path`")
+
+    return result

--- a/message_ix_models/tools/newclimate/structure.py
+++ b/message_ix_models/tools/newclimate/structure.py
@@ -1,0 +1,430 @@
+"""Data structures and data model for Climate Policy Database."""
+
+import builtins
+import logging
+import re
+from dataclasses import dataclass, field, fields
+from enum import Enum, auto
+from functools import cache
+from types import GenericAlias
+from typing import TYPE_CHECKING, Any, get_args, get_origin
+
+from message_ix_models.tools.policy import Policy
+from message_ix_models.util.pycountry import iso_3166_alpha_3
+
+if TYPE_CHECKING:
+    from pycountry.db import Country
+
+log = logging.getLogger(__name__)
+
+#: Aliases for CSV field names. For each entry, the first name appears in recent
+#: versions(s) of the database and also corresponds to an attribute of
+#: :class:`.NewClimatePolicy`. The second entry appears in certain earlier version(s).
+CSV_FIELD_ALIASES = (
+    ("supranational_region", "supernational_region"),
+    ("subnational_region", "subnational_region_or_state"),
+    ("city_or_local", "city"),
+    ("country_iso", "country_iso_code"),
+    ("country_update", ""),  # No alias, this just ensures the key is present
+    ("decision_date", "date_of_decision"),
+    ("instrument", "type_of_policy_instrument"),
+    ("sector", "sector_name"),
+    ("status", "implementation_state"),
+    ("start_date", "start_date_of_implementation"),
+    ("end_date", "end_date_of_implementation"),
+    ("reference", "source_or_references"),
+    ("last_update", "last_updated"),
+    ("impact_indicators_base_year", "impact_indicator_base_year"),
+    ("impact_indicators_comments", "impact_indicator_comments"),
+    ("impact_indicators_name", "impact_indicator_name_of_impact_indicator"),
+    ("impact_indicators_value", "impact_indicator_value"),
+    ("impact_indicators_target_year", "impact_indicator_target_year"),
+)
+
+
+class HIGH_IMPACT(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.high_impact`.
+
+    .. todo:: If a codebook is available identifying what criteria were used to assign
+       these codes to the primary source data, reference or quote the defintions for
+       each code.
+
+       Do the same for the other enumerations in this module.
+    """
+
+    NOTSET = auto()
+    High = auto()
+    low_medium = auto()
+    Unclear = auto()
+
+    #: NB both 'unclear' and 'Unclear' appear in the 2025 draft database as of
+    #: 2026-04-17.
+    unclear = auto()
+    Unknown = auto()
+
+
+class JURISDICTION(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.jurisdiction`."""
+
+    City = auto()
+    Country = auto()
+    Subnational_region = auto()
+
+
+class OBJECTIVE(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.objective`."""
+
+    Adaptation = auto()
+    Air_pollution = auto()
+    Economic_development = auto()
+    Energy_access = auto()
+    Energy_security = auto()
+    Food_security = auto()
+    Mitigation = auto()
+    Land_use = auto()
+    Water = auto()
+
+
+class STATUS(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.status`."""
+
+    Draft = auto()
+    Ended = auto()
+    In_force = auto()
+    Planned = auto()
+    Superseded = auto()
+    Under_review = auto()
+    Unknown = auto()
+
+
+class SECTOR(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.sector`."""
+
+    Agricultural_CH4 = auto()
+    Agricultural_CO2 = auto()
+    Agricultural_N2O = auto()
+    Agriculture_and_forestry = auto()
+    Air = auto()
+    Appliances = auto()
+    Buildings = auto()
+    CCS = auto()
+    Coal = auto()
+    Construction = auto()
+    Electricity_and_heat = auto()
+    Fluorinated_gases = auto()
+    Forestry = auto()
+    Fossil_fuel_exploration_and_production = auto()
+    Gas = auto()
+    General = auto()
+    Heating_and_cooling = auto()
+    Heavy_duty_vehicles = auto()
+    Hot_water_and_cooking = auto()
+    Industrial_N2O = auto()
+    Industrial_energy_related = auto()
+    Industrial_process_CO2 = auto()
+    Industry = auto()
+    Light_duty_vehicles = auto()
+    Low_emissions_mobility = auto()
+    Negative_emissions = auto()
+    Nuclear = auto()
+    Oil = auto()
+    Rail = auto()
+    Renewables = auto()
+    Shipping = auto()
+    Transport = auto()
+    Unknown = auto()
+    Waste_CH4 = auto()
+
+
+class STRINGENCY(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.stringency`."""
+
+    _0 = 0
+    _1 = 1
+    _2 = 2
+    _3 = 3
+    _4 = 4
+    NOTSET = auto()
+
+
+# Ensure lookup of STRINGENCY["1"] gives a valid member
+for member in STRINGENCY:
+    new_name = member.name[1:]
+    if new_name.isdigit():
+        # TODO Use the following line once Python 3.13 is the minimum supported version
+        # member._add_alias_[new_name]
+        # For compatibility with Python 3.10–3.12
+        STRINGENCY._member_map_[new_name] = member
+
+
+class TYPE(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.type`."""
+
+    Energy_service_demand_reduction_and_resource_efficiency = auto()
+    Energy_efficiency = auto()
+    Non_energy_use = auto()
+    Other_low_carbon_technologies_and_fuel_switch = auto()
+    Renewables = auto()
+    Unknown = auto()
+
+
+class UPDATE(Enum):
+    """Enumeration for :attr:`.NewClimatePolicy.country_update`."""
+
+    Annual = auto()
+    Sporadic = auto()
+
+    #: NB This member added only to accommodate database version 2022 and earlier, in
+    #: which the respective field does not exist. In versions where the field *does*
+    #: exist, its value MUST be one of the two other members.
+    NOTSET = auto()
+
+
+@dataclass(slots=True, unsafe_hash=True)
+class NewClimatePolicy(Policy):
+    """Policy in the NewClimate data model.
+
+    Properties of this class match the column names appearing in the NewClimate CSV file
+    format as of 2024, with the following exceptions:
+
+    - The redundant prefix "policy_" is omitted, for instance "name" instead of
+      "policy_name".
+    - :attr:`geo` for geography; see the attribute documentation.
+    - :attr:`impact_indicators_base_year` and similar have an underscore, rather than
+      period (".") in the name.
+
+    For some attributes such as :attr:`country_update`, the type is an enumeration:
+    only members of the enumeration may be used. For others, such as :attr:`objective`,
+    the type is a :class:`list` of enumeration members, because the database contains
+    multiple values, separated by commas. It is unclear if the order in the database is
+    meaningful or not, so :class:`list` (rather than :class:`set`) is used to preserve
+    the original order.
+
+    .. todo::
+
+       - Add reference(s) to documentation of the data model, if any.
+       - Add docstrings for individual fields, quoting the documentation.
+       - Parse dates to Python :class:`.datetime` objects.
+    """
+
+    #: Country update.
+    country_update: UPDATE
+
+    #: MAY be empty.
+    decision_date: str
+
+    #: MAY be empty.
+    description: str
+
+    #: End date.
+    end_date: str
+
+    #: High impact.
+    high_impact: HIGH_IMPACT
+
+    #: Unique identifier for the policy.
+    id: str
+
+    #: Impact indicator base year.
+    impact_indicators_base_year: str
+
+    #: Impact indicator base year.
+    impact_indicators_comments: str
+
+    #: Impact indicator name.
+    impact_indicators_name: str
+
+    #: Impact indicator target year.
+    impact_indicators_target_year: str
+
+    #: Impact indicator value.
+    impact_indicators_value: str
+
+    #: Instrument.
+    instrument: str
+
+    #: Jurisdiction.
+    jurisdiction: JURISDICTION
+
+    #: Last update (of data in the database).
+    last_update: str
+
+    #: Name.
+    name: str
+
+    #: Objective.
+    objective: list[OBJECTIVE]
+
+    #: MAY be empty.
+    reference: str
+
+    #: Sector.
+    sector: list[SECTOR]
+
+    #: Start date.
+    start_date: str
+
+    #: Status.
+    status: STATUS
+
+    #: Stringency.
+    stringency: STRINGENCY
+
+    #: Title.
+    title: str
+
+    #: Type.
+    type: list[TYPE]
+
+    #: Geography. MUST be length 1 or greater. Items MAY include:
+    #:
+    #: 1. English name of supranational region
+    #: 2. A :class:`pycountry.db.Country` object.
+    #: 3. English name of a subnational region.
+    #: 4. English name of a city or locality.
+    #:
+    #: Some forms visible in the database include:
+    #:
+    #: - Only (1), for instance :py:`["European Union"]`.
+    #: - Only (2).
+    #: - Both (2) and (3).
+    #: - Both (2) and (4).
+    geo: list["str | Country"] = field(default_factory=list)
+
+    def __post_init__(
+        self,
+    ) -> None:
+        # Check that certain fields are non-empty
+        for field_name in ("instrument", "name", "title"):
+            if getattr(self, field_name) == "":
+                raise ValueError(f"{field_name}=''")
+
+        # Replace str with Enum members
+        pattern = re.compile("[ /-]")
+        for name, enum_type, container in self._enum_fields():
+            value = getattr(self, name)
+            if isinstance(value, str):
+                # Parse the value as a comma-separated list of elements
+                values: list[Enum | str] = []
+                for v in value.split(","):
+                    try:
+                        values.append(
+                            enum_type[pattern.sub("_", v.strip()) or "NOTSET"]
+                        )
+                    except KeyError:
+                        log.warning(f"Not a member of {enum_type}: {v!r}")
+                        values.append(v)
+
+                setattr(
+                    self, name, values[0] if container is None else container(values)
+                )
+
+    @classmethod
+    @cache
+    def _enum_fields(
+        cls,
+    ) -> tuple[tuple[str, builtins.type[Enum], builtins.type | None]]:
+        """Return 3-duples of (field name, Enum type, container type)."""
+        result = []
+        for f in fields(cls):
+            if isinstance(f.type, GenericAlias):
+                inner = get_args(f.type)[0]
+                if isinstance(inner, type) and issubclass(inner, Enum):
+                    result.append((f.name, inner, get_origin(f.type)))
+            elif isinstance(f.type, type) and issubclass(f.type, Enum):
+                result.append((f.name, f.type, None))  # type: ignore
+
+        return tuple(result)  # type: ignore
+
+    @classmethod
+    def from_csv_dict(cls, data: dict[str, str]) -> "NewClimatePolicy":
+        """Create from a :class:`dict` from a :class:`.csv.CsvReader`.
+
+        This method handles the following transformations:
+
+        - Strip leading white space. Some cells have leading non-printing white space,
+          like the UTF-8 byte-order mark \\uFEFF.
+        - Replace "." with "_", since the former cannot be used in Python names. For
+          example, "impact_indicators.base_year" becomes "impact_indicators_base_year".
+        - Remove the redundant prefix "policy_".
+        - Handle geographical fields. The CSV format has at least 5 fields that express
+          geographical concepts, as well as older aliases:
+
+          1. "city_or_local", "city": Identifier for a city or local geographical unit.
+          2. "country": name of a country.
+          3. "country_iso", "country_iso_code": ISO 3166 alpha-3 code of a country.
+          4. "subnational_region", "subnational_region_or_state": name of a region
+             within a country.
+          5. "supranational_region", "supernational_region": not used in the 2025
+             database. May be in use elsewhere. The name implies it is a name for parts
+             or all of 2 or more countries.
+
+          (1), (2), (4) and likely (5) are given in English.
+
+          These are transformed into a single value for the
+          :attr:`.NewClimatePolicy.geo` field; see its documentation.
+        - Handle older versions of field names appearing in 2022 and earlier database
+          versions, per :data:`CSV_FIELD_ALIASES`.
+        """
+        from pycountry import countries
+
+        # Clean and mogrify field names
+        pattern = re.compile("^(\ufeff|policy_)+")
+        new_data: dict[str, Any] = {
+            pattern.sub("", k).replace(".", "_"): v for k, v in data.items()
+        }
+
+        # Handle old names
+        for name, name_old in CSV_FIELD_ALIASES:
+            values: list[str] = list(
+                filter(None, [new_data.pop(name, ""), new_data.pop(name_old, "")])
+            )
+            match len(values):
+                case 0:
+                    new_data[name] = ""
+                case 1:
+                    new_data[name] = values[0]
+                case _:
+                    msg = f"Both {name}={values[0]} and {name_old}={values[1]}"
+                    raise ValueError(msg)
+
+        # Handle geographical fields
+
+        # Candidate entries for the `geo` field, to be filtered
+        geo: list[str | Country] = [
+            new_data.pop("supranational_region"),
+            "",
+            new_data.pop("subnational_region"),
+            new_data.pop("city_or_local"),
+        ]
+
+        # Convert country_iso to a pycountry.db.Country object and check consistency
+        country = new_data.pop("country")
+        if country_iso := new_data.pop("country_iso"):
+            # 2023 database uses an erroneous "URU"
+            country_iso = country_iso.replace("URU", "URY")
+            if obj := countries.get(alpha_3=country_iso):
+                if country and iso_3166_alpha_3(country) != obj.alpha_3:
+                    log.warning(f"Name {country!r} does not match ISO 3166-1 {obj}")
+                geo[1] = obj
+            elif country_iso == "EUE":
+                # This is not an ISO 3166-1 code; the EU is a supranational region
+                geo[0] = "European Union"
+            else:
+                raise ValueError(f"country={country!r} country_iso={country_iso!r}")
+
+        # Filter out empty strings
+        new_data["geo"] = list(filter(None, geo))
+
+        return cls(**new_data)  # type: ignore
+
+    @property
+    def country(self) -> "Country":
+        """Return a :mod:`pycountry` object from :attr:`.geo`.
+
+        Raises :class:`ValueError` if none exists.
+        """
+        for value in self.geo:
+            if not isinstance(value, str):
+                return value
+        raise ValueError

--- a/message_ix_models/util/pooch.py
+++ b/message_ix_models/util/pooch.py
@@ -1,7 +1,7 @@
 """Utilities for using :doc:`Pooch <pooch:about>`."""
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 from typing import Any
 
@@ -47,7 +47,7 @@ class UnpackSnapshot:
 GH_MAIN = "https://github.com/iiasa/message-ix-models/raw/main/message_ix_models/data"
 
 #: Supported remote sources of data.
-SOURCE: Mapping[str, Mapping[str, Any]] = {
+SOURCE: MutableMapping[str, Mapping[str, Any]] = {
     "CEPII_BACI": dict(
         pooch_args=dict(
             base_url="https://www.cepii.fr/DATA_DOWNLOAD/baci/data/",

--- a/message_ix_models/util/pycountry.py
+++ b/message_ix_models/util/pycountry.py
@@ -1,13 +1,15 @@
 from functools import lru_cache
 
-from pycountry import countries, historic_countries
-
 #: Mapping from common, non-standard country names to exact field values occurring in
 #: the ISO 3166-1 database.
 #:
 #: Other code **may** extend this mapping before calling :func:`iso_3166_alpha_3`.
 COUNTRY_NAME = {
+    "Cape Verde": "Cabo Verde",
     "Korea": "Korea, Republic of",
+    "Libyan Arab Jamahiriya": "Libya",
+    "Macedonia, the former Yugoslav Republic of": "North Macedonia",
+    "Palestinian Territory, Occupied": "Palestine, State of",
     "Republic of Korea": "Korea, Republic of",
     "Russia": "Russian Federation",
     "South Korea": "Korea, Republic of",
@@ -31,6 +33,8 @@ def iso_3166_alpha_3(name: str) -> str | None:
     -------
     str or None
     """
+    from pycountry import countries, historic_countries
+
     # Maybe map a known, non-standard value to a standard value
     name = COUNTRY_NAME.get(name, name)
 


### PR DESCRIPTION
Since 2019, the hope was that NewClimate et al. would adopt a [structured data format](https://codeberg.org/khaeru/structured-policy-data) for the policy database, rather than spreadsheet/CSV. This hasn't happened; however (a) the data format now seems more stable, with fewer changes year to year, and (b) since 2023, versions of the database are archived permanently on Zenodo: https://zenodo.org/records/15432946.

This PR creates an initial implementation of data structures and code to fetch and process these files into Python objects that can be handled abstract of their origin/storage format. This can be a basis for:
- Adapting to any changes in the 2025/2026 databases, whenever they are published;
- Extending to related file formats, e.g. if the PBL-processed version(s) of the files has the same (hopefully) or related format.
- Applications, including the NEWPATHWAYS project.

I also left a bunch of TODOs where upstream information is either missing or I did not have time to go collect it.

## How to review

- Read the added docs section on the new module: https://iiasa-energy-program-message-ix--499.com.readthedocs.build/projects/models/en/499/api/data-sources.html#tools-newclimate
- Skim the diff and note that the CI checks all pass.

One of the added tests, `test_read_local_data`, uses files from the private repo [NewClimateInstitute/policy-modelling](https://github.com/NewClimateInstitute/policy-modelling). Users with access to this repo may drop the files in their local data path to confirm that the code reads them. The tests are skipped if the files are not present.

## PR checklist

- [x] Continuous integration checks all ✅
  - [x] Adapt for [Enum.\_add_alias_() not present in Python <3.13](https://docs.python.org/3/library/enum.html#enum.Enum._add_alias_).
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.