### PR TITLE
Suggested structure for conceptual documentation of Buildings/Materials/Transport

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -2,11 +2,11 @@ name: Test
 
 on:
   # To debug the workflow, uncomment this entry AND comment pull_request_target
-  # pull_request:
-  #   branches: [ main ]
-  pull_request_target:
-    branches: [ main, "migrate**" ]
-    types: [ labeled, opened, reopened, synchronize ]
+  pull_request:
+     branches: [ main ]
+  # pull_request_target:
+  #   branches: [ main, "migrate**" ]
+  #   types: [ labeled, opened, reopened, synchronize ]
   schedule:
   - cron: "0 5 * * *"  # = 06:00 CET = 07:00 CEST
 
@@ -25,8 +25,20 @@ env:
   python-version: "3.14"
 
 jobs:
+  skip:
+    name: Skip workflow on PR branch
+    runs-on: ubuntu-latest
+    steps:
+    - name: Early exit
+      run: |
+        gh run cancel ${{ github.run_id }}
+        gh run watch ${{ github.run_id }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   check:
     name: Check permissions, identify ref to test
+    needs: skip
     runs-on: ubuntu-latest
     steps:
     - if: >

--- a/doc/conceptual/buildings/index.rst
+++ b/doc/conceptual/buildings/index.rst
@@ -1,0 +1,4 @@
+MESSAGEix-Buildings
+*******************
+
+Placeholder for conceptual documentation of MESSAGEix-Buildings model.

--- a/doc/conceptual/materials/index.rst
+++ b/doc/conceptual/materials/index.rst
@@ -1,0 +1,4 @@
+MESSAGEix-Materials
+*******************
+
+Placeholder for conceptual documentation of MESSAGEix-Materials model.

--- a/doc/conceptual/transport/index.rst
+++ b/doc/conceptual/transport/index.rst
@@ -1,0 +1,4 @@
+MESSAGEix-Transport
+*******************
+
+Placeholder for conceptual documentation of MESSAGEix-Transport model.

--- a/doc/global/index.rst
+++ b/doc/global/index.rst
@@ -1,6 +1,15 @@
 MESSAGEix-GLOBIOM global model
 ==============================
 
+.. caution:: This section of the documentation is under revision
+   on this branch.
+   See :issue:`424` for details.
+
+   Text on these pages may mix old and revised material;
+   links may be broken;
+   and in general these pages **should not** be used as reference
+   until changes are reviewed and merged via :pull:`425`.
+
 These pages document the IIASA Integrated Assessment Modeling (IAM) framework, also referred to as **MESSAGEix-GLOBIOM**, owing to the fact that the energy model |MESSAGEix| and the land use model GLOBIOM are its most important components.
 |MESSAGEix|-GLOBIOM was developed for the quantification of the so-called Shared Socio-economic Pathways (SSPs) which are the first application of the IAM framework.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -46,6 +46,9 @@ describing in detail how it represents global energy systems:
    :hidden:
 
    global/index
+   conceptual/materials/index
+   conceptual/buildings/index
+   conceptual/transport/index
 
 - :doc:`global/index`
 


### PR DESCRIPTION
Following discussions in the MESSAGEix weekly meeting on 13 May 2026, this PR suggests three entries under the conceptual documentation section for _MESSAGEix-Buildings/Materials/Transport_ next to _MESSAGEix-GLOBIOM global model_. Given that these three end-use modules are complex and their documentation will not fit into the single pages foreseen under `energy/enduse/` in the _MESSAGEix-GLOBIOM global model_ documentation, the suggestion is to have separate documentation pages at the top level of the conceptual documentation that can be linked from the subpages of the _MESSAGEix-GLOBIOM global model_ documentation. 

## How to review

- View the changed docs.

## PR checklist

- ~Continuous integration checks all ✅~ N/A; disabled for docs PR.
- ~Add or expand tests; coverage checks both ✅~
- [ ] Add, expand, or update documentation.
- ~Update doc/whatsnew.~ N/A; will be handled via base PR #425.