### PR TITLE
Fix/import without plotnine

### DIFF
--- a/doc/api/report/index.rst
+++ b/doc/api/report/index.rst
@@ -138,8 +138,11 @@ API reference
 
 .. currentmodule:: message_ix_models.report
 
+
 .. automodule:: message_ix_models.report
    :members:
+
+   :mod:`.report` requires the ``report`` :ref:`optional dependencies <install-dependencies>`.
 
    General-purpose code:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,16 +1,17 @@
 Installation
 ************
 
-.. note:: :mod:`message_ix_models` requires :mod:`message_ix` to run.
-   Please ensure your system has :ref:`their required dependencies <message-ix:system-dependencies>` installed.
-
-:mod:`message_ix_models` is structured as a Python package and is published to the PyPI public code repository.
+:mod:`message_ix_models` is structured as a Python package,
+is published to the Python Package Index (PyPI) public repository,
+and is Free Software.
 Hence, there are two options for the installation:
 
-From PyPI
----------
+From the Python Package Index (PyPI)
+------------------------------------
 
 This option is only recommended for users who do not wish to make any changes to the source code.
+This page uses `pip <https://pip.pypa.io>`_;
+another alternative is `uv pip <https://docs.astral.sh/uv/reference/cli/#uv-pip>`_.
 
 1. Run::
 
@@ -40,20 +41,47 @@ Please consider :doc:`contributing <message-ix:contributing>` your changes.
 
     $ pip install --editable .[<extra_dependencies>]
 
+.. _install-dependencies:
 
 Dependencies
 ------------
 
-See :file:`pyproject.toml`.
-The following sets of extra dependencies are available; per the user guide linked above, they can be installed along with the mandatory dependencies by adding (for instance) ``extra_name`` to the package spec :program:`pip install message_data[extra_name]`.
+The mandatory dependencies of :mod:`message_ix_models` include:
 
+- :mod:`message_ix` and thus :ref:`its upstream dependencies <message-ix:system-dependencies>`.
+
+The following ‘extras’, or sets of optional dependencies, are available.
+Without the associated dependencies,
+the respective modules or features will not work:
+for example, it is optional to use :doc:`material/index`,
+but in order to use it the ``material`` extra dependencies **must** be installed.
+
+Per the :program:`pip` documentation (linked above),
+they can be installed along with the mandatory dependencies by adding to the package spec.
+For example, :program:`pip install message_data[material,transport]`
+will install the dependencies in those two sets.
+
+``bilateralize``
+   For :mod:`.tools.bilateralize`.
+``buildings``
+   For :doc:`buildings/index`.
 ``docs``
-   Minimum requirements for building the docs.
+   Build these documentation pages.
+``iea-web``
+   For :mod:`.tools.iea.web`.
+``material``
+   For :doc:`material/index`.
+``migrate``
+   For :doc:`howto/migrate`.
 ``report``
-   For running the :doc:`api/report/index` functionality.
+   For :doc:`api/report/index`;
+   includes :mod:`plotnine` and :mod:`xlsxwriter`.
 ``tests``
-   Minimal requirements for the test suite.
+   Run the test suite.
+``transport``
+   For :doc:`transport/index`.
 
+See :file:`pyproject.toml` in the source for the exact contents of each set.
 
 Check that installation was successful
 --------------------------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Fix import of :mod:`message_ix_models` without :mod:`plotnine` (:issue:`323`, :issue:`540`, :pull:`547`).
 - Add IAMC code list :class:`~.iamc.structure.CL_SCENARIO_DIAGNOSTIC` (:pull:`501`).
 - New module :ref:`tools-newclimate` (:pull:`499`).
 - Add :class:`.model.water.Config` to collect water module settings (:pull:`509`).

--- a/message_ix_models/report/__init__.py
+++ b/message_ix_models/report/__init__.py
@@ -20,7 +20,11 @@ from message_ix_models.model.workflow import STAGE
 from message_ix_models.util._logging import mark_time, silence_log
 
 from .config import Config
