### PR TITLE
Accept a caller-supplied spec and data in .bare.create_res

### DIFF
--- a/doc/api/model.rst
+++ b/doc/api/model.rst
@@ -43,6 +43,7 @@ Submodules described on separate pages:
       generate_product
       generate_set_elements
       get_codes
+      get_parent_region
       get_region_codes
       process_units_anno
       process_commodity_codes

--- a/doc/pkg-data/node.rst
+++ b/doc/pkg-data/node.rst
@@ -94,6 +94,38 @@ Israel (``ISR``)
 .. literalinclude:: ../../message_ix_models/data/node/ISR.yaml
    :language: yaml
 
+.. _CA:
+
+Central Asia (``CA``)
+---------------------
+
+.. literalinclude:: ../../message_ix_models/data/node/CA.yaml
+   :language: yaml
+
+.. _EE:
+
+Eastern Europe (``EE``)
+-----------------------
+
+.. literalinclude:: ../../message_ix_models/data/node/EE.yaml
+   :language: yaml
+
+.. _MED:
+
+Mediterranean (``MED``)
+-----------------------
+
+.. literalinclude:: ../../message_ix_models/data/node/MED.yaml
+   :language: yaml
+
+.. _SEE:
+
+South-Eastern Europe (``SEE``)
+------------------------------
+
+.. literalinclude:: ../../message_ix_models/data/node/SEE.yaml
+   :language: yaml
+
 .. _ZMB:
 
 Zambia (``ZMB``)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- :func:`.bare.create_res` accepts a caller-supplied spec and data (:pull:`559`).
 - Support the 2025 edition of the Climate Policy Database in :mod:`.tools.newclimate` (:pull:`560`).
 - Fix import of :mod:`message_ix_models` without :mod:`plotnine` (:issue:`323`, :issue:`540`, :pull:`547`).
 - Add IAMC code list :class:`~.iamc.structure.CL_SCENARIO_DIAGNOSTIC` (:pull:`501`).

--- a/message_ix_models/data/node/CA.yaml
+++ b/message_ix_models/data/node/CA.yaml
@@ -1,0 +1,15 @@
+# Codes for the "node" dimension of a Central Asia model
+#
+# Member countries are the Central Asia grouping of the Organization for Security
+# and Co-operation in Europe. The region is resolved as a single node. Which
+# member supplies input data is a property of the model that uses this list;
+# resolving the region into one node per member is a change to this file.
+
+World:
+  name: World
+  description: Central Asia model regions
+
+CA:
+  name: Central Asia
+  parent: World
+  child: [KAZ, KGZ, TJK, TKM, UZB]

--- a/message_ix_models/data/node/EE.yaml
+++ b/message_ix_models/data/node/EE.yaml
@@ -1,0 +1,15 @@
+# Codes for the "node" dimension of an Eastern Europe model
+#
+# Member countries are the Eastern Europe grouping of the Organization for
+# Security and Co-operation in Europe. The region is resolved as a single node.
+# Which member supplies input data is a property of the model that uses this
+# list; resolving the region into one node per member is a change to this file.
+
+World:
+  name: World
+  description: Eastern Europe model regions
+
+EE:
+  name: Eastern Europe
+  parent: World
+  child: [MDA, UKR]

--- a/message_ix_models/data/node/MED.yaml
+++ b/message_ix_models/data/node/MED.yaml
@@ -1,0 +1,15 @@
+# Codes for the "node" dimension of a Mediterranean model
+#
+# Member countries are the Mediterranean grouping of the Organization for
+# Security and Co-operation in Europe. The region is resolved as a single node.
+# Which member supplies input data is a property of the model that uses this
+# list; resolving the region into one node per member is a change to this file.
+
+World:
+  name: World
+  description: Mediterranean model regions
+
+MED:
+  name: Mediterranean
+  parent: World
+  child: [DZA, JOR]

