### PR TITLE
Support the 2025 edition of the Climate Policy Database

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,6 +4,7 @@ What's new
 Next release
 ============
 
+- Support the 2025 edition of the Climate Policy Database in :mod:`.tools.newclimate` (:pull:`560`).
 - Fix import of :mod:`message_ix_models` without :mod:`plotnine` (:issue:`323`, :issue:`540`, :pull:`547`).
 - Add IAMC code list :class:`~.iamc.structure.CL_SCENARIO_DIAGNOSTIC` (:pull:`501`).
 - New module :ref:`tools-newclimate` (:pull:`499`).

--- a/message_ix_models/tests/tools/test_newclimate.py
+++ b/message_ix_models/tests/tools/test_newclimate.py
@@ -14,7 +14,7 @@ class TestSTRINGENCY:
 
 
 @mark.zenodo_timeout
-@mark.parametrize("version", ("2024", "2023", "2022", "2021", "2020", "2019"))
+@mark.parametrize("version", ("2025", "2024", "2023", "2022", "2021", "2020", "2019"))
 def test_fetch(version: str) -> None:
     # File can be fetched
     p = fetch(version)
@@ -25,6 +25,7 @@ def test_fetch(version: str) -> None:
 @mark.parametrize(
     "version, N_total, N_transport",
     (
+        param("2025", 6727, 1342, marks=mark.zenodo_timeout),
         param("2024", 6507, 1298, marks=mark.zenodo_timeout),
         param("2023", 6273, 1246, marks=mark.zenodo_timeout),
         param("2022", 5883, 1203, marks=mark.zenodo_timeout),

--- a/message_ix_models/tools/newclimate/__init__.py
+++ b/message_ix_models/tools/newclimate/__init__.py
@@ -29,18 +29,18 @@ These enable programmatic use of the information in the database. For example:
    from message_ix_models.tools.newclimate import SECTOR, get
    from pycountry import countries
 
-   # Fetch and parse the 2024 edition of the database
-   policies = get("2024")
-   print(len(policies))  # 6507 objects
+   # Fetch and parse the 2025 edition of the database
+   policies = get("2025")
+   print(len(policies))  # 6727 objects
 
    # Filter the dict to a list of policy objects matching a certain sector
    p_transport = list(filter(lambda p: SECTOR.Transport in p.sector, policies.values()))
-   print(len(p_transport))  # 1298 objects
+   print(len(p_transport))  # 1342 objects
 
    # Filter for any policies concerning the country of Austria, or the EU
    match = {pycountry.lookup("Austria"), "European Union"}
    p_AUT = list(filter(lambda p: set(p.geo) & match, policies.values()))
-   print(len(p_AUT)))  # 259 objects
+   print(len(p_AUT)))  # 262 objects
 
 .. todo:: Extend the module:
 
@@ -91,6 +91,16 @@ log = logging.getLogger(__name__)
 
 #: Pooch information for fetching files from the static version of the database.
 SOURCE = {  # noqa: E501
+    "newclimate-2025": dict(
+        pooch_args=dict(
+            base_url="doi:10.5281/zenodo.19682932",
+            registry={
+                "ClimatePolicyDatabase_v2025.csv": (
+                    "sha256:77ceb6959afb7c150f3421945da9917d51ed667825a7fbf3be09d4dc1a2032a4"
+                ),
+            },
+        ),
+    ),
     "newclimate-2024": dict(
         pooch_args=dict(
             base_url="doi:10.5281/zenodo.15432946",

--- a/message_ix_models/tools/newclimate/structure.py
+++ b/message_ix_models/tools/newclimate/structure.py
@@ -57,10 +57,12 @@ class HIGH_IMPACT(Enum):
     low_medium = auto()
     Unclear = auto()
 
-    #: NB both 'unclear' and 'Unclear' appear in the 2025 draft database as of
-    #: 2026-04-17.
-    unclear = auto()
     Unknown = auto()
+
+    #: NB lower-case variants of the above appear alongside them in the 2025 database.
+    high = auto()
+    unclear = auto()
+    unknown = auto()
 
 
 class JURISDICTION(Enum):
@@ -69,6 +71,9 @@ class JURISDICTION(Enum):
     City = auto()
     Country = auto()
     Subnational_region = auto()
+
+    #: Appears from the 2025 database, for instance for the European Union.
+    Supranational_region = auto()
 
 
 class OBJECTIVE(Enum):
@@ -128,6 +133,7 @@ class SECTOR(Enum):
     Negative_emissions = auto()
     Nuclear = auto()
     Oil = auto()
+    Public_transport = auto()
     Rail = auto()
     Renewables = auto()
     Shipping = auto()
@@ -240,7 +246,7 @@ class NewClimatePolicy(Policy):
     #: Impact indicator value.
     impact_indicators_value: str
 
-    #: Instrument.
+    #: Instrument. MAY be empty, from the 2025 database.
     instrument: str
 
     #: Jurisdiction.
@@ -295,7 +301,7 @@ class NewClimatePolicy(Policy):
         self,
     ) -> None:
         # Check that certain fields are non-empty
-        for field_name in ("instrument", "name", "title"):
+        for field_name in ("name", "title"):
             if getattr(self, field_name) == "":
                 raise ValueError(f"{field_name}=''")
 
@@ -304,13 +310,15 @@ class NewClimatePolicy(Policy):
         for name, enum_type, container in self._enum_fields():
             value = getattr(self, name)
             if isinstance(value, str):
-                # Parse the value as a comma-separated list of elements
+                # Parse the value as a comma-separated list of elements. For a list
+                # field, an empty string gives an empty list rather than [""].
+                parts = [v.strip() for v in value.split(",")]
+                if container is not None:
+                    parts = list(filter(None, parts))
                 values: list[Enum | str] = []
-                for v in value.split(","):
+                for v in parts:
                     try:
-                        values.append(
-                            enum_type[pattern.sub("_", v.strip()) or "NOTSET"]
-                        )
+                        values.append(enum_type[pattern.sub("_", v) or "NOTSET"])
                     except KeyError:
                         log.warning(f"Not a member of {enum_type}: {v!r}")
                         values.append(v)


### PR DESCRIPTION
Replaces #554, which got accidentally merged while restacking.

Add the zenodo record for the 2025 vintage extend the data model to support new entries. 


This PR extends vintage support to the 2025 release. The 2025 release adds: an empty instrument field, the sector 'Public transport', the jurisdiction 'Supranational region', and lower-case high-impact codes. An empty list-valued field now parses to an empty list.

## How to review
Read the diff, check this does not break things for earlier edition, check zenodo fetch works as advertised. 


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update doc/whatsnew.