-from .plot import prepare_computer as add_plots
+
+try:
+    from .plot import prepare_computer as add_plots
+except ImportError:  # pragma: no cover
+    pass  # Plotnine not installed
 
 if TYPE_CHECKING:
     from genno.core.key import KeyLike  # TODO Import from genno.types

--- a/message_ix_models/report/config.py
+++ b/message_ix_models/report/config.py
@@ -24,12 +24,19 @@ Callback = Callable[[ComputerT, "Context"], None]
 
 
 def _default_callbacks() -> list[Callback]:
-    from message_ix_models.report import plot
-
     from . import defaults, extraction
 
     # NB When updating this list, also update the docstring of Config.callback
-    return [defaults, extraction.callback, plot.callback]
+    result: list[Callback] = [defaults, extraction.callback]
+
+    try:
+        from message_ix_models.report import plot
+
+        result.append(plot.callback)
+    except ImportError:  # pragma: no cover
+        pass  # Plotnine is not installed
+
+    return result
 
 
 @dataclass

--- a/message_ix_models/types.py
+++ b/message_ix_models/types.py
@@ -8,15 +8,7 @@ import sdmx.model.common
 from genno.core.key import KeyLike  # TODO Import from genno.types, when possible
 from plotnine import ggplot
 
-try:
-    from genno.core.quantity import AnyQuantity
-except ImportError:  # genno <= 1.24
-    from genno.core.quantity import Quantity
-
-    AnyQuantity: type = Quantity  # type: ignore [no-redef]
-
 __all__ = [
-    "AnyQuantity",
     "KeyLike",
     "MaintainableArtefactArgs",
     "MutableParameterData",

--- a/message_ix_models/util/cache.py
+++ b/message_ix_models/util/cache.py
@@ -22,8 +22,7 @@ import ixmp
 import sdmx.model
 import xarray as xr
 from genno import Computer
-
-from message_ix_models.types import AnyQuantity
+from genno.core.quantity import AnyQuantity
 
 from ._dataclasses import asdict
 from .context import Context
@@ -38,13 +37,16 @@ COMPUTER = Computer()
 # Show genno how to hash function arguments seen in message_ix_models
 
 
-def _quantity(o: "AnyQuantity"):
+def _quantity(o: "AnyQuantity") -> tuple:
+    """Encode :class:`genno.Quantity` `o` for cache key construction."""
     return tuple(o.to_series().to_dict())
 
 
 try:
     genno.caching.Encoder.register(AnyQuantity)(_quantity)
-except TypeError:  # Python 3.10 or earlier
+except TypeError:
+    # In Python <= 3.10, functools.singledispatch() does not support typing.Union
+    # Register each of the Quantity classes separately
     from genno.core.attrseries import AttrSeries
     from genno.core.sparsedataarray import SparseDataArray
 


### PR DESCRIPTION
This PR addresses the `plotnine` import failure from the `message-ix-models` half of #540, and addresses #323 as well. 

`message_ix_models/report/plot.py` needs plotnine at import time. This PR makes its eager imports lazy.  There are two such sites: 
the `add_plots` re-export in `report/__init__.py`, now resolved through a module `__getattr__`, and the third default callback in `report/config.py`, now a wrapper that imports `.report.plot` when the callback runs instead of when `Config` is constructed. 

`types.py` imported `ggplot` solely to annotate `PlotAddable.__radd__`, so that import moves under `TYPE_CHECKING`

## How to review

- Read the diff.
- Check that CI passes.
- Install `message_ix_models` from this branch without optional dependencies, particularly plotnine; run `python -c "import message_ix_models"`; and observe no ImportError.
- Try local plain install of this branch once `ixmp` is ~pointed at~ installed from the branch associated iiasa/ixmp#640.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.
