### PR TITLE
Use first-party actions to cache Git LFS objects

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -257,7 +257,7 @@ jobs:
         mix-models config show
         # Symlink message-static-data into local data path
         mkdir -p ${{ github.workspace }}/local-data
-        cp -rsv $(realpath message-static-data)/* local-data/
+        cp -frsv $(realpath message-static-data)/* local-data/ || true
 
     - name: Run test suite using pytest
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,7 +37,7 @@ jobs:
           || contains(github.event.pull_request.labels.*.name, env.label)
         )
       run: |
-        echo "Pytest workflow will not run for branch in fork without label \`${{ env.label }}\`." >>$GITHUB_STEP_SUMMARY
+        echo "Workflow will not run for branch in fork without label \`${{ env.label }}\`." >>$GITHUB_STEP_SUMMARY
         exit 1
 
     - name: Identify ref to check out
@@ -45,6 +45,7 @@ jobs:
       run: echo "ref=${{ github.event_name != 'pull_request_target' && github.ref || github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
 
     outputs:
+      # This is available in the following jobs as needs.check.outputs.ref
       ref: ${{ steps.ref.outputs.ref }}
 
   warm-lfs-cache:
@@ -54,17 +55,37 @@ jobs:
     strategy:
       matrix:
         os: [ macos-15-intel, macos-latest, ubuntu-latest, windows-latest ]
+
     runs-on: ${{ matrix.os }}
+
     steps:
-    - uses: francisbilham11/action-cached-lfs-checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{ needs.check.outputs.ref }}
+        # This step only runs if the 'check' job above succeeds
+        allow-unsafe-pr-checkout: true
+
+    - name: Create Git LFS file list
+      run: git lfs ls-files -l | cut -d' ' -f1 | sort >.git/lfs-hashes.txt
+
+    - name: Cache Git LFS objects
+      uses: actions/cache@v6
+      with:
+        path: .git/lfs
+        key: ${{ runner.os }}-lfsdata-v1-${{ hashFiles('.git/lfs-hashes.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-lfsdata-v1-
+          ${{ runner.os }}-lfsdata
+
+    - name: Fetch any needed Git LFS objects and prune extraneous ones
+      run: git lfs fetch --prune
+      # The objects are not checked out or used in this job
 
     - name: Cache static data
       uses: actions/cache@v6
       with:
         path: message-static-data
-        key: static-data-${{ matrix.os }}
+        key: static-data-${{ runner.os }}
 
     - uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -82,6 +103,7 @@ jobs:
         sparse-checkout: |
           iea/eei
           ssp
+        allow-unsafe-pr-checkout: true
 
   pytest:
     needs: [ check, warm-lfs-cache ]
@@ -123,24 +145,35 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.version.python }}-upstream-${{ matrix.version.upstream }}
 
     steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.check.outputs.ref }}
+        allow-unsafe-pr-checkout: true
+
+    - name: Restore Git LFS objects from cache
+      uses: actions/cache/restore@v6
+      with:
+        key: ${{ runner.os }}-lfsdata-v1-FOO
+        restore-keys: |
+          ${{ runner.os }}-lfsdata-v1-
+        path: .git/lfs
+
+    - name: Check out Git LFS files
+      run: git lfs checkout
+
+    - name: Restore message-static-data from cache
+      uses: actions/cache/restore@v6
+      with:
+        key: static-data-${{ runner.os }}
+        path: message-static-data
+
     - name: Cache test data
       uses: actions/cache@v6
       with:
         path: |
           local-data
           .pytest_cache/d
-        key: local-data-${{ matrix.os }}-upstream-${{ matrix.version.upstream }}
-
-    - name: Check out message-ix-models
-      uses: francisbilham11/action-cached-lfs-checkout@v4
-      with:
-        ref: ${{ needs.check.outputs.ref }}
-
-    - name: Restore message-static-data from cache
-      uses: actions/cache/restore@v6
-      with:
-        path: message-static-data
-        key: static-data-${{ matrix.os }}
+        key: local-data-${{ runner.os }}-upstream-${{ matrix.version.upstream }}
 
     - name: Set up uv, Python
       uses: astral-sh/setup-uv@v7
@@ -246,7 +279,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-      with: { ref: "${{ needs.check.outputs.ref }}" }
+      with:
+        ref: ${{ needs.check.outputs.ref }}
+        allow-unsafe-pr-checkout: true
     - uses: astral-sh/setup-uv@v7
       with: { python-version: "${{ env.python-version }}" }
     - name: Clear and re-create the pre-commit environments

--- a/message_ix_models/testing/__init__.py
+++ b/message_ix_models/testing/__init__.py
@@ -23,6 +23,7 @@ import pytest
 import sdmx.exceptions
 from ixmp import config as ixmp_config
 from packaging.version import Version
+from requests import ReadTimeout
 
 from message_ix_models import util
 from message_ix_models.model import snapshot
@@ -131,6 +132,9 @@ MARK: dict[str, pytest.MarkDecorator | MarkFactory] = {
         condition=GHA,
         reason="https://github.com/khaeru/sdmx/issues/230",
         raises=sdmx.exceptions.XMLParseError,
+    ),
+    "zenodo_timeout": pytest.mark.xfail(
+        condition=GHA, reason="Connection to Zenodo times out", raises=ReadTimeout
     ),
 }
 MARK.update(transport.MARK)

--- a/message_ix_models/tests/tools/test_newclimate.py
+++ b/message_ix_models/tests/tools/test_newclimate.py
@@ -1,6 +1,8 @@
 import pytest
+from pytest import mark, param
 
 from message_ix_models.testing import KEY as STASH_KEY
+from message_ix_models.testing import NIE
 from message_ix_models.tools.newclimate import SECTOR, fetch, get, read
 from message_ix_models.tools.newclimate.structure import STRINGENCY
 
@@ -11,10 +13,8 @@ class TestSTRINGENCY:
         assert STRINGENCY["1"] == STRINGENCY._1
 
 
-@pytest.mark.parametrize(
-    "version",
-    ("2024", "2023", "2022", "2021", "2020", "2019"),
-)
+@mark.zenodo_timeout
+@mark.parametrize("version", ("2024", "2023", "2022", "2021", "2020", "2019"))
 def test_fetch(version: str) -> None:
     # File can be fetched
     p = fetch(version)
@@ -22,15 +22,15 @@ def test_fetch(version: str) -> None:
     assert p.exists()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "version, N_total, N_transport",
     (
-        ("2024", 6507, 1298),
-        ("2023", 6273, 1246),
-        ("2022", 5883, 1203),
-        pytest.param("2021", 1, 1, marks=pytest.mark.xfail(raises=NotImplementedError)),
-        pytest.param("2020", 1, 1, marks=pytest.mark.xfail(raises=NotImplementedError)),
-        pytest.param("2019", 1, 1, marks=pytest.mark.xfail(raises=NotImplementedError)),
+        param("2024", 6507, 1298, marks=mark.zenodo_timeout),
+        param("2023", 6273, 1246, marks=mark.zenodo_timeout),
+        param("2022", 5883, 1203, marks=mark.zenodo_timeout),
+        param("2021", 1, 1, marks=[NIE, mark.zenodo_timeout]),
+        param("2020", 1, 1, marks=[NIE, mark.zenodo_timeout]),
+        param("2019", 1, 1, marks=[NIE, mark.zenodo_timeout]),
     ),
 )
 def test_get(version: str, N_total: int, N_transport: int) -> None:
@@ -48,6 +48,7 @@ def test_get(version: str, N_total: int, N_transport: int) -> None:
     assert N_transport == N
 
 
+@mark.zenodo_timeout
 def test_read0() -> None:
     result = get("2024")
 
@@ -64,7 +65,7 @@ def test_read0() -> None:
     assert "Italy" == p.country.name
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "filename, N_total",
     (
         ("Canada_edits_additions0.csv", 18),


### PR DESCRIPTION
In #510 we see that the current config for PRs from forks can not coexist with our config to limit Git LFS bandwidth usage/associated costs.

- We use a multi-job configuration to first (in a `check` job), see whether the rest of the workflow should run at all, and if not error. See #281 and #288.
- GitHub's first-party actions/checkout introduced, in v7, an input `allow-unsafe-pr-checkout: true` that must be used in certain situations. The default of `false` is meant to protect users who don't have a config like ours.
- We have used [francisbilham11/action-cached-lfs-checkout](https://github.com/francisbilham11/action-cached-lfs-checkout/blob/main/action.yml) to avoid using Git LFS bandwidth on every job, but…
- …this action does not allow to pass the `allow-unsafe-pr-checkout: true` along to actions/checkout.

I adjust by using the steps suggested per https://github.com/actions/checkout/issues/165#issuecomment-2776048200, which is in an issue linked from the README of action-cached-lfs-checkout. In this way, we use actions/checkout directly, and can pass it the needed input.

Also:
- Mark some tests that are failing frequently because of network timeouts (perhaps rate limiting?) connecting to Zenodo.

## How to review

View [this run](https://github.com/iiasa/message-ix-models/actions/runs/33507112835) of the workflow on the "pull_request" trigger. This run was started because of the TEMPORARY commit on the branch; that commit will be dropped before merging.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only
- ~Update doc/whatsnew.~ ditto