### PR TITLE
Add open-license energy balance sources

### DIFF
--- a/doc/api/data-sources.rst
+++ b/doc/api/data-sources.rst
@@ -11,6 +11,16 @@ Tools for specific data sources
 .. automodule:: message_ix_models.tools.cepii
    :members:
 
+.. _tools-eurostat:
+
+Eurostat (:mod:`.tools.eurostat`)
+=================================
+
+.. currentmodule:: message_ix_models.tools.eurostat
+
+.. automodule:: message_ix_models.tools.eurostat
+   :members:
+
 .. _tools-gfei:
 
 Global Fuel Economy Initiative (GFEI) (:mod:`.tools.gfei`)
@@ -187,4 +197,14 @@ NewClimate Institute (:mod:`.tools.newclimate`)
 ===============================================
 
 .. automodule:: message_ix_models.tools.newclimate
+   :members:
+
+.. _tools-unsd:
+
+UN Statistics Division (UNSD) (:mod:`.tools.unsd`)
+==================================================
+
+.. currentmodule:: message_ix_models.tools.unsd
+
+.. automodule:: message_ix_models.tools.unsd
    :members:

--- a/message_ix_models/tests/tools/test_eurostat.py
+++ b/message_ix_models/tests/tools/test_eurostat.py
@@ -1,0 +1,178 @@
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+from genno import Computer
+
+from message_ix_models.tools import eurostat
+
+if TYPE_CHECKING:
+    from message_ix_models import Context
+
+#: Reference areas used by :func:`gapped_series`, and the alpha-3 codes they map to.
+GEO = ("RS", "AL")
+N = ("SRB", "ALB")
+
+
+def gapped_series() -> pd.Series:
+    """Return a :func:`.eurostat.fetch`-like series with gaps.
+
+    Serbia has observations for 2000 and 2002 but not 2001; Albania has only 2000. Both
+    gaps must survive to the output: the defect these fixtures guard against is a
+    missing observation becoming a zero or an interpolated value.
+    """
+    other = {"freq": "A", "nrg_bal": "GAE", "siec": "TOTAL", "unit": "TJ"}
+    index = pd.MultiIndex.from_tuples(
+        [
+            (g, *other.values(), period)
+            for g, period in ((GEO[0], "2000"), (GEO[0], "2002"), (GEO[1], "2000"))
+        ],
+        names=["geo", *other, "TIME_PERIOD"],
+    )
+    return pd.Series([1.0, 3.0, 5.0], index=index, name="value")
+
+
+class TestMakeKey:
+    """The positional key is the part that fails silently.
+
+    A key whose parts are in the wrong dimension order is answered by the service rather
+    than rejected, returning data for a selection nobody asked for. These expectations
+    are written by hand from the documented dimension order, not generated from
+    :data:`.eurostat.KEY_ORDER`, so that reordering that constant fails here.
+    """
+
+    def test_order(self) -> None:
+        # freq.nrg_bal.siec.unit.geo — the flow dimension precedes the product
+        # dimension, and geo comes last; both are the reverse of .tools.unsd.
+        assert "A.GAE.TOTAL.TJ.AL+RS" == eurostat.make_key(
+            geo=("RS", "AL"), product=("TOTAL",), flow=("GAE",)
+        )
+
+    def test_unit_always_constrained(self) -> None:
+        """The dataflow carries several units; a mixture cannot be summed."""
+        key = eurostat.make_key(geo=("RS",), product=(), flow=())
+        assert "TJ" in key.split(".")
+
+    def test_empty_selection_is_unfiltered(self) -> None:
+        """An empty tuple must yield an empty key part, not the string '()'."""
+        assert ".." in eurostat.make_key(geo=("RS",), product=(), flow=())
+
+    def test_label_order_is_normalized(self) -> None:
+        """Label order within a dimension carries no meaning to the service.
+
+        Two callers naming the same areas in different orders must produce one key, and
+        so one entry in the cache of :func:`.eurostat.fetch`, rather than two.
+        """
+        kw: dict = dict(product=("TOTAL",), flow=("GAE",))
+        assert eurostat.make_key(geo=("RS", "AL"), **kw) == eurostat.make_key(
+            geo=("AL", "RS"), **kw
+        )
+
+
+class TestLoadData:
+    """Assembly of the returned frame, with :func:`.eurostat.fetch` replaced.
+
+    The defect these guard against is a missing observation becoming a zero. Eurostat
+    omits years a country did not report, and coverage begins well after 2000 for
+    several non-member countries; if any step reindexes onto a complete year range,
+    “not reported” and “reported as zero” become the same value and no downstream
+    consumer can tell them apart.
+    """
+
+    @pytest.fixture
+    def gapped(self, monkeypatch) -> None:
+        """Patch :func:`.eurostat.fetch` with a series missing 2001 for one country."""
+        monkeypatch.setattr(eurostat, "fetch", lambda **kwargs: gapped_series())
+
+    def test_gap_is_not_filled(self, gapped) -> None:
+        df = eurostat.load_data(geo=["RS", "AL"])
+
+        assert 3 == len(df)
+        assert [2000, 2002] == sorted(df.loc[df["n"] == "SRB", "y"])
+        assert 2001 not in set(df["y"])
+        assert 0 not in set(df["value"])
+
+    def test_columns_and_dtypes(self, gapped) -> None:
+        df = eurostat.load_data(geo=["RS"])
+
+        assert ["n", "y", "product", "flow", "value"] == list(df.columns)
+        assert df["y"].dtype == int
+        assert set(N) == set(df["n"])
+
+    @pytest.mark.parametrize("label, expected", (("EL", "GRC"), ("UK", "GBR")))
+    def test_non_iso_label(self, monkeypatch, label: str, expected: str) -> None:
+        """Eurostat retains labels that are not ISO 3166-1 alpha-2.
+
+        :func:`.iso_3166_alpha_3` returns :any:`None` for each of them, so without
+        :data:`.eurostat.GEO` these countries would not raise — they would map to NaN
+        and vanish from the result.
+        """
+        series = gapped_series().rename(index={"RS": label}, level="geo")
+        monkeypatch.setattr(eurostat, "fetch", lambda **kwargs: series)
+
+        df = eurostat.load_data(geo=[label])
+        assert expected in set(df["n"])
+
+    def test_unmapped_area_raises(self, monkeypatch) -> None:
+        """An aggregate label has no alpha-3 code and must not vanish silently."""
+        series = gapped_series().rename(index={"RS": "EU27_2020"}, level="geo")
+        monkeypatch.setattr(eurostat, "fetch", lambda **kwargs: series)
+
+        with pytest.raises(
+            ValueError, match=r"alpha-3 code for Eurostat reference area"
+        ):
+            eurostat.load_data(geo=["EU27_2020", "AL"])
+
+    def test_extra_dimension_raises(self, monkeypatch) -> None:
+        """A dimension the module does not know would be dropped silently."""
+        series = gapped_series()
+        series.index = series.index.rename(["FOO"] + list(series.index.names[1:]))
+        monkeypatch.setattr(eurostat, "fetch", lambda **kwargs: series)
+
+        with pytest.raises(RuntimeError, match=r"Unexpected dimension\(s\) \['FOO'\]"):
+            eurostat.load_data(geo=["RS"])
+
+
+class TestESTATEnergyBalance:
+    """The :mod:`genno` path, with :func:`.eurostat.fetch` replaced.
+
+    :meth:`.ExoDataSource.add_tasks` adds the transformations selected by
+    :attr:`.BaseOptions.aggregate` and :attr:`.BaseOptions.interpolate`. Both are off by
+    default for this class. If interpolation were on, the observed periods would be
+    replaced by the model periods and the gaps in the fixture data filled by
+    extrapolation — the same defect the plain-data-frame tests above guard against, and
+    invisible to them because it happens in the Computer rather than in the loader.
+    """
+
+    def test_geo_required(self) -> None:
+        with pytest.raises(ValueError, match="at least one reference area"):
+            eurostat.ESTAT_ENERGY_BALANCE()
+
+    @pytest.mark.parametrize("aggregate", (False, True))
+    def test_add_tasks(
+        self, monkeypatch, test_context: "Context", aggregate: bool
+    ) -> None:
+        monkeypatch.setattr(eurostat, "fetch", lambda **kwargs: gapped_series())
+        test_context.model.regions = "R12"
+
+        c = Computer()
+        keys = eurostat.ESTAT_ENERGY_BALANCE.add_tasks(
+            c, context=test_context, geo=GEO, aggregate=aggregate
+        )
+        result = c.get(keys[0])
+
+        # Dimensions and units match .IEA_EWEB
+        assert {"n", "y", "product", "flow"} == set(result.dims)
+        assert "terajoule" == f"{result.units}"
+
+        # Only the observed periods appear: not the missing 2001, and not the model
+        # periods that interpolation would substitute
+        assert {2000, 2002} == set(result.coords["y"].data)
+
+        n = set(result.coords["n"].data)
+        if aggregate:
+            # Countries are replaced by the R12 node(s) containing them
+            assert n and not (n & set(N))
+            assert all(label.startswith("R12_") for label in n)
+        else:
+            assert set(N) == n

