### PR TITLE
Add workflow_dispatch trigger to "pytest" workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -9,6 +9,7 @@ on:
     types: [ labeled, opened, reopened, synchronize ]
   schedule:
   - cron: "0 5 * * *"  # = 06:00 CET = 07:00 CEST
+  workflow_dispatch: {}
 
 # Cancel previous runs that have not completed
 concurrency:
@@ -33,6 +34,7 @@ jobs:
     - if: >
         !(
           github.event_name == 'schedule'
+          || github.event_name == 'workflow_dispatch'
           || github.repository == github.event.pull_request.head.repo.full_name
           || contains(github.event.pull_request.labels.*.name, env.label)
         )


### PR DESCRIPTION
This allows for those with maintainer access to trigger a run of the workflow on the `main` branch, using the `gh` command-line tool (`gh workflow run pytest.yaml`) or the GitHub web interface.

This is a follow-up/addition to #550. Once that PR branch was merged, the workflow was not automatically run on `main`, and so the caches created could not be used in runs of e.g. #510.

## How to review

View [this run](https://github.com/iiasa/message-ix-models/actions/runs/33522931509) created from the PR branch using `gh workflow run pytest.yaml --ref ci/workflow-dispatch-trigger`.

<!--
**Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
If no review is required, write “No review:” and describe why.

For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Look at a certain page in the ReadTheDocs preview build of the documentation.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

- ~Continuous integration checks all ✅~ N/A; CI changes only
- ~Add or expand tests;~ coverage checks both ✅~ ditto
- ~Add, expand, or update documentation.~ ditto
- ~Update doc/whatsnew.~ ditto