### PR TITLE
Support multiple BACI releases in the CEPII source

### DIFF
--- a/message_ix_models/tests/tools/test_cepii.py
+++ b/message_ix_models/tests/tools/test_cepii.py
@@ -4,7 +4,14 @@ from typing import TYPE_CHECKING
 import pytest
 from genno import Computer
 
-from message_ix_models.tools.cepii import BACI
+from message_ix_models.tools.cepii import (
+    ARCHIVE,
+    BACI,
+    COUNTRY_CODES,
+    _code_map,
+    load_data,
+)
+from message_ix_models.util.pooch import SOURCE, fetch
 
 if TYPE_CHECKING:
     from message_ix_models import Context
@@ -18,6 +25,14 @@ class TestBACI:
                 match=re.escape("non-existent dimension(s): ['x', 'y', 'z']"),
             ):
                 BACI.Options(filter_pattern={"k": "", "x": "", "y": "", "z": ""})
+
+        def test_release_default(self) -> None:
+            """The default is the earliest release, so adding one changes nothing."""
+            assert min(ARCHIVE) == BACI.Options().release
+
+        def test_release_invalid(self) -> None:
+            with pytest.raises(ValueError, match="release='202401'; expected one of"):
+                BACI.Options(release="202401")
 
     @pytest.mark.parametrize(
         "measure",
@@ -66,3 +81,65 @@ class TestBACI:
         # Data have the expected dimensions and size
         assert {"t", "i", "j", "k"} == set(result.dims)
         assert size == result.size
+
+
+class TestArchive:
+    def test_keys_match_registry(self) -> None:
+        """Every release names a file the registry can fetch, and vice versa.
+
+        Guards a release added to one and not the other, which would otherwise
+        surface as a KeyError or a silent fallback at fetch time.
+        """
+        registry = set(SOURCE["CEPII_BACI"]["pooch_args"]["registry"])
+        assert registry == set(ARCHIVE.values())
+
+    def test_release_appears_in_filename(self) -> None:
+        """`get()` selects data files by release substring, so this must hold."""
+        for release, filename in ARCHIVE.items():
+            assert f"V{release}" in filename
+
+
+class TestFetch:
+    """The registry holds more than one file, so `filename` is not optional."""
+
+    def test_filename_required(self) -> None:
+        with pytest.raises(ValueError, match="filename= must name one of"):
+            fetch(**SOURCE["CEPII_BACI"])
+
+    def test_filename_unknown(self) -> None:
+        with pytest.raises(ValueError, match="is not in the registry"):
+            fetch(**SOURCE["CEPII_BACI"], filename="BACI_HS92_V1999.zip")
+
+
+class TestCodeMap:
+    def test_idiosyncratic_codes_take_precedence(self) -> None:
+        """The hand-listed codes must not be overwritten by the ISO 3166-1 values.
+
+        Several deliberately differ from ISO for the same country, so the merge order
+        is load-bearing: reverse it and e.g. 891 resolves to the ISO country rather
+        than the historical entity that carries pre-2006 trade.
+        """
+        mapping = _code_map()
+
+        for code, alpha_3 in COUNTRY_CODES:
+            assert alpha_3 == mapping[code], f"{code} overwritten"
+
+    def test_serbia_and_montenegro(self) -> None:
+        assert "SCG" == _code_map()[891]
+
+
+class TestLoadData:
+    def test_unknown_reporter_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unmapped reporter fails loudly rather than vanishing from the result."""
+        import pandas as pd
+
+        from message_ix_models.tools import cepii
+
+        frame = pd.DataFrame(
+            {"t": [2022, 2022], "i": [4, 8], "j": [8, 99999], "k": [270112, 270112]}
+        )
+        monkeypatch.setattr(cepii, "fetch", lambda **kw: ())
+        monkeypatch.setattr(cepii, "baci_data_from_files", lambda *a: frame)
+
+        with pytest.raises(ValueError, match=r"reporter\(s\) \[99999\]$"):
+            load_data(release="202601")

--- a/message_ix_models/tools/cepii.py
+++ b/message_ix_models/tools/cepii.py
@@ -51,6 +51,14 @@ COUNTRY_CODES = [
     (891, "SCG"),  # Part of ISO 3166-3, not -1
 ]
 
+#: Archive file name for each supported release. These are the keys of the
+#: "CEPII_BACI" registry in :data:`.pooch.SOURCE`; the mapping is here so that
+#: :class:`BACI` can name a release rather than a file.
+ARCHIVE = {
+    "202501": "BACI_HS92_V202501.zip",
+    "202601": "BACI_HS92_V202601.zip",
+}
+
 #: Dimensions and data types for input data. In order to reduce memory and disk usage:
 #:
 #: - :py:`np.uint16` (0 to 65_535) is used for t (year), i (exporter), and j (importer)
@@ -71,13 +79,12 @@ class BACI(ExoDataSource):
 
     Currently the class supports:
 
-    - The 202501 release only.
+    - The releases in :data:`ARCHIVE`; see :attr:`Options.release`.
     - The 1992 Harmonized System (HS92) only.
 
     .. todo::
        - Aggregate to MESSAGE regions.
        - Test with additional HS categorizations.
-       - Test with additional releases.
     """
 
     @dataclass
@@ -86,6 +93,10 @@ class BACI(ExoDataSource):
         aggregate: bool = False
         #: By default, do not interpolate.
         interpolate: bool = False
+
+        #: BACI release to use. The default is the earliest supported, so that
+        #: adding a newer one does not change existing results.
+        release: str = "202501"
 
         #: Either "quantity" or "value".
         measure: str = "quantity"
@@ -119,6 +130,10 @@ class BACI(ExoDataSource):
                 raise ValueError(
                     f"measure={self.measure}; must be either 'quantity' or 'value'"
                 )
+            if self.release not in ARCHIVE:
+                raise ValueError(
+                    f"release={self.release!r}; expected one of {sorted(ARCHIVE)}"
+                )
             if extra := set(self.filter_pattern) - set(self.dims):
                 raise ValueError(
                     f"Filter patterns for non-existent dimension(s): {sorted(extra)}"
@@ -135,9 +150,10 @@ class BACI(ExoDataSource):
 
         This method performs the following steps:
 
-        1. If needed, retrieve the data archive from :data:`.pooch.SOURCE` using the
-           entry "CEPII_BACI". The file is stored in the :attr:`.Config.cache_path`, and
-           is about 2.2 GiB.
+        1. If needed, retrieve the archive for :attr:`Options.release` from
+           :data:`.pooch.SOURCE`, using the entry "CEPII_BACI". The file is stored in
+           the :attr:`.Config.cache_path`, and is about 2.2 GiB. Releases extract to a
+           shared directory, so only the selected release's data files are read.
         2. If needed, extract all the members of the archive to a :file:`…/cepii-baci/`
            subdirectory of the cache directory. The extracted size is about 7.9 GiB,
            containing about 2.6 × 10⁸ observations.
@@ -151,8 +167,10 @@ class BACI(ExoDataSource):
         if not self.options.test:  # pragma: no cover
             # - Fetch (if necessary) and unpack (if necessary) the BACI data archive.
             # - Select only the data files.
+            release = self.options.release
             paths: Iterable[Path] = filter(
-                lambda p: p.name.startswith("BACI"), fetch(**SOURCE["CEPII_BACI"])
+                lambda p: p.name.startswith("BACI") and f"V{release}" in p.name,
+                fetch(**SOURCE["CEPII_BACI"], filename=ARCHIVE[release]),
             )
         else:
             paths = path_fallback("cepii-baci", where="test").glob("*.csv")
@@ -208,6 +226,57 @@ def baci_data_from_files(
     return result
 
 
+def _code_map() -> dict[int, str]:
+    """Return BACI reporter code to ISO 3166-1 alpha-3.
+
+    ISO 3166-1 numeric codes, plus the idiosyncratic values in :data:`COUNTRY_CODES`,
+    which take precedence.
+    """
+    from pycountry import countries
+
+    return {int(c.numeric): c.alpha_3 for c in countries} | dict(COUNTRY_CODES)
+
+
+def load_data(
+    *,
+    release: str = "202501",
+    measure: str = "quantity",
+    filter_pattern: dict[str, "str | Pattern"] | None = None,
+) -> "DataFrame":
+    """Return BACI data as a :class:`pandas.DataFrame`.
+
+    This is the entry point for consumers that process the data with :mod:`pandas` and
+    have no :class:`genno.Computer` to which tasks could be added; those that do build
+    one should prefer :class:`BACI`.
+
+    Columns are the dimensions in :attr:`BACI.Options.dims` plus one for `measure`,
+    named as in the source files. The :math:`(i, j)` dimensions carry ISO 3166-1
+    alpha-3 codes rather than the numeric codes of the source.
+
+    Raises
+    ------
+    ValueError
+        if the data contain a reporter code with no known alpha-3 code, rather than
+        dropping those observations.
+    """
+    options = BACI.Options(
+        release=release, measure=measure, filter_pattern=filter_pattern or {}
+    )
+
+    paths = [
+        p
+        for p in fetch(**SOURCE["CEPII_BACI"], filename=ARCHIVE[options.release])
+        if p.name.startswith("BACI") and f"V{options.release}" in p.name
+    ]
+    result = baci_data_from_files(paths, options.measure, options.filter_pattern)
+
+    mapping = _code_map()
+    if unknown := sorted((set(result["i"]) | set(result["j"])) - set(mapping)):
+        raise ValueError(f"No ISO 3166-1 alpha-3 code for BACI reporter(s) {unknown}")
+
+    return result.assign(i=result["i"].map(mapping), j=result["j"].map(mapping))
+
+
 def get_mapping() -> MappingAdapter:
     """Return an adapter from codes appearing in BACI data.
 
@@ -220,10 +289,8 @@ def get_mapping() -> MappingAdapter:
     :mod:`message_ix_models` ``node`` code lists, which include those alpha-3 codes as
     children of each region code.
     """
-    from pycountry import countries
-
     # All values from ISO 3166-1, plus some idiosyncratic values from COUNTRY_CODES
-    num_to_a3 = COUNTRY_CODES + [(int(c.numeric), c.alpha_3) for c in countries]
+    num_to_a3 = list(_code_map().items())
 
     # Use the same mapping for both i and j dimensions
     return MappingAdapter({"i": num_to_a3, "j": num_to_a3}, on_missing="raise")

--- a/message_ix_models/util/pooch.py
+++ b/message_ix_models/util/pooch.py
@@ -48,6 +48,9 @@ GH_MAIN = "https://github.com/iiasa/message-ix-models/raw/main/message_ix_models
 
 #: Supported remote sources of data.
 SOURCE: MutableMapping[str, Mapping[str, Any]] = {
+    # One entry per BACI release. :class:`.tools.cepii.BACI` selects among them with
+    # its :attr:`~.tools.cepii.BACI.Options.release`; pass `filename` to :func:`fetch`
+    # to choose directly.
     "CEPII_BACI": dict(
         pooch_args=dict(
             base_url="https://www.cepii.fr/DATA_DOWNLOAD/baci/data/",
@@ -55,6 +58,10 @@ SOURCE: MutableMapping[str, Mapping[str, Any]] = {
                 "BACI_HS92_V202501.zip": (
                     "sha256:9b36cd9529d6dae0df3fc42ac42af2daecd1f4cd6fb9c281ee66187974f"
                     "a025c"
+                ),
+                "BACI_HS92_V202601.zip": (
+                    "sha256:43259580059fa83e17fcdb6866e7b7f39aaf0dd50277cfe494a1ed05a48"
+                    "44faf"
                 ),
             },
         ),
@@ -115,6 +122,7 @@ def fetch(
     pooch_args: dict,
     *,
     extra_cache_path: str | None = None,
+    filename: str | None = None,
     verbose: bool = False,
     **fetch_kwargs,
 ) -> tuple[Path, ...]:
@@ -127,6 +135,10 @@ def fetch(
     ----------
     args
         Passed to :func:`pooch.create`.
+    filename
+        Name of the entry in the registry to fetch. Optional where the registry has
+        exactly one entry; required where it has more than one, since there is
+        otherwise no way to say which is wanted.
     kwargs
         Passed to :meth:`pooch.Pooch.fetch`.
 
@@ -145,10 +157,17 @@ def fetch(
 
     p = pooch.create(**pooch_args)
 
-    if len(p.registry) > 1:  # pragma: no cover
-        raise NotImplementedError("fetch() with registries with >1 files")
+    if filename is None:
+        if len(p.registry) > 1:
+            raise ValueError(
+                f"filename= must name one of {sorted(p.registry)} when the registry "
+                "has more than one entry"
+            )
+        filename = next(iter(p.registry.keys()))
+    elif filename not in p.registry:
+        raise ValueError(f"{filename!r} is not in the registry {sorted(p.registry)}")
 
-    filenames = p.fetch(next(iter(p.registry.keys())), **fetch_kwargs)
+    filenames = p.fetch(filename, **fetch_kwargs)
 
     if isinstance(filenames, (str, Path)):
         filenames = [filenames]


### PR DESCRIPTION
This is a draft PR which builds on #543, to extend support for newer BACI releases

Further extensions might be added here related to BACI data workflow as the project evolves. 

## PR checklist


- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
~- [ ] Update doc/whatsnew.~

