### PR TITLE
tools/bilateralize: Update prepare_edit.py to version used for fuel security project

### DIFF
--- a/doc/api/tools-bilateralize.rst
+++ b/doc/api/tools-bilateralize.rst
@@ -30,35 +30,26 @@ in MESSAGEix. It is located in the ``message-ix-models/tools/bilateralize`` dire
 
 The tool follows the following steps, which are also available in ``tool/bilateralize/workflow.py``:
 
-Step 1 | Edit (``tools/bilateralize/prepare_edit.py``)
+Step 0 | Calculate distances (``tools/bilateralize/calculate_distance.py``)
 ======================================================
 
-The first step is to generate empty (or default valued) parameters that are required for 
-bilateralization, specified by commodity. This step requires updates to a configuration file 
-(``config.yaml``) that should be housed in a project directory 
-(e.g., ``message-ix-models/projects/newpathways-trade/config.yaml``). A template configuration 
-file is provided at ``message-ix-models/data/bilateralize/configs/base_config.yaml``. 
+This step calculates distances between regions for a given commodity.
+These distances can be differentiated between maritime and pipeline routes, as well as by commodity.
 
-Once the configuration is updated, the user can run 
-``message_ix_models.tools.bilateralize.prepare_edit.generate_edit_files(log, project_name, config_name, message_regions)`` 
-to produce empty (or default valued) parameters as CSV files. 
-These CSV files will populate in ``message-ix-models/data/[your_trade_commodity]/edit_files``. 
+The user can call :func:`~.tools.bilateralize.calculate_distance.calculate_distance` to calculate distances.
 
-The tools may stop if the user specifies in their config that they want to specify a trade network 
-(i.e., specify which regions can trade with regions). In this case, a file called ``specify_trade_network.csv`` 
-will appear in ``message-ix-models/data/bilateralize/[your_trade_commodity]/speciy_network_[your_trade_commodity].csv``.
+Functions in this step (:mod:`~.tools.bilateralize.calculate_distance`):
 
-Additional functions used here include:
+.. currentmodule:: message_ix_models.tools.bilateralize.calculate_distance
 
