### PR TITLE
Fix/import without plotnine

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Fix import of :mod:`message_ix_models` without :mod:`plotnine` (:issue:`323`, :issue:`540`, :pull:`546`).
 - Add IAMC code list :class:`~.iamc.structure.CL_SCENARIO_DIAGNOSTIC` (:pull:`501`).
 - New module :ref:`tools-newclimate` (:pull:`499`).
 - Add :class:`.model.water.Config` to collect water module settings (:pull:`509`).

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from re import escape
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 import genno.config
@@ -20,12 +20,14 @@ from message_ix_models.model.workflow import STAGE
 from message_ix_models.util._logging import mark_time, silence_log
 
 from .config import Config
-from .plot import prepare_computer as add_plots
 
 if TYPE_CHECKING:
     from genno.core.key import KeyLike  # TODO Import from genno.types
 
     from .config import Callback
+
+    # Provided at runtime by __getattr__(), below
+    from .plot import prepare_computer as add_plots
 
 __all__ = [
     "NOT_IMPLEMENTED_IAMC",
@@ -38,6 +40,15 @@ __all__ = [
     "register",
     "report",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # Import .plot on demand: it requires plotnine, from the "report" extra
+    if name == "add_plots":
+        from .plot import prepare_computer
+
+        return prepare_computer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 log = logging.getLogger(__name__)

--- a/message_ix_models/report/config.py
+++ b/message_ix_models/report/config.py
@@ -23,13 +23,22 @@ ComputerT = TypeVar("ComputerT", bound="genno.Computer")
 Callback = Callable[[ComputerT, "Context"], None]
 
 
-def _default_callbacks() -> list[Callback]:
+def _plot_callback(c: "genno.Computer", context: "Context") -> None:
+    """Call :func:`.report.plot.callback`.
+
+    The :mod:`.report.plot` import is deferred to here because it requires
+    :mod:`plotnine`, from the "report" extra.
+    """
     from message_ix_models.report import plot
 
+    plot.callback(c, context)
+
+
+def _default_callbacks() -> list[Callback]:
     from . import defaults, extraction
 
     # NB When updating this list, also update the docstring of Config.callback
-    return [defaults, extraction.callback, plot.callback]
+    return [defaults, extraction.callback, _plot_callback]
 
 
 @dataclass

--- a/message_ix_models/types.py
+++ b/message_ix_models/types.py
@@ -1,12 +1,14 @@
 """Types for hinting."""
 
 from collections.abc import Mapping, MutableMapping
-from typing import Any, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict
 
 import pandas as pd
 import sdmx.model.common
 from genno.core.key import KeyLike  # TODO Import from genno.types, when possible
-from plotnine import ggplot
+
+if TYPE_CHECKING:
+    from plotnine import ggplot
 
 try:
     from genno.core.quantity import AnyQuantity
@@ -35,7 +37,7 @@ MutableParameterData = MutableMapping[str, pd.DataFrame]
 
 
 class PlotAddable(Protocol):
-    def __radd__(self, other: ggplot) -> ggplot: ...
+    def __radd__(self, other: "ggplot") -> "ggplot": ...
 
 
 # For sdmx1


### PR DESCRIPTION
This PR addresses the `plotnine` import failure from the `message-ix-models` half of #540, and addresses #323 as well. 

`message_ix_models/report/plot.py` needs plotnine at import time. This PR makes its eager imports lazy.  There are two such sites: 
the `add_plots` re-export in `report/__init__.py`, now resolved through a module `__getattr__`, and the third default callback in `report/config.py`, now a wrapper that imports `.report.plot` when the callback runs instead of when `Config` is constructed. 

`types.py` imported `ggplot` solely to annotate `PlotAddable.__radd__`, so that import moves under `TYPE_CHECKING`



## How to review

Read the diff, check CI passes. Try local plain install of this branch once `ixmp` is pointed at iiasa/ixmp#640


## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
~- [ ] Add or expand tests; coverage checks both ✅~ CI side change required if any. 
~- [ ] Add, expand, or update documentation.~
- [x] Update doc/whatsnew.