--- a/message_ix_models/tests/tools/test_unsd.py
+++ b/message_ix_models/tests/tools/test_unsd.py
@@ -1,0 +1,161 @@
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+from genno import Computer
+
+from message_ix_models.tools import unsd
+
+if TYPE_CHECKING:
+    from message_ix_models import Context
+
+#: Reference areas used by :func:`gapped_series`, and the alpha-3 codes they map to.
+GEO = ("398", "795")
+N = ("KAZ", "TKM")
+
+
+def gapped_series() -> pd.Series:
+    """Return a :func:`.unsd.fetch`-like series with gaps.
+
+    Kazakhstan has observations for 2000 and 2002 but not 2001; Turkmenistan has only
+    2000. Both gaps must survive to the output: the defect these fixtures guard against
+    is a missing observation becoming a zero or an interpolated value.
+    """
+    other = {"COMMODITY": "B09_TE", "TRANSACTION": "B07_GA", "UNIT": "HSO"}
+    index = pd.MultiIndex.from_tuples(
+        [
+            (g, *other.values(), period)
+            for g, period in ((GEO[0], "2000"), (GEO[0], "2002"), (GEO[1], "2000"))
+        ],
+        names=["REF_AREA", *other, "TIME_PERIOD"],
+    )
+    return pd.Series([1.0, 3.0, 5.0], index=index, name="value")
+
+
+class TestMakeKey:
+    """The positional key is the part that fails silently.
+
+    A key whose parts are in the wrong dimension order is answered by the service rather
+    than rejected, returning data for a selection nobody asked for. These expectations
+    are written by hand from the documented dimension order, not generated from
+    :data:`.unsd.KEY_ORDER`, so that reordering that constant fails here.
+    """
+
+    def test_order(self) -> None:
+        # REF_AREA.COMMODITY.TRANSACTION.UNIT
+        assert "398+417.B09_TE.B07_GA.HSO" == unsd.make_key(
+            geo=("398", "417"), product=("B09_TE",), flow=("B07_GA",)
+        )
+
+    def test_unit_always_constrained(self) -> None:
+        """The dataflow carries several units; a mixture cannot be summed."""
+        key = unsd.make_key(geo=("398",), product=(), flow=())
+        assert "HSO" in key.split(".")
+
+    def test_empty_selection_is_unfiltered(self) -> None:
+        """An empty tuple must yield an empty key part, not the string '()'."""
+        assert ".." in unsd.make_key(geo=("398",), product=(), flow=())
+
+    def test_label_order_is_normalized(self) -> None:
+        """Label order within a dimension carries no meaning to the service.
+
+        Two callers naming the same areas in different orders must produce one key, and
+        so one entry in the cache of :func:`.unsd.fetch`, rather than two.
+        """
+        kw: dict = dict(product=("B09_TE",), flow=("B07_GA",))
+        assert unsd.make_key(geo=("398", "417"), **kw) == unsd.make_key(
+            geo=("417", "398"), **kw
+        )
+
+
+class TestLoadData:
+    """Assembly of the returned frame, with :func:`.unsd.fetch` replaced.
+
+    The defect these guard against is a missing observation becoming a zero. UNSD omits
+    years a country did not report; if any step reindexes onto a complete year range,
+    “not reported” and “reported as zero” become the same value and no downstream
+    consumer can tell them apart.
+    """
+
+    @pytest.fixture
+    def gapped(self, monkeypatch) -> None:
+        """Patch :func:`.unsd.fetch` with a series missing 2001 for one country."""
+        monkeypatch.setattr(unsd, "fetch", lambda **kwargs: gapped_series())
+
+    def test_gap_is_not_filled(self, gapped) -> None:
+        df = unsd.load_data(geo=["398", "795"])
+
+        assert 3 == len(df)
+        assert [2000, 2002] == sorted(df.loc[df["n"] == "KAZ", "y"])
+        assert 2001 not in set(df["y"])
+        assert 0 not in set(df["value"])
+
+    def test_columns_and_dtypes(self, gapped) -> None:
+        df = unsd.load_data(geo=["398"])
+
+        assert ["n", "y", "product", "flow", "value"] == list(df.columns)
+        assert df["y"].dtype == int
+        # Numeric reference-area codes are mapped to alpha-3
+        assert set(N) == set(df["n"])
+
+    def test_unmapped_area_raises(self, monkeypatch) -> None:
+        """An aggregate label has no alpha-3 code and must not vanish silently."""
+        series = gapped_series().rename(index={"398": "1"}, level="REF_AREA")
+        monkeypatch.setattr(unsd, "fetch", lambda **kwargs: series)
+
+        with pytest.raises(ValueError, match=r"alpha-3 code for UNSD reference area"):
+            unsd.load_data(geo=["1", "795"])
+
+    def test_extra_dimension_raises(self, monkeypatch) -> None:
+        """A dimension the module does not know would be dropped silently."""
+        series = gapped_series()
+        series.index = series.index.rename(["FOO"] + list(series.index.names[1:]))
+        monkeypatch.setattr(unsd, "fetch", lambda **kwargs: series)
+
+        with pytest.raises(RuntimeError, match=r"Unexpected dimension\(s\) \['FOO'\]"):
+            unsd.load_data(geo=["398"])
+
+
+class TestUNSDEnergyBalance:
+    """The :mod:`genno` path, with :func:`.unsd.fetch` replaced.
+
+    :meth:`.ExoDataSource.add_tasks` adds the transformations selected by
+    :attr:`.BaseOptions.aggregate` and :attr:`.BaseOptions.interpolate`. Both are off by
+    default for this class. If interpolation were on, the observed periods would be
+    replaced by the model periods and the gaps in the fixture data filled by
+    extrapolation — the same defect the plain-data-frame tests above guard against, and
+    invisible to them because it happens in the Computer rather than in the loader.
+    """
+
+    def test_geo_required(self) -> None:
+        with pytest.raises(ValueError, match="at least one reference area"):
+            unsd.UNSD_ENERGY_BALANCE()
+
+    @pytest.mark.parametrize("aggregate", (False, True))
+    def test_add_tasks(
+        self, monkeypatch, test_context: "Context", aggregate: bool
+    ) -> None:
+        monkeypatch.setattr(unsd, "fetch", lambda **kwargs: gapped_series())
+        test_context.model.regions = "R12"
+
+        c = Computer()
+        keys = unsd.UNSD_ENERGY_BALANCE.add_tasks(
+            c, context=test_context, geo=GEO, aggregate=aggregate
+        )
+        result = c.get(keys[0])
+
+        # Dimensions and units match .IEA_EWEB
+        assert {"n", "y", "product", "flow"} == set(result.dims)
+        assert "terajoule" == f"{result.units}"
+
+        # Only the observed periods appear: not the missing 2001, and not the model
+        # periods that interpolation would substitute
+        assert {2000, 2002} == set(result.coords["y"].data)
+
+        n = set(result.coords["n"].data)
+        if aggregate:
+            # Countries are replaced by the R12 node(s) containing them
+            assert n and not (n & set(N))
+            assert all(label.startswith("R12_") for label in n)
+        else:
+            assert set(N) == n