--- a/message_ix_models/data/node/SEE.yaml
+++ b/message_ix_models/data/node/SEE.yaml
@@ -1,0 +1,15 @@
+# Codes for the "node" dimension of a South-Eastern Europe model
+#
+# Member countries are the South-Eastern Europe grouping of the Organization for
+# Security and Co-operation in Europe. The region is resolved as a single node.
+# Which member supplies input data is a property of the model that uses this
+# list; resolving the region into one node per member is a change to this file.
+
+World:
+  name: World
+  description: South-Eastern Europe model regions
+
+SEE:
+  name: South-Eastern Europe
+  parent: World
+  child: [ALB, BIH, MKD, MNE, SRB]

--- a/message_ix_models/model/bare.py
+++ b/message_ix_models/model/bare.py
@@ -30,7 +30,7 @@ SETTINGS = dict(
 )
 
 
-def create_res(context, quiet=True):
+def create_res(context, quiet=True, *, spec=None, data=None):
     """Create a 'bare' MESSAGEix-GLOBIOM reference energy system (RES).
 
     Parameters
@@ -43,17 +43,23 @@ def create_res(context, quiet=True):
         - Scenario name "baseline".
     quiet : bool, optional
         Passed to `quiet` argument of :func:`.build.apply_spec`.
+    spec : .Spec, optional
+        Structural specification. The default is :func:`get_spec`.
+    data : callable, optional
+        Parameter-data callback passed to :func:`.apply_spec`. The default is
+        :func:`.model.data.get_data`.
 
     Returns
     -------
     message_ix.Scenario
-        A scenario as described by :func:`.bare.get_spec`, prepared using
-        :func:`.apply_spec`.
+        A scenario as described by `spec`, prepared using :func:`.apply_spec`.
     """
     mp = context.get_platform()
 
