### PR TITLE
Fix CO2_Emission relation_activity bug in CO2 Utilisation technologies

### DIFF
--- a/message_ix_models/project/ssp/script/util/functions.py
+++ b/message_ix_models/project/ssp/script/util/functions.py
@@ -548,6 +548,8 @@ def add_ccs_setup(scen: message_ix.Scenario, ssp="SSP2"):  # noqa: C901
             "dac_htg",
         ]
 
+        co2util_techs = ["meth_h2"]
+
         dac_techs = ["dac_lt", "dac_hte", "dac_htg"]
 
         update_meth_h2_modes(scen)
@@ -584,7 +586,7 @@ def add_ccs_setup(scen: message_ix.Scenario, ssp="SSP2"):  # noqa: C901
             "relation_activity",
             scen.par(
                 "relation_activity",
-                {"technology": co2_pipes + ccs_techs, "relation": rels},
+                {"technology": co2_pipes + ccs_techs + co2util_techs, "relation": rels},
             ),
         )
 


### PR DESCRIPTION
Previously, when implementing the new CCS setup, we only cleaned up CO₂-emission-related `relation_activity` entries for CCS technologies and CO₂ pipelines. This PR fixes the CO₂ utilization bug by including the technology set in the removal process of the legacy `relation_activity`.

## How to review

Check if all CO2 Utilisation technologies in the models are already included in the technology list.

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