--- a/message_ix_models/tests/util/test_sdmx.py
+++ b/message_ix_models/tests/util/test_sdmx.py
@@ -1,9 +1,12 @@
 import logging
 import re
 import sys
+from types import SimpleNamespace
 
 import genno
+import pandas as pd
 import pytest
+import sdmx
 from genno import Computer, Key
 from sdmx.model.common import Code
 from sdmx.model.v21 import Annotation
@@ -15,6 +18,7 @@ from message_ix_models.util.sdmx import (
     ItemSchemeEnumType,
     URNLookupEnum,
     eval_anno,
+    fetch_data,
     read,
 )
 
@@ -120,6 +124,53 @@ class TestDataflow:
 
 
 _urn_prefix = "urn:sdmx:org.sdmx.infomodel"
+
+
+class TestFetchData:
+    """Test :func:`.fetch_data`."""
+
+    @pytest.fixture
+    def client(self, monkeypatch):
+        """Replace :class:`sdmx.Client`; yield a record of what it was asked for."""
+        calls: dict = {}
+
+        class Stub:
+            def __init__(self, source: str) -> None:
+                calls.update(source=source)
+
+            def data(self, dataflow, key, params):
+                calls.update(dataflow=dataflow, key=key, params=params)
+                # A message carrying more than 1 data set
+                return SimpleNamespace(data=["data set 0", "data set 1"])
+
+        def to_pandas(obj):
+            calls.update(converted=obj)
+            return pd.Series([1.0])
+
+        monkeypatch.setattr(sdmx, "Client", Stub)
+        monkeypatch.setattr(sdmx, "to_pandas", to_pandas)
+
+        yield calls
+
+    def test_query(self, client) -> None:
+        result = fetch_data("UNSD", "DF_FOO", "398..HSO", startPeriod="2000")
+
+        assert "UNSD" == client["source"]
+        assert "DF_FOO" == client["dataflow"]
+        assert "398..HSO" == client["key"]
+        assert dict(startPeriod="2000") == client["params"]
+        assert 1 == len(result)
+
+    def test_convert_one_data_set(self, client) -> None:
+        """The single data set is converted, not the message.
+
+        :func:`sdmx.to_pandas` applied to a data message carrying more than 1 data set
+        returns a :class:`list`, not a :class:`pandas.Series`. Callers use the result as
+        a Series, so the mistake surfaces far from here.
+        """
+        fetch_data("UNSD", "DF_FOO", "398..HSO")
+
+        assert "data set 0" == client["converted"]
 
 
 class TestItemSchemeEnum:

--- a/message_ix_models/tools/eurostat.py
+++ b/message_ix_models/tools/eurostat.py
@@ -1,0 +1,267 @@
+"""Handle data from Eurostat.
+
+Eurostat administers, with the IEA and UNECE, the five joint annual questionnaires
+through which countries report their energy statistics, and publishes the resulting
+balances for the EU member states together with candidate countries and others that
+file. A country's primary national return goes to one collector and not the other, so
+this source and :mod:`.tools.unsd` are complementary rather than alternative: between
+them they cover the Western Balkans, Moldova and Ukraine as well as Central Asia,
+without recourse to the proprietary :class:`.IEA_EWEB`.
+
+The data are served without registration from the Eurostat dissemination API. Reuse is
+permitted for commercial and non-commercial purposes with acknowledgement.
+
+"ESTAT" throughout this module is Eurostat's agency ID in SDMX, and is the ID under
+which :mod:`sdmx` knows the web service.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import genno
+
+from message_ix_models.tools.exo_data import BaseOptions, ExoDataSource, register_source
+from message_ix_models.util import cached
+from message_ix_models.util.sdmx import fetch_data
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from genno.types import AnyQuantity
+
+log = logging.getLogger(__name__)
+
+#: ID of the dataflow retrieved by :func:`fetch`: complete energy balances.
+DATAFLOW = "NRG_BAL_C"
+
+#: Order in which :data:`DATAFLOW` declares its dimensions, and thus the order of the
+#: parts of a positional data key. Note that the flow dimension precedes the product
+#: dimension, and that ``geo`` comes last; both are the reverse of :mod:`.tools.unsd`.
+#: See :func:`.util.sdmx.fetch_data`.
+KEY_ORDER = ("freq", "nrg_bal", "siec", "unit", "geo")
+
+#: Mapping from the dimension IDs of :data:`DATAFLOW` to the dimensions of the data
+#: returned by :func:`load_data` and :class:`ESTAT_ENERGY_BALANCE`.
+DIMS = {
+    "geo": "n",
+    "TIME_PERIOD": "y",
+    "siec": "product",
+    "nrg_bal": "flow",
+}
+
+#: Label selected on the ``unit`` dimension: terajoules. :data:`DATAFLOW` also carries
+#: gigawatt-hours and tonnes of oil equivalent, so a query that does not constrain the
+#: unit returns a mixture that cannot be summed.
+UNIT = "TJ"
+
+#: Labels appearing on the ``geo`` dimension that are not ISO 3166-1 alpha-2 codes, with
+#: the alpha-3 code each maps to. Eurostat retains a few pre-ISO or politically-neutral
+#: labels; ``XK`` has no ISO 3166-1 entry at all.
+GEO = {
+    "EL": "GRC",  # Greece; ISO 3166-1 alpha-2 is GR
+    "UK": "GBR",  # United Kingdom; ISO 3166-1 alpha-2 is GB
+    "XK": "XKX",  # Kosovo; user-assigned, following World Bank practice
+}
+
+
+def make_key(
+    *, geo: tuple[str, ...], product: tuple[str, ...], flow: tuple[str, ...]
+) -> str:
+    """Return a positional data key for :data:`DATAFLOW`.
+
+    Dimensions not named here are left empty, meaning unfiltered; the unit dimension is
+    always constrained to :data:`UNIT`, and the frequency to annual.
+
+    The labels selected on each dimension are sorted. Their order carries no meaning to
+    the service, so sorting makes the key — and thus the :func:`.cached` key of
+    :func:`fetch` — independent of the order in which the caller happened to list them.
+    """
+    labels = {
+        "freq": ("A",),
+        "nrg_bal": flow,
+        "siec": product,
+        "unit": (UNIT,),
+        "geo": geo,
+    }
+    return ".".join("+".join(sorted(labels.get(d, ()))) for d in KEY_ORDER)
+
+
+@cached
+def fetch(
+    *,
+    geo: tuple[str, ...],
+    product: tuple[str, ...],
+    flow: tuple[str, ...],
+    start: int,
+    end: int,
+) -> "pd.Series":
+    """Retrieve part of :data:`DATAFLOW`.
+
+    The result has the dimension IDs of the dataflow on its index, not yet renamed.
+    Decorated with :func:`.cached`, so repeated calls with identical arguments do not
+    re-query the web service.
+
+    The cache has no expiry, so a revised national submission is not picked up until the
+    entry is invalidated: either set :attr:`.Config.cache_skip` to force the query, or
+    delete the cached file from :attr:`.Config.cache_path`.
+
+    Parameters
+    ----------
+    geo
+        Reference areas, as Eurostat ``geo`` labels, for instance :py:`("RS",)` for
+        Serbia.
+    product, flow
+        Labels to select on the ``siec`` and ``nrg_bal`` dimensions. Empty selects all
+        labels, which for this dataflow is a large query.
+    start, end
+        First and last period, inclusive.
+    """
+    return fetch_data(
+        "ESTAT",
+        DATAFLOW,
+        make_key(geo=geo, product=product, flow=flow),
+        startPeriod=str(start),
+        endPeriod=str(end),
+    )
+
+
+def load_data(
+    *,
+    geo: "tuple[str, ...] | list[str]",
+    product: "tuple[str, ...] | list[str]" = (),
+    flow: "tuple[str, ...] | list[str]" = (),
+    start: int = 2000,
+    end: int = 2022,
+) -> "pd.DataFrame":
+    """Return part of :data:`DATAFLOW` as a :class:`pandas.DataFrame`.
+
+    This is the entry point for consumers that process the data with :mod:`pandas` and
+    have no :class:`genno.Computer` to which tasks could be added; those that do build
+    one should prefer :class:`ESTAT_ENERGY_BALANCE`.
+
+    Columns are ``n`` (ISO 3166-1 alpha-3), ``y``, ``product``, ``flow`` and ``value``,
+    with values in TJ. Observations absent from the source are absent from the result:
+    they are **not** filled with zero, because a zero and an unreported value are
+    different facts and no consumer can distinguish them after the fact. Coverage begins
+    well after 2000 for several non-member countries.
+
+    See :func:`fetch` for the parameters.
+
+    Raises
+    ------
+    ValueError
+        if the data contain a reference area with no ISO 3166-1 alpha-3 code, for
+        instance one of the aggregates such as ``EU27_2020``.
+    RuntimeError
+        if the data have a dimension named in neither :data:`DIMS` nor
+        :data:`KEY_ORDER`.
+    """
+    from message_ix_models.util.pycountry import iso_3166_alpha_3
+
+    series = fetch(
+        geo=tuple(geo),
+        product=tuple(product),
+        flow=tuple(flow),
+        start=start,
+        end=end,
+    )
+
+    # Guard against the dataflow gaining a dimension. The column selection below would
+    # drop it silently, collapsing observations that differ only on that dimension onto
+    # identical index entries.
+    known = set(DIMS) | set(KEY_ORDER)
+    if extra := sorted(set(series.index.names) - known):
+        raise RuntimeError(
+            f"Unexpected dimension(s) {extra} in Eurostat data; expected only "
+            f"{sorted(known)}"
+        )
+
+    df = series.rename("value").reset_index()
+    df = df.rename(columns=DIMS)[["n", "y", "product", "flow", "value"]]
+
+    # Map reference areas to alpha-3, handling the labels in GEO first.
+    # iso_3166_alpha_3() returns None for a label it does not recognize, which would
+    # make those observations vanish rather than fail, so check before mapping. Compare
+    # .cepii.get_mapping(), which passes on_missing="raise" to MappingAdapter for the
+    # same reason.
+    labels = {n: GEO.get(n) or iso_3166_alpha_3(n) for n in df["n"].unique()}
+    if missing := sorted(k for k, v in labels.items() if v is None):
+        raise ValueError(
+            f"No ISO 3166-1 alpha-3 code for Eurostat reference area {missing}"
+        )
+
+    return df.assign(n=df["n"].map(labels)).astype({"y": int})
+
+
+@register_source
+class ESTAT_ENERGY_BALANCE(ExoDataSource):
+    """Complete energy balances published by Eurostat.
+
+    The data have the same dimensionality and units as :class:`.IEA_EWEB` —
+    :py:`"energy:n-y-product-flow"` in TJ — under the distinct key tag :py:`":estat"`,
+    so a consumer written against the IEA balance can take this source without change on
+    the |n| and |y| dimensions. The labels on ``product`` and ``flow`` are Eurostat's
+    own ``siec`` and ``nrg_bal`` codes, **not** IEA codes.
+
+    Reference areas are given as Eurostat ``geo`` labels.
+
+    Aggregation on |n| and interpolation on |y| are both **off** by default, unlike
+    :class:`.BaseOptions`. A balance records what each country reported for each year it
+    reported; interpolating onto the model periods would fill the years it did not,
+    making “not reported” and “reported as zero” indistinguishable, and would discard
+    every observed period besides. Compare :meth:`.IEA_EWEB.transform`, which suppresses
+    both for the same reason. A caller that wants either **may** ask for it explicitly.
+
+    Example
+    -------
+    >>> keys = ESTAT_ENERGY_BALANCE.add_tasks(
+    ...     computer, context=context, geo=("RS",), start=2000, end=2022
+    ... )
+    >>> result = computer.get(keys[0])
+    """
+
+    key = genno.Key("energy:n-y-product-flow:estat")
+
+    @dataclass
+    class Options(BaseOptions):
+        #: By default, do not aggregate.
+        aggregate: bool = False
+        #: By default, do not interpolate.
+        interpolate: bool = False
+
+        #: Reference areas to retrieve, as Eurostat ``geo`` labels.
+        geo: tuple[str, ...] = ()
+
+        #: Select only these labels on the ``siec`` dimension.
+        product: tuple[str, ...] = ()
+
+        #: Select only these labels on the ``nrg_bal`` dimension.
+        flow: tuple[str, ...] = ()
+
+        #: First and last period, inclusive.
+        start: int = 2000
+        end: int = 2022
+
+        def __post_init__(self) -> None:
+            if not self.geo:
+                raise ValueError("geo=(); at least one reference area is required")
+
+    options: Options
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.options = self.Options.from_args(self, *args, **kwargs)
+        super().__init__()
+
+    def get(self) -> "AnyQuantity":
+        """Retrieve the data and return it with :mod:`message_ix_models` dimensions."""
+        opt = self.options
+        df = load_data(
+            geo=opt.geo,
+            product=opt.product,
+            flow=opt.flow,
+            start=opt.start,
+            end=opt.end,
+        )
+        return genno.Quantity(
+            df.set_index(["n", "y", "product", "flow"])["value"], units="TJ"
+        )

--- a/message_ix_models/tools/unsd.py
+++ b/message_ix_models/tools/unsd.py
@@ -1,0 +1,261 @@
+"""Handle data from the UN Statistics Division (UNSD).
+
+UNSD compiles national energy balances for the countries that the five joint annual
+questionnaires do not reach. Those questionnaires are administered by Eurostat, the IEA
+and UNECE, and a country's primary national return goes to one collector and not the
+other, so this source and :mod:`.tools.eurostat` are complementary rather than
+alternative: between them they cover Central Asia, the Western Balkans, North Africa and
+the Middle East without recourse to the proprietary :class:`.IEA_EWEB`.
+
+The data are served without registration from https://unstats.un.org/unsd/energystats/api/
+UNdata's terms of use permit them to be “copied freely, duplicated and further
+distributed provided that UNdata is cited as the reference”.
+
+.. _unsd-granularity:
+
+.. note:: On granularity, for anyone arriving here from a calibration.
+
+   :class:`UNSD_ENERGY_BALANCE` carries 9 fuel groups on ``product``. Calibration
+   mappings written against the IEA balance reference on the order of 69 distinct
+   PRODUCT codes, so this source cannot identify individual technologies and **must
+   not** be substituted into such a mapping. The commodity-level dataflow
+   ``DF_UNDATA_ENERGY`` carries 75 commodities and is the appropriate source there; it
+   is deliberately not implemented here, because no consumer needs it yet.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import genno
+
+from message_ix_models.tools.exo_data import BaseOptions, ExoDataSource, register_source
+from message_ix_models.util import cached
+from message_ix_models.util.sdmx import fetch_data
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from genno.types import AnyQuantity
+
+log = logging.getLogger(__name__)
+
+#: ID of the dataflow retrieved by :func:`fetch`.
+DATAFLOW = "DF_UNData_EnergyBalance"
+
+#: Order in which :data:`DATAFLOW` declares its dimensions, and thus the order of the
+#: parts of a positional data key. See :func:`.util.sdmx.fetch_data`.
+KEY_ORDER = ("REF_AREA", "COMMODITY", "TRANSACTION", "UNIT")
+
+#: Mapping from the dimension IDs of :data:`DATAFLOW` to the dimensions of the data
+#: returned by :func:`load_data` and :class:`UNSD_ENERGY_BALANCE`.
+DIMS = {
+    "REF_AREA": "n",
+    "TIME_PERIOD": "y",
+    "COMMODITY": "product",
+    "TRANSACTION": "flow",
+}
+
+#: Label selected on the ``UNIT`` dimension: terajoules. :data:`DATAFLOW` also carries
+#: cubic metres, kilowatts, kilowatt-hours and metric tons, so a query that does not
+#: constrain the unit returns a mixture that cannot be summed.
+UNIT = "HSO"
+
+
+def make_key(
+    *, geo: tuple[str, ...], product: tuple[str, ...], flow: tuple[str, ...]
+) -> str:
+    """Return a positional data key for :data:`DATAFLOW`.
+
+    Dimensions not named here are left empty, meaning unfiltered; the unit dimension is
+    always constrained to :data:`UNIT`.
+
+    The labels selected on each dimension are sorted. Their order carries no meaning to
+    the service, so sorting makes the key — and thus the :func:`.cached` key of
+    :func:`fetch` — independent of the order in which the caller happened to list them.
+    """
+    labels = {
+        "REF_AREA": geo,
+        "COMMODITY": product,
+        "TRANSACTION": flow,
+        "UNIT": (UNIT,),
+    }
+    return ".".join("+".join(sorted(labels.get(d, ()))) for d in KEY_ORDER)
+
+
+@cached
+def fetch(
+    *,
+    geo: tuple[str, ...],
+    product: tuple[str, ...],
+    flow: tuple[str, ...],
+    start: int,
+    end: int,
+) -> "pd.Series":
+    """Retrieve part of :data:`DATAFLOW`.
+
+    The result has the dimension IDs of the dataflow on its index, not yet renamed.
+    Decorated with :func:`.cached`, so repeated calls with identical arguments do not
+    re-query the web service.
+
+    The cache has no expiry, so a revised national submission is not picked up until the
+    entry is invalidated: either set :attr:`.Config.cache_skip` to force the query, or
+    delete the cached file from :attr:`.Config.cache_path`.
+
+    Parameters
+    ----------
+    geo
+        Reference areas, as ISO 3166-1 numeric codes, for instance :py:`("398",)` for
+        Kazakhstan.
+    product, flow
+        Labels to select on the ``COMMODITY`` and ``TRANSACTION`` dimensions. Empty
+        selects all labels.
+    start, end
+        First and last period, inclusive.
+    """
+    return fetch_data(
+        "UNSD",
+        DATAFLOW,
+        make_key(geo=geo, product=product, flow=flow),
+        startPeriod=str(start),
+        endPeriod=str(end),
+    )
+
+
+def load_data(
+    *,
+    geo: "tuple[str, ...] | list[str]",
+    product: "tuple[str, ...] | list[str]" = (),
+    flow: "tuple[str, ...] | list[str]" = (),
+    start: int = 2000,
+    end: int = 2022,
+) -> "pd.DataFrame":
+    """Return part of :data:`DATAFLOW` as a :class:`pandas.DataFrame`.
+
+    This is the entry point for consumers that process the data with :mod:`pandas` and
+    have no :class:`genno.Computer` to which tasks could be added; those that do build
+    one should prefer :class:`UNSD_ENERGY_BALANCE`.
+
+    Columns are ``n`` (ISO 3166-1 alpha-3), ``y``, ``product``, ``flow`` and ``value``,
+    with values in TJ. Observations absent from the source are absent from the result:
+    they are **not** filled with zero, because a zero and an unreported value are
+    different facts and no consumer can distinguish them after the fact.
+
+    See :func:`fetch` for the parameters.
+
+    Raises
+    ------
+    ValueError
+        if the data contain a reference area with no ISO 3166-1 alpha-3 code, for
+        instance one of the aggregates published alongside the countries.
+    RuntimeError
+        if the data have a dimension named in neither :data:`DIMS` nor
+        :data:`KEY_ORDER`.
+    """
+    from message_ix_models.util.pycountry import iso_3166_alpha_3
+
+    series = fetch(
+        geo=tuple(geo),
+        product=tuple(product),
+        flow=tuple(flow),
+        start=start,
+        end=end,
+    )
+
+    # Guard against the dataflow gaining a dimension. The column selection below would
+    # drop it silently, collapsing observations that differ only on that dimension onto
+    # identical index entries.
+    known = set(DIMS) | set(KEY_ORDER)
+    if extra := sorted(set(series.index.names) - known):
+        raise RuntimeError(
+            f"Unexpected dimension(s) {extra} in UNSD data; expected only "
+            f"{sorted(known)}"
+        )
+
+    df = series.rename("value").reset_index()
+    df = df.rename(columns=DIMS)[["n", "y", "product", "flow", "value"]]
+
+    # Map reference areas to alpha-3. iso_3166_alpha_3() returns None for a label it
+    # does not recognize, which would make those observations vanish rather than fail,
+    # so check before mapping. Compare .cepii.get_mapping(), which passes
+    # on_missing="raise" to MappingAdapter for the same reason.
+    labels = {n: iso_3166_alpha_3(n) for n in df["n"].unique()}
+    if missing := sorted(k for k, v in labels.items() if v is None):
+        raise ValueError(
+            f"No ISO 3166-1 alpha-3 code for UNSD reference area {missing}"
+        )
+
+    return df.assign(n=df["n"].map(labels)).astype({"y": int})
+
+
+@register_source
+class UNSD_ENERGY_BALANCE(ExoDataSource):
+    """Energy balances published by the UN Statistics Division.
+
+    The data have the same dimensionality and units as :class:`.IEA_EWEB` —
+    :py:`"energy:n-y-product-flow"` in TJ — under the distinct key tag :py:`":unsd"`, so
+    a consumer written against the IEA balance can take this source without change on
+    the |n| and |y| dimensions. The labels on ``product`` and ``flow`` are UNSD's own,
+    **not** IEA codes; see the granularity note above before calibrating with them.
+
+    Reference areas are given as ISO 3166-1 numeric codes.
+
+    Aggregation on |n| and interpolation on |y| are both **off** by default, unlike
+    :class:`.BaseOptions`. A balance records what each country reported for each year it
+    reported; interpolating onto the model periods would fill the years it did not,
+    making “not reported” and “reported as zero” indistinguishable, and would discard
+    every observed period besides. Compare :meth:`.IEA_EWEB.transform`, which suppresses
+    both for the same reason. A caller that wants either **may** ask for it explicitly.
+
+    Example
+    -------
+    >>> keys = UNSD_ENERGY_BALANCE.add_tasks(
+    ...     computer, context=context, geo=("398",), start=2000, end=2022
+    ... )
+    >>> result = computer.get(keys[0])
+    """
+
+    key = genno.Key("energy:n-y-product-flow:unsd")
+
+    @dataclass
+    class Options(BaseOptions):
+        #: By default, do not aggregate.
+        aggregate: bool = False
+        #: By default, do not interpolate.
+        interpolate: bool = False
+
+        #: Reference areas to retrieve, as ISO 3166-1 numeric codes.
+        geo: tuple[str, ...] = ()
+
+        #: Select only these labels on the ``COMMODITY`` dimension.
+        product: tuple[str, ...] = ()
+
+        #: Select only these labels on the ``TRANSACTION`` dimension.
+        flow: tuple[str, ...] = ()
+
+        #: First and last period, inclusive.
+        start: int = 2000
+        end: int = 2022
+
+        def __post_init__(self) -> None:
+            if not self.geo:
+                raise ValueError("geo=(); at least one reference area is required")
+
+    options: Options
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.options = self.Options.from_args(self, *args, **kwargs)
+        super().__init__()
+
+    def get(self) -> "AnyQuantity":
+        """Retrieve the data and return it with :mod:`message_ix_models` dimensions."""
+        opt = self.options
+        df = load_data(
+            geo=opt.geo,
+            product=opt.product,
+            flow=opt.flow,
+            start=opt.start,
+            end=opt.end,
+        )
+        return genno.Quantity(
+            df.set_index(["n", "y", "product", "flow"])["value"], units="TJ"
+        )

--- a/message_ix_models/util/sdmx.py
+++ b/message_ix_models/util/sdmx.py
@@ -31,6 +31,7 @@ from .context import Context
 if TYPE_CHECKING:
     from os import PathLike
 
+    import pandas as pd
     import pint
     from genno import Computer, Key
     from sdmx.message import StructureMessage
@@ -715,6 +716,44 @@ def eval_anno(obj: common.AnnotableArtefact, id: str):
     except Exception as e:  # Something that can't be eval()'d, e.g. a plain string
         log.debug(f"Could not eval({value!r}): {e}")
         return value
+
+
+def fetch_data(source: str, dataflow: str, key: str, **params: str) -> "pd.Series":
+    """Retrieve data from an SDMX web service.
+
+    Parameters
+    ----------
+    source
+        ID of a data source known to :mod:`sdmx`, for instance "ESTAT" or "UNSD"; this
+        supplies the URL of the web service.
+    dataflow
+        ID of a data flow provided by that service.
+    key
+        Positional data key: the labels selected on each dimension of `dataflow`, in the
+        order in which that data flow declares its dimensions, separated by ".". An
+        empty part selects every label on the corresponding dimension. A key whose parts
+        are in another order is *answered* by the service rather than rejected, with
+        data for a selection that was not requested, so callers **must** construct it
+        from the dimension order of `dataflow` itself.
+    params
+        Further query parameters, for instance :py:`startPeriod="2000"`.
+
+    Returns
+    -------
+    pandas.Series
+        with one level per dimension of `dataflow` on its index, labelled with the
+        dimension IDs used by the service.
+    """
+    log.info(f"Query {source} {dataflow} for key {key!r}")
+    message = sdmx.Client(source).data(dataflow, key=key, params=params)
+
+    # Convert the single data set, not the message: sdmx.to_pandas() applied to a
+    # DataMessage returns a list if the message carries more than 1 data set. Compare
+    # .tools.wb.assign_income_groups().
+    result = sdmx.to_pandas(message.data[0])
+    log.info(f"{len(result)} observation(s)")
+
+    return result
 
 
 def get(urn: str) -> "common.MaintainableArtefact | None":


### PR DESCRIPTION
This is a draft PR corresponding to the working branch for the osce-energy-resilience project. It adds support to fetch UNSD and EUROSTAT data to provide an alternative to IEA for energy balance data. 


Add tools/unsd.py and tools/eurostat.py: national energy balances from the UN Statistics Division and from Eurostat over SDMX, each as a registered ExoDataSource and as a load_data() function for consumers that use pandas and have no Computer. Both emit the same dimensionality and units as IEA_EWEB under their own key tags, so a consumer can swap providers without its n and y dimensions changing shape.

Add util.sdmx.fetch_data() for the part of the query that is specific to neither service.

Neither aggregation nor interpolation runs unless asked for, and absent observations are never filled. The UNSD balance carries nine fuel groups against the IEA product axis of sixty-nine codes, so it serves aggregate indicators and cannot drive a technology calibration;


## How to review
~na~


## PR checklist

<!-- This item is always required. -->
~- [ ] Continuous integration checks all ✅~
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
~- [ ] Update doc/whatsnew.~