-    # Retrieve the spec; this also sets defaults expected by name()
-    spec = get_spec(context)
+    # Both name() and get_spec() read context.model
+    context.setdefault("model", Config())
+    spec = spec or get_spec(context)
+    data = data or partial(get_data, context=context, spec=spec)
 
     # Model and scenario name for the RES
     args = dict(
@@ -79,7 +85,7 @@ def create_res(context, quiet=True):
     apply_spec(
         scenario,
         spec,
-        data=partial(get_data, context=context, spec=spec),
+        data=data,
         quiet=quiet,
         message=f"Create using message-ix-models {message_ix_models.__version__}",
     )

--- a/message_ix_models/model/structure.py
+++ b/message_ix_models/model/structure.py
@@ -108,6 +108,24 @@ def get_region_codes(codelist: str) -> list[Code]:
     return nodes[nodes.index(Code(id="World"))].child
 
 
+def get_parent_region(codelist: str, country: str) -> Code:
+    """Return the region in `codelist` of which `country` is a child.
+
+    For instance, :py:`get_parent_region("R12", "KAZ")` returns the code for "R12_FSU".
+    This is the region whose values a single-country model of `country` inherits from a
+    model with the regions of `codelist`.
+
+    Raises
+    ------
+    ValueError
+        if `country` is a child of no region in `codelist`.
+    """
+    for code in get_region_codes(codelist):
+        if country in map(str, code.child):
+            return code
+    raise ValueError(f"{country!r} is a child of no region in node/{codelist}")
+
+
 def generate_product(
     data: Mapping, name: str, template: Code
 ) -> tuple[list[Code], dict[str, xr.DataArray]]:

--- a/message_ix_models/testing/check.py
+++ b/message_ix_models/testing/check.py
@@ -172,11 +172,26 @@ class Dump(Check):
 
 @dataclass
 class HasCoords(Check):
-    """Object has/omits certain coordinates."""
+    """Object has/omits certain coordinates.
 
-    coords: dict[str, Collection[Hashable]]
+    By default, the object must have every label in :attr:`coords` on each dimension.
+    With :attr:`inverse`, it must have none of them; with :attr:`subset`, it must have
+    no label outside them, for instance when parameter data must not introduce labels
+    beyond a declared set. The two are exclusive.
+    """
+
+    coords: Mapping[str, Collection[Hashable]]
     inverse: bool = False
+    subset: bool = False
+    #: Compare labels as :class:`str`, for instance when :attr:`coords` gives years as
+    #: strings and the object holds them as integers.
+    as_str: bool = False
     types = (dict, pd.DataFrame, genno.Quantity)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.inverse and self.subset:
+            raise ValueError("HasCoords(inverse=True, subset=True) is contradictory")
 
     def run(self, obj):
         if isinstance(obj, dict):
@@ -196,11 +211,22 @@ class HasCoords(Check):
             if dim not in coords:
                 continue
             d, exp, obs = f"Dimension {dim!r}", set(v), coords[dim]
+            if self.as_str:
+                exp, obs = set(map(str, exp)), set(map(str, obs))
 
-            if not self.inverse and not exp <= obs:
-                result = False
-                message.append(f"{d} is missing coords {exp - obs}")
-            elif self.inverse and not exp.isdisjoint(obs):
+            if self.subset:
+                if not obs <= exp:
+                    result = False
+                    message.append(f"{d} has unexpected coords {obs - exp}")
+                else:
+                    message.append(f"{d} has {len(obs)} allowed coords")
+            elif not self.inverse:
+                if not exp <= obs:
+                    result = False
+                    message.append(f"{d} is missing coords {exp - obs}")
+                else:
+                    message.append(f"{d} has {len(exp)}/{len(exp)} expected coords")
+            elif not exp.isdisjoint(obs):
                 result = False
                 message.append(f"{d} has unexpected coords {exp ^ obs}")
             else:

--- a/message_ix_models/tests/model/test_bare.py
+++ b/message_ix_models/tests/model/test_bare.py
@@ -1,5 +1,6 @@
 import message_ix
 import pytest
+from message_ix import make_df
 
 from message_ix_models import testing
 from message_ix_models.model.bare import Config
@@ -26,6 +27,11 @@ SET_SIZE = dict(
         (dict(regions="RCP"), dict(node=5 + 1)),
         # MESSAGE-IL
         (dict(regions="ISR"), dict(node=1 + 1)),
+        # One region, resolved as a single node
+        (dict(regions="CA"), dict(node=1 + 1)),
+        (dict(regions="EE"), dict(node=1 + 1)),
+        (dict(regions="MED"), dict(node=1 + 1)),
+        (dict(regions="SEE"), dict(node=1 + 1)),
         #
         # Different time periods
         (dict(years="A"), dict(year=16)),  # ..., 2010, 2020, ..., 2110
@@ -59,6 +65,35 @@ def test_create_res(request, test_context, settings, expected):
     for name, size in sets.items():
         values = scenario.set(name)
         assert size == len(values), (name, values)
+
+
+def test_create_res_spec_data(test_context):
+    """A caller can supply the structure and the parameter data."""
+    from message_ix_models.model.bare import create_res, get_spec
+
+    test_context.model = Config(regions="SEE", years="B")
+    spec = get_spec(test_context)
+    # Reduce the structure: a single technology
+    spec.add.set["technology"] = spec.add.set["technology"][:1]
+
+    demand = make_df(
+        "demand",
+        node="SEE",
+        commodity=str(spec.add.set["commodity"][0]),
+        level=str(spec.add.set["level"][0]),
+        year=spec.add.set["year"][-1],
+        time="year",
+        value=1.0,
+        unit="GWa",
+    )
+
+    def data(scenario, dry_run=False):
+        return dict(demand=demand)
+
+    scenario = create_res(test_context, spec=spec, data=data)
+
+    assert 1 == len(scenario.set("technology"))
+    assert 1 == len(scenario.par("demand"))
 
 
 class TestConfig:

--- a/message_ix_models/tests/model/test_structure.py
+++ b/message_ix_models/tests/model/test_structure.py
@@ -12,6 +12,7 @@ from message_ix_models.model.structure import (
     codelists,
     generate_set_elements,
     get_codes,
+    get_parent_region,
     get_region_codes,
     process_commodity_codes,
     process_units_anno,
@@ -27,7 +28,10 @@ from message_ix_models.util import as_codes
             {
                 "ADVANCE",
                 "B210-R11",
+                "CA",
+                "EE",
                 "ISR",
+                "MED",
                 "R11",
                 "R12",
                 "R14",
@@ -35,6 +39,7 @@ from message_ix_models.util import as_codes
                 "R20",
                 "R32",
                 "RCP",
+                "SEE",
                 "ZMB",
             },
         ),
@@ -208,6 +213,22 @@ class TestGetCodes:
         elec_exp = data[data.index("elec_exp")]
         assert False is eval(str(elec_exp.get_annotation(id="vintaged").text))
 
+    @pytest.mark.parametrize(
+        "codelist, members",
+        [
+            ("CA", {"KAZ", "KGZ", "TJK", "TKM", "UZB"}),
+            ("EE", {"MDA", "UKR"}),
+            ("MED", {"DZA", "JOR"}),
+            ("SEE", {"ALB", "BIH", "MKD", "MNE", "SRB"}),
+        ],
+    )
+    def test_node_one_region(self, codelist, members):
+        """One-region node code lists have the expected region and members."""
+        (region,) = get_region_codes(codelist)
+
+        assert codelist == region.id
+        assert members == set(map(str, region.child))
+
     @pytest.mark.parametrize("codelist, length", [("A", 16), ("B", 28)])
     def test_year(self, codelist, length):
         """Year code lists can be loaded and contain the correct number of codes.
@@ -219,6 +240,14 @@ class TestGetCodes:
 
         # List contains the expected number of codes
         assert len(data) == length
+
+
+def test_get_parent_region():
+    assert "R12_FSU" == get_parent_region("R12", "KAZ").id
+    assert "R11_EEU" == get_parent_region("R11", "SRB").id
+
+    with pytest.raises(ValueError, match="child of no region"):
+        get_parent_region("R12", "XXX")
 
 
 def test_cli_techs(session_context, mix_models_cli):

--- a/message_ix_models/tests/testing/test_check.py
+++ b/message_ix_models/tests/testing/test_check.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 import pytest
 
-from message_ix_models.testing.check import NoDuplicates
+from message_ix_models.testing.check import HasCoords, NoDuplicates
 
 if TYPE_CHECKING:
     from message_ix_models.types import ParameterData
@@ -39,3 +39,25 @@ FAIL: 1 parameters
 
         # Log messages contain further details
         assert "    x   y  value\n1  x1  y1    2.0" == caplog.messages[0]
+
+
+def test_has_coords_subset():
+    """Subset mode accepts only labels from the declared coordinate set."""
+    check = HasCoords({"node": ["World", "KAZ"]}, subset=True)
+
+    assert check.run(pd.DataFrame({"node": ["KAZ"], "value": [1.0]}))[0]
+    result = check.run(pd.DataFrame({"node": ["XXX"], "value": [1.0]}))
+    assert not result[0]
+    assert "unexpected coords {'XXX'}" in result[1]
+
+    with pytest.raises(ValueError, match="contradictory"):
+        HasCoords({"node": []}, inverse=True, subset=True)
+
+
+def test_has_coords_as_str():
+    """Integer year labels match declared strings only when compared as strings."""
+    coords = {"year": ["2020", "2030"]}
+    df = pd.DataFrame({"year": [2020], "value": [1.0]})
+
+    assert not HasCoords(coords, subset=True).run(df)[0]
+    assert HasCoords(coords, subset=True, as_str=True).run(df)[0]


### PR DESCRIPTION
In the spirit of #551, this PR lets create_res() build a reference energy system from any Spec and any parameter-data callback, so the same function serves a global model and a single-region model built from its own inputs. 

Additionally this PR adds one-region node code lists for the four CAEECRES(OSCE) regional groupings, each resolving its region as a single node whose members are the countries of the grouping; 

## How to review
Drafting so this is part of the OSCE PR stack. 
- Read the diff and note that the CI checks all pass.
- Ensure that changes/additions are self-documenting. 


## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update doc/whatsnew.