-- ``message_ix_models.tools.bilateralize.calculate_distance()``: 
-  Calculates the great-circle distance between regions (TODO: update this to use explicit maritime routes)
-- ``message_ix_models.tools.bilateralize.historical_calibration.build_historical_price()``: 
-  Builds historical price dataframes
-- ``message_ix_models.tools.bilateralize.mariteam_calibration.calibrate_mariteam()``: 
-  Calibrates maritime shipping (flow technologies) using MariTEAM output.
-- ``message_ix_models.tools.bilateralize.pull_gem.import_gem()``: 
-  Imports pre-downloaded raw data from the Global Energy Monitor which is used to calibrate 
-  the flow technology piped oil and gas
+.. autosummary::
+
+   haversine_distance
+   calculate_port_distances
+   calculate_distance
+   calculate_pipeline_distances
+
+.. currentmodule:: message_ix_models.tools.bilateralize
 
   **This step is not necessary for the following commodities 
   (they are already defined in ``scenario_parameters.pkl`` in 
@@ -83,6 +74,57 @@ Additional functions used here include:
   - LNG (``LNG_shipped``)
   - Methanol (``meth_shipped``)
   - Piped gas (``gas_piped``)
+
+Step 1 | Edit (``tools/bilateralize/prepare_edit.py``)
+======================================================
+
+The first step is to generate empty (or default valued) parameters that are required for 
+bilateralization, specified by commodity. This step requires updates to a configuration file 
+(``config.yaml``) that should be housed in a project directory 
+(e.g., ``message-ix-models/projects/newpathways-trade/config.yaml``). A template configuration 
+file is provided at ``message-ix-models/data/bilateralize/configs/base_config.yaml``. 
+
+Once the configuration is updated, the user can run 
+``message_ix_models.tools.bilateralize.prepare_edit.generate_edit_files(log, project_name, config_name, message_regions)`` 
+to produce empty (or default valued) parameters as CSV files. 
+These CSV files will populate in ``message-ix-models/data/[your_trade_commodity]/edit_files``. 
+
+The tools may stop if the user specifies in their config that they want to specify a trade network 
+(i.e., specify which regions can trade with regions). In this case, a file called ``specify_trade_network.csv`` 
+will appear in ``message-ix-models/data/bilateralize/[your_trade_commodity]/speciy_network_[your_trade_commodity].csv``.
+
+Functions in this step (:mod:`~.tools.bilateralize.prepare_edit`):
+
+.. currentmodule:: message_ix_models.tools.bilateralize.prepare_edit
+
+.. autosummary::
+
+   folders_for_trade
+   define_networks
+   build_parameterdf
+   build_input
+   build_output
+   build_technical_lifetime
+   build_historical_activity
+   build_costs
+   build_capacity_factor
+   build_constraints
+   build_domestic_coalgas_relation
+   build_emission_factor
+   build_accounting_relations
+   build_flow_input
+   build_flow_output
+   build_flow_capacity_constraints
+   build_flow_FIcosts
+   build_flow_Vcosts
+   build_flow_capacity_factor
+   build_flow_technical_lifetime
+   flow_as_trade_input
+   export_edit_files
+   generate_edit_files
+   prepare_edit_files
+
+.. currentmodule:: message_ix_models.tools.bilateralize
 
 Step 2 | Bare (``tools/bilateralize/bare_to_scenario``)
 =======================================================
@@ -120,18 +162,33 @@ into a dictionary of parameter dataframes that will be used to build a scenario.
 Note that this function pulls from ``bare_files`` and not ``edit_files``, so the user should ensure that 
 the right files are transferred in the previous step.
 
-Additional functions here include:
+Step 3 | Calibrate historical activity, capacity, and prices (``tools/bilateralize/historical_calibration.py``)
+=====================================================================================================
 
-``message_ix_models.tools.bilateralize.historical_calibration.build_hist_new_capacity_flow(message_regions)``: 
-Builds new capacity dataframes for historical activity of flow technologies (e.g., pipelines)
+This step calibrates historical activity, capacity, and prices for the given commodity.
 
-``message_ix_models.tools.bilateralize.historical_calibration.build_hist_new_capacity_trade(message_regions)``: 
-Builds new capacity dataframes for historical activity of trade technologies (e.g., piped gas)
+Functions in this step (:mod:`~.tools.bilateralize.historical_calibration`):
 
-``message_ix_models.tools.bilateralize.historical_calibration.build_historical_activity(message_regions)``: 
-Builds historical activity dataframes
+.. currentmodule:: message_ix_models.tools.bilateralize.historical_calibration
 
-Step 3 | Build (``tools/bilateralize/load_and_solve.py``)
+.. autosummary::
+
+   setup_datapath
+   generate_cfdict
+   import_uncomtrade
+   convert_trade
+   import_iea_gas
+   import_iea_balances
+   check_iea_balances
+   reformat_to_parameter
+   build_historical_activity
+   build_hist_new_capacity_trade
+   build_historical_price
+   build_hist_new_capacity_flow
+
+.. currentmodule:: message_ix_models.tools.bilateralize
+
+Step 4 | Build (``tools/bilateralize/load_and_solve.py``)
 =========================================================
 
 This step builds a scenario. 
@@ -142,6 +199,27 @@ This will pull the base model/scenario, clone it, remove specified trade technol
 add them back as bilateralized versions, and export to a GDX file (if specifed- the default is to not export) 
 and/or solve the scenario (default is to solve). Note that exporting to GDX means that it is not stored in the ixmp database.
 This will also optionally solve the scenario.
+
+Functions in this step (:mod:`~.tools.bilateralize.load_and_solve`):
+
+.. currentmodule:: message_ix_models.tools.bilateralize.load_and_solve
+
+.. autosummary::
+
+   remove_trade_tech
+   add_trade_sets
+   add_trade_parameters
+   update_relation_parameters
+   update_bunker_fuels
+   update_additional_parameters
+   remove_pao_coal_constraint
+   ensure_balance_equality
+   save_to_gdx
+   solve_or_save
+   load_and_clone
+   load_and_solve
+
+.. currentmodule:: message_ix_models.tools.bilateralize
 
 Reporting
 =========

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -3,7 +3,9 @@ What's new
 
 Next release
 ============
-
+- Update bugs in fix_cost and var_cost in data prepartion for trade bilateralization in module :mod:`tools.bilateralize` (:pull:`552`)
+- Add default values for emission factors in module :mod:`tools.bilateralize` (:pull:`552`)
+- Ensure commodity-specific distances are translated through data prepartion in module :mod:`tools.bilateralize` (:pull:`552`)
 - Fix import of :mod:`message_ix_models` without :mod:`plotnine` (:issue:`323`, :issue:`540`, :pull:`547`).
 - Add IAMC code list :class:`~.iamc.structure.CL_SCENARIO_DIAGNOSTIC` (:pull:`501`).
 - New module :ref:`tools-newclimate` (:pull:`499`).

--- a/message_ix_models/tests/tools/bilateralize/test_prepare_edit.py
+++ b/message_ix_models/tests/tools/bilateralize/test_prepare_edit.py
@@ -1,0 +1,218 @@
+from pathlib import Path
+
+import message_ix
+import pandas as pd
+import pytest
+
+from message_ix_models.tools.bilateralize.prepare_edit import (
+    build_accounting_relations,
+    build_flow_input,
+    build_flow_output,
+    build_flow_Vcosts,
+    flow_as_trade_input,
+)
+
+COMMON_YEARS = dict(year_vtg="broadcast", year_rel="broadcast", year_act="broadcast")
+COMMON_COLS = dict(mode="M1", time="year", time_origin="year", time_dest="year")
+
+
+@pytest.fixture
+def network_setup() -> dict:
+    df = pd.DataFrame(
+        {
+            "exporter": ["R12_AFR", "R12_CHN"],
+            "importer": ["R12_CHN", "R12_AFR"],
+            "export_technology": ["gas_pipe_exp_chn", "gas_pipe_exp_afr"],
+            "import_technology": ["gas_pipe_imp", "gas_pipe_imp"],
+        }
+    )
+    return {"gas_piped": df}
+
+
+def test_build_accounting_relations_with_emission_factor(network_setup: dict) -> None:
+    config_dict = {
+        "trade_commodity": {"gas_piped": "NG"},
+        "trade_technology": {"gas_piped": "gas_pipe"},
+        "emission_factor": {"gas_piped": {"CO2": 0.5}},
+    }
+    parameter_outputs: dict[str, dict[str, dict]] = {"gas_piped": {"trade": {}}}
+
+    build_accounting_relations(
+        tec="gas_piped",
+        network_setup=network_setup,
+        config_dict=config_dict,
+        common_years=COMMON_YEARS,
+        common_cols=COMMON_COLS,
+        parameter_outputs=parameter_outputs,
+    )
+
+    df_rel = parameter_outputs["gas_piped"]["trade"]["relation_activity_CO2_Emission"]
+
+    exports = df_rel[df_rel["technology"] != "gas_piped_imp"]
+    imports = df_rel[df_rel["technology"] == "gas_piped_imp"]
+
+    assert not exports.empty
+    assert (exports["value"] == -0.5).all()
+
+    assert not imports.empty
+    assert (imports["value"] == 0.5).all()
+
+
+def test_build_accounting_relations_without_emission_factor(
+    network_setup: dict,
+) -> None:
+    config_dict = {
+        "trade_commodity": {"gas_piped": "NG"},
+        "trade_technology": {"gas_piped": "gas_pipe"},
+        "emission_factor": {"gas_piped": {"CO2": None}},
+    }
+    parameter_outputs: dict[str, dict[str, dict]] = {"gas_piped": {"trade": {}}}
+
+    build_accounting_relations(
+        tec="gas_piped",
+        network_setup=network_setup,
+        config_dict=config_dict,
+        common_years=COMMON_YEARS,
+        common_cols=COMMON_COLS,
+        parameter_outputs=parameter_outputs,
+    )
+
+    df_rel = parameter_outputs["gas_piped"]["trade"]["relation_activity_CO2_Emission"]
+    assert (df_rel["value"] == 0).all()
+
+
+def test_build_flow_input_gas_pipe_default(network_setup: dict) -> None:
+    config_dict = {
+        "flow_fuel_input": {"gas_piped": {"gas_pipe_flow": ["electr"]}},
+        "flow_material_input": {"gas_piped": {"gas_pipe_flow": []}},
+        "flow_constraint": {"gas_piped": "bilateral"},
+        "export_level": {"gas_piped": "secondary"},
+        "bunker_technology": {"gas_piped": None},
+    }
+    parameter_outputs = {"gas_piped": {"flow": {"input": message_ix.make_df("input")}}}
+
+    build_flow_input(
+        flow_tec="gas_pipe_flow",
+        tec="gas_piped",
+        network_setup=network_setup,
+        config_dict=config_dict,
+        common_years=COMMON_YEARS,
+        common_cols=COMMON_COLS,
+        parameter_outputs=parameter_outputs,
+    )
+
+    df_input = parameter_outputs["gas_piped"]["flow"]["input"]
+    assert not df_input.empty
+    assert (df_input["value"] == 0.002).all()
+
+
+def test_build_flow_output_pipe_overrides(network_setup: dict) -> None:
+    config_dict = {
+        "flow_constraint": {"gas_piped": "bilateral"},
+        "flow_commodity_output": {"gas_piped": "NG"},
+        "flow_units": {"gas_piped": "GWa"},
+        "trade_level": {"gas_piped": "secondary"},
+        "bunker_technology": {"gas_piped": None},
+    }
+
+    values_by_flow_tec = {}
+    for flow_tec in ["gas_pipe_flow", "oil_pipe_flow", "LNG_Tanker_flow"]:
+        parameter_outputs = {"gas_piped": {"flow": {"output": pd.DataFrame()}}}
+        build_flow_output(
+            flow_tec=flow_tec,
+            tec="gas_piped",
+            network_setup=network_setup,
+            config_dict=config_dict,
+            common_years=COMMON_YEARS,
+            common_cols=COMMON_COLS,
+            parameter_outputs=parameter_outputs,
+        )
+        df_output = parameter_outputs["gas_piped"]["flow"]["output"]
+        values_by_flow_tec[flow_tec] = set(df_output["value"].unique())
+
+    assert values_by_flow_tec["gas_pipe_flow"] == {20}
+    assert values_by_flow_tec["oil_pipe_flow"] == {10}
+    assert values_by_flow_tec["LNG_Tanker_flow"] == {1}
+
+
+def test_build_flow_Vcosts_global_mode(network_setup: dict) -> None:
+    config_dict = {
+        "flow_constraint": {"gas_piped": "global"},
+        "flow_units": {"gas_piped": "GWa"},
+    }
+    parameter_outputs = {
+        "gas_piped": {"flow": {"var_cost": message_ix.make_df("var_cost")}}
+    }
+
+    build_flow_Vcosts(
+        flow_tec="gas_pipe_flow",
+        tec="gas_piped",
+        network_setup=network_setup,
+        config_dict=config_dict,
+        common_years=COMMON_YEARS,
+        common_cols=COMMON_COLS,
+        parameter_outputs=parameter_outputs,
+        message_regions="R12",
+    )
+
+    df_vcost = parameter_outputs["gas_piped"]["flow"]["var_cost"]
+    assert (df_vcost["mode"] == "M1").all()
+    # No duplicate rows after concatenation
+    assert len(df_vcost) == len(df_vcost.drop_duplicates())
+
+
+@pytest.mark.parametrize(
+    "trade_commodity, expected_filename",
+    [
+        ("LNG", "R12_LNG_distances.csv"),
+        ("coal", "R12_base_distances.csv"),
+    ],
+)
+def test_flow_as_trade_input_distance_file(
+    tmp_path: Path, network_setup: dict, trade_commodity: str, expected_filename: str
+) -> None:
+    distances_dir = tmp_path / "distances"
+    distances_dir.mkdir()
+
+    # Only create the file expected to be read; a wrong lookup fails with
+    # FileNotFoundError instead of silently reading the other file.
+    pd.DataFrame(
+        {
+            "Node1": ["R12_AFR"],
+            "Node2": ["R12_CHN"],
+            "Distance_km": [1000.0],
+        }
+    ).to_csv(distances_dir / expected_filename, index=False)
+
+    pd.DataFrame(
+        {"Commodity": [trade_commodity], "Specific Energy (GWa/Mt)": [0.5]}
+    ).to_excel(tmp_path / "specific_energy.xlsx", index=False)
+
+    config_dict = {
+        "flow_constraint": {"gas_piped": "global"},
+        "flow_commodity_output": {"gas_piped": "NG"},
+        "flow_units": {"gas_piped": "GWa"},
+        "trade_level": {"gas_piped": "secondary"},
+        "trade_units": {"gas_piped": "GWa"},
+        "trade_commodity": {"gas_piped": trade_commodity},
+        "trade_technology": {"gas_piped": "gas_pipe"},
+    }
+    parameter_outputs = {"gas_piped": {"trade": {"input": message_ix.make_df("input")}}}
+
+    flow_as_trade_input(
+        flow_tec="gas_pipe_flow",
+        tec="gas_piped",
+        network_setup=network_setup,
+        config_dict=config_dict,
+        common_years=COMMON_YEARS,
+        common_cols=COMMON_COLS,
+        parameter_outputs=parameter_outputs,
+        message_regions="R12",
+        data_path=tmp_path,
+    )
+
+    df_input = parameter_outputs["gas_piped"]["trade"]["input"]
+    matched = df_input[df_input["node_loc"] == "R12_AFR"]
+
+    # Distance (1000 km) / specific energy (0.5 GWa/Mt) = 2000
+    assert (matched["value"] == 2000).all()

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -491,9 +491,26 @@ def build_accounting_relations(
         **common_years,
         **common_cols,
     )
-    df_rel = df_rel.drop_duplicates()
+    df_rel_exports = df_rel.copy().drop_duplicates()
 
-    parameter_outputs[tec]["trade"]["relation_activity_CO2_Emission"] = df_rel
+    df_rel_imports = df_rel.copy().drop_duplicates()
+    df_rel_imports["technology"] = tec + "_imp"
+    df_rel_imports = df_rel_imports.drop_duplicates()
+
+    if config_dict["emission_factor"][tec] is not None:
+        emission_factor = config_dict["emission_factor"][tec]["CO2"]
+        if emission_factor is not None:
+            df_rel_exports["value"] = emission_factor * -1
+            df_rel_imports["value"] = emission_factor
+        else:
+            df_rel_exports["value"] = 0
+            df_rel_imports["value"] = 0
+
+    df_rel = pd.concat([df_rel_exports, df_rel_imports])
+
+    parameter_outputs[tec]["trade"]["relation_activity_CO2_Emission"] = (
+        df_rel.drop_duplicates()
+    )
 
     # Primary energy total
     df_rel = message_ix.make_df(
@@ -1083,6 +1100,7 @@ def export_edit_files(
             os.path.join(
                 "relation_activity_regional_exp.csv"
             ),  # necessary for legacy reporting
+            os.path.join("relation_activity_CO2_Emission.csv"),
             os.path.join("flow_technology", "capacity_factor.csv"),
             os.path.join("flow_technology", "input.csv"),
             os.path.join("flow_technology", "output.csv"),

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -1378,10 +1378,10 @@ def prepare_edit_files(
         costdf["technology"] = costdf["technology"].str.replace("ethanol_", "eth_")
         costdf["technology"] = costdf["technology"].str.replace("fueloil_", "foil_")
 
-        for tec in [i for i in covered_tec if i != "gas_piped"]:
+        for tec in covered_tec:
             log.info("Add fix cost for " + tec)
 
-            if "piped" in tec:
+            if "piped" in tec and tec != "gas_piped":
                 tec_shipped = tec.replace("piped", "shipped")
                 add_df = costdf[costdf["technology"].str.contains(tec_shipped)].copy()
                 add_df["technology"] = add_df["technology"].str.replace(
@@ -1419,7 +1419,7 @@ def prepare_edit_files(
             add_df["value"] = np.where(
                 add_df["value"].isnull(), mean_cost, add_df["value"]
             )
-            add_df["value"] = round(add_df["value"] / 5, 0)
+            add_df["value"] = round(add_df["value"], 0)
 
             add_df["unit"] = "USD/GWa"
 

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -35,7 +35,10 @@ from message_ix_models.util import package_data_path
 # %% Generate folders if missing
 def folders_for_trade(covered_tec: list[str]):
     """
-    Generate folders for each trade technology
+    Generate folders for each trade technology.
+
+    Args:
+        covered_tec: Trade technologies covered by the current project config
     """
     for tec in covered_tec:
         tecpath = os.path.join(Path(package_data_path("bilateralize")), tec)
@@ -60,10 +63,16 @@ def define_networks(
     data_path: Path,
 ):
     """
-    Define network dataframe
+    Define network dataframe.
 
     Args:
+        log: Logger
         message_regions: Regional resolution
+        covered_tec: Trade technologies covered by the current project config
+        config_dict: Config dictionary, keyed by config field then by technology
+        data_path: Path to the bilateralize data directory
+    Returns:
+        network_setup: Dictionary of network dataframes, keyed by technology
     """
     # Generate full combination of nodes to build technology-specific network
     node_path = package_data_path("node", message_regions + ".yaml")
@@ -160,7 +169,14 @@ def build_parameterdf(
         par_name: Parameter name (e.g., capacity_factor)
         network_df: Specified network dataframe
         col_values: Values for other columns to populate as default
+        common_years: Common year-related column values (year_vtg, year_act,
+            year_rel); if None, all set to "broadcast"
+        common_cols: Common column values (mode, time, time_origin, time_dest);
+            if None, defaults to M1/year
         export_only: If True, only produces dataframe for export technology
+    Returns:
+        df: Parameter dataframe for the export (and, unless `export_only`, import)
+            technology
     """
 
     if common_years is None:
@@ -204,7 +220,18 @@ def build_input(
     parameter_outputs: dict,
 ):
     """
-    Generate input parameter (trade technology)
+    Generate input parameter (trade technology).
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     # Trade Level (supply to piped/shipped)
     df_input_trade = message_ix.make_df(
@@ -251,7 +278,18 @@ def build_output(
     parameter_outputs: dict,
 ):
     """
-    Generate output parameter (trade technology)
+    Generate output parameter (trade technology).
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     # Trade Level
     df_output_trade = message_ix.make_df(
@@ -293,7 +331,15 @@ def build_technical_lifetime(
     tec: str, network_setup: dict, parameter_outputs: dict, **kwargs
 ):
     """
-    Generate technical lifetime parameter (trade technology)
+    Generate technical lifetime parameter (trade technology).
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_teclt = build_parameterdf(
         "technical_lifetime",
@@ -314,7 +360,16 @@ def build_historical_activity(
     tec: str, network_setup: dict, config_dict: dict, parameter_outputs: dict, **kwargs
 ):
     """
-    Generate costs for trade technology
+    Generate historical activity parameter (trade technology).
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_hist = pd.DataFrame()
 
@@ -337,7 +392,16 @@ def build_costs(
     tec: str, network_setup: dict, config_dict: dict, parameter_outputs: dict, **kwargs
 ):
     """
-    Generate costs for trade technology
+    Generate costs for trade technology.
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     # Create base files: inv_cost, fix_cost, var_cost
     for cost_par in ["inv_cost", "fix_cost", "var_cost"]:
@@ -356,7 +420,16 @@ def build_capacity_factor(
     tec: str, network_setup: dict, config_dict: dict, parameter_outputs: dict, **kwargs
 ):
     """
-    Generate capacity factor parameter (trade technology)
+    Generate capacity factor parameter (trade technology).
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_cf = build_parameterdf(
         "capacity_factor",
@@ -374,7 +447,16 @@ def build_constraints(
     tec: str, network_setup: dict, config_dict: dict, parameter_outputs: dict, **kwargs
 ):
     """
-    Generate constraints for trade technology
+    Generate constraints for trade technology.
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     for par_name in [
         "initial_activity",
@@ -418,7 +500,20 @@ def build_domestic_coalgas_relation(
     **kwargs,
 ):
     """
-    Generate domestic coal and gas relation parameter (trade technology)
+    Generate domestic coal and gas relation parameter (trade technology).
+
+    Only applies to the ``gas_piped`` technology.
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     if tec in ["gas_piped"]:
         for rel_act in ["domestic_coal", "domestic_gas"]:
@@ -446,7 +541,16 @@ def build_emission_factor(
     tec: str, network_setup: dict, config_dict: dict, parameter_outputs: dict, **kwargs
 ):
     """
-    Generate emission factor parameter (trade technology)
+    Generate emission factor parameter (trade technology).
+
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     if config_dict["tracked_emissions"][tec] is not None:
         df_ef = pd.DataFrame()
@@ -476,8 +580,18 @@ def build_accounting_relations(
     """
     Relations for accounting purposes:
     CO2 emissions, primary energy total, aggregate exports,
-    regional exports, regional imports
+    regional exports, regional imports.
 
+    Args:
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     # CO2 emissions
     df_rel = message_ix.make_df(
@@ -598,7 +712,20 @@ def build_flow_input(
     **kwargs,
 ):
     """
-    Generate flow technology input parameter
+    Generate flow technology input parameter.
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+        message_regions: MESSAGE regional resolution (e.g., "R12")
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_input = pd.DataFrame()
     # List of commodity/material inputs
@@ -684,7 +811,20 @@ def build_flow_output(
     **kwargs,
 ):
     """
-    Generate flow technology output parameter
+    Generate flow technology output parameter.
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+        message_regions: MESSAGE regional resolution (e.g., "R12")
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_output = pd.DataFrame()
     # If pipelines technologies and outputs are bilateral
@@ -766,7 +906,20 @@ def build_flow_capacity_constraints(
     **kwargs,
 ):
     """
-    Generate flow technology capacity constraints parameter
+    Generate flow technology capacity constraints parameter.
+
+    Args:
+        par: Constraint parameter name (e.g., "growth_new_capacity")
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     for t in ["lo", "up"]:
         if config_dict["flow_constraint"][tec] == "bilateral":
@@ -808,7 +961,19 @@ def build_flow_FIcosts(
     **kwargs,
 ):
     """
-    Generate flow technology costs parameter
+    Generate flow technology costs parameter (fix and investment costs).
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     for cost_par in ["fix_cost", "inv_cost"]:
         if config_dict["flow_constraint"][tec] == "bilateral":
@@ -857,7 +1022,20 @@ def build_flow_Vcosts(
     **kwargs,
 ):
     """
-    Generate flow technology variable costs parameter
+    Generate flow technology variable costs parameter.
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+        message_regions: MESSAGE regional resolution (e.g., "R12")
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     if config_dict["flow_constraint"][tec] == "bilateral":
         tec_use = (
@@ -907,7 +1085,19 @@ def build_flow_capacity_factor(
     **kwargs,
 ):
     """
-    Generate flow technology capacity factor parameter
+    Generate flow technology capacity factor parameter.
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_cf_base = build_parameterdf(
         "capacity_factor",
@@ -951,7 +1141,19 @@ def build_flow_technical_lifetime(
     **kwargs,
 ):
     """
-    Generate flow technology technical lifetime parameter
+    Generate flow technology technical lifetime parameter.
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     df_teclt_base = build_parameterdf(
         "technical_lifetime",
@@ -1004,7 +1206,28 @@ def flow_as_trade_input(
     commodity_specific_distances: list[str] = ["crudeoil", "lightoil", "LNG"],
 ):
     """
-    Generate flow technology as trade technology input parameter
+    Generate flow technology as trade technology input parameter.
+
+    For shipped commodities, the input value is scaled by distance and energy
+    content, using distance data specific to the technology's commodity (for
+    those in `commodity_specific_distances`) or a base distance file otherwise.
+
+    Args:
+        flow_tec: Flow technology name (e.g., "gas_pipe")
+        tec: Technology name
+        network_setup: Dictionary of network dataframes, as produced by
+            `define_networks`
+        config_dict: Config dictionary, keyed by config field then by technology
+        common_years: Common year-related column values
+        common_cols: Common column values
+        parameter_outputs: Dictionary of parameter dataframes being built up
+        message_regions: MESSAGE regional resolution (e.g., "R12")
+        data_path: Path to the bilateralize data directory
+        commodity_specific_distances: Trade commodities for which a
+            commodity-specific distance file exists; other commodities fall
+            back to the base distance file
+    Returns:
+        parameter_outputs: Updated dictionary of parameter dataframes
     """
     if config_dict["flow_constraint"][tec] == "bilateral":
         df_input_flow = message_ix.make_df(
@@ -1089,7 +1312,15 @@ def export_edit_files(
     parameter_outputs: dict,
 ):
     """
-    Export edit files
+    Write edit files to CSV, and copy required parameters to bare files that
+    do not already exist.
+
+    Args:
+        covered_tec: Trade technologies covered by the current project config
+        log: Logger
+        data_path: Path to the bilateralize data directory
+        parameter_outputs: Dictionary of parameter dataframes, keyed by
+            technology
     """
     for tec in covered_tec:
         log.info(f"Exporting trade parameters for {tec}")
@@ -1155,14 +1386,14 @@ def generate_edit_files(
     message_regions: str = "R12",
 ):
     """
-    Generate bare sheets to collect required parameters
+    Generate bare sheets to collect required parameters.
 
     Args:
-        log (log, required): Log file to track progress
-        project_name (str, optional): Project name (message_ix_models/project/[THIS])
-        config_name (str, optional): Name of the config file.
+        log: Logger
+        project_name: Name of the project (message_ix_models/project/[THIS])
+        config_name: Name of the config file.
             If None, uses default config from data/bilateralize/config_default.yaml
-        message_regions (str, optional): Default is R12 regionality
+        message_regions: MESSAGE regional resolution (e.g., "R12")
     """
     data_path = package_data_path("bilateralize")
     data_path = Path(os.path.join(os.path.dirname(data_path), "bilateralize"))

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -629,6 +629,8 @@ def build_flow_input(
                 **common_years,
                 **common_cols,
             )
+            if "gas_pipe" in tec:
+                df_input_base["value"] = 0.002
             df_input = pd.concat([df_input, df_input_base])
 
         # If shipping, technologies and outputs are global with diff modes
@@ -737,7 +739,14 @@ def build_flow_output(
 
     df_output = df_output.drop_duplicates()
 
-    df_output["value"] = 1
+    df_output["value"] = 1  # For shipping
+    df_output["value"] = np.where(
+        df_output["technology"].str.contains("gas_pipe_"), 20, df_output["value"]
+    )
+    df_output["value"] = np.where(
+        df_output["technology"].str.contains("oil_pipe_"), 10, df_output["value"]
+    )
+
     output_out = pd.concat([parameter_outputs[tec]["flow"]["output"], df_output])
     parameter_outputs[tec]["flow"]["output"] = output_out
 

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -1001,6 +1001,7 @@ def flow_as_trade_input(
     parameter_outputs: dict,
     message_regions: str,
     data_path: Path,
+    commodity_specific_distances: list[str] = ["crudeoil", "lightoil", "LNG"],
 ):
     """
     Generate flow technology as trade technology input parameter
@@ -1033,9 +1034,19 @@ def flow_as_trade_input(
         ).drop_duplicates()
 
     # For shipped commodities calculate capacities based on distance & energy content
-    distance_df = pd.read_csv(
-        os.path.join(data_path, "distances", message_regions + "_distances.csv")
-    )
+    if config_dict["trade_commodity"][tec] in commodity_specific_distances:
+        c = config_dict["trade_commodity"][tec]
+        distance_df = pd.read_csv(
+            os.path.join(
+                data_path, "distances", message_regions + f"_{c}_distances.csv"
+            )
+        )
+    else:
+        distance_df = pd.read_csv(
+            os.path.join(
+                data_path, "distances", message_regions + "_base_distances.csv"
+            )
+        )
     energycontent_df = pd.read_excel(os.path.join(data_path, "specific_energy.xlsx"))
     if config_dict["trade_units"][tec] == "GWa":
         tradecom = config_dict["trade_commodity"][tec]

--- a/message_ix_models/tools/bilateralize/prepare_edit.py
+++ b/message_ix_models/tools/bilateralize/prepare_edit.py
@@ -875,14 +875,10 @@ def build_flow_Vcosts(
         )
 
     elif config_dict["flow_constraint"][tec] == "global":
-        exp0 = network_setup[tec]["exporter"].str.replace(message_regions + "_", "")
-        imp0 = network_setup[tec]["importer"].str.replace(message_regions + "_", "")
-        mode_use = exp0 + "-" + imp0
-
         df_vcost_base = message_ix.make_df(
             "var_cost",
             node_loc=network_setup[tec]["exporter"],
-            mode=mode_use,
+            mode="M1",
             technology=flow_tec,
             unit="USD/" + config_dict["flow_units"][tec],
             time="year",
@@ -891,7 +887,9 @@ def build_flow_Vcosts(
     if "shipped" in tec:
         df_vcost_base["value"] = 0.002  # Default is 0.002 USD/Mt-km
 
-    vcost_out = pd.concat([parameter_outputs[tec]["flow"]["var_cost"], df_vcost_base])
+    vcost_out = pd.concat(
+        [parameter_outputs[tec]["flow"]["var_cost"], df_vcost_base]
+    ).drop_duplicates()
     parameter_outputs[tec]["flow"]["var_cost"] = vcost_out
 
     return parameter_outputs


### PR DESCRIPTION
### Update prepare_edit.py with features necessary for fuel security analysis
This PR includes 5 features that were identified through fuel security analysis, including CO2 relation activities, pipeline cost updates, and commodity-specific distances.

More specifically:
* Adds default values for CO2 relation activity in bilateral trade format
* The input coefficient for pipelines so that the energy requirement is 0.002GWa/km and the output is based on assumed pipeline capacity service
* Assume mode of "M1" for all cost parameters (in this case fixed for var_cost)
* Make sure that commodity-specific distances are translated to prepare_edit.py from calculate_distance.py
* Ensure that fix_costs are applied to gas pipelines by default (and they are not discounted)

## How to review

- Read the diff and note that the CI checks all pass (note that some checks appear to fail due to a Zenodo issue)
- Ensure that the tests cover patch

## PR checklist
- [ ]  Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.